### PR TITLE
Update ADO.NET span content

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Data;
 using System.Data.Common;
@@ -88,10 +89,11 @@ namespace Datadog.Trace.ClrProfiler
 
                 Span parent = tracer.ActiveScope?.Span;
 
+                string statement = command.CommandText.Length > 1024 ? command.CommandText.Substring(0, 1024) : command.CommandText;
+
                 if (parent != null &&
-                    parent.Type == SpanTypes.Sql &&
                     parent.GetTag(Tags.DbType) == dbType &&
-                    parent.ResourceName == command.CommandText)
+                    parent.GetTag(Tags.DbStatement) == statement)
                 {
                     // we are already instrumenting this,
                     // don't instrument nested methods that belong to the same stacktrace
@@ -106,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler
                 var span = scope.Span;
                 span.SetTag(Tags.DbType, dbType);
                 span.SetTag(Tags.InstrumentationName, integrationName);
-                span.AddTagsFromDbCommand(command);
+                span.AddTagsFromDbCommand(command, statement);
 
                 // set analytics sample rate if enabled
                 var analyticsSampleRate = tracer.Settings.GetIntegrationAnalyticsSampleRate(integrationName, enabledWithGlobalSetting: false);

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Data;
 using System.Data.Common;
@@ -29,10 +30,15 @@ namespace Datadog.Trace.ExtensionMethods
         /// </summary>
         /// <param name="span">The span to add the tags to.</param>
         /// <param name="command">The db command to get tags values from.</param>
-        public static void AddTagsFromDbCommand(this Span span, IDbCommand command)
+        /// <param name="statement">The db statement to use over command.CommandText.</param>
+        public static void AddTagsFromDbCommand(this Span span, IDbCommand command, string statement = "")
         {
-            span.ResourceName = command.CommandText;
-            span.Type = SpanTypes.Sql;
+            if (string.IsNullOrEmpty(statement))
+            {
+                statement = command.CommandText.Length > 1024 ? command.CommandText.Substring(0, 1024) : command.CommandText;
+            }
+
+            span.SetTag(Tags.DbStatement, statement);
 
             // parse the connection string
             var builder = new DbConnectionStringBuilder { ConnectionString = command.Connection.ConnectionString };

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -93,7 +93,12 @@ namespace Datadog.Trace
         /// <summary>
         /// The name of the database.
         /// </summary>
-        public const string DbName = "db.name";
+        public const string DbName = "db.instance";
+
+        /// <summary>
+        /// The command/query text
+        /// </summary>
+        public const string DbStatement = "db.statement";
 
         /// <summary>
         /// The query text
@@ -123,12 +128,12 @@ namespace Datadog.Trace
         /// <summary>
         /// The hostname of a outgoing server connection.
         /// </summary>
-        public const string OutHost = "out.host";
+        public const string OutHost = "peer.hostname";
 
         /// <summary>
         /// The port of a outgoing server connection.
         /// </summary>
-        public const string OutPort = "out.port";
+        public const string OutPort = "peer.port";
 
         /// <summary>
         /// The raw command sent to Redis.

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,12 +21,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 21 : 24;
             const string dbType = "mysql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.MySql-" + dbType;
+            const string expectedServiceName = "Samples.MySql";
 
             int agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port))
+            using (var agent = new MockZipkinCollector(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, envVars: ZipkinEnvVars))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
@@ -36,8 +37,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 {
                     Assert.Equal(expectedOperationName, span.Name);
                     Assert.Equal(expectedServiceName, span.Service);
-                    Assert.Equal(SpanTypes.Sql, span.Type);
+                    Assert.Null(span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
+                    Assert.NotNull(span.Tags[Tags.DbStatement]);
                 }
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,12 +21,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const int expectedSpanCount = 35;
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.SqlServer-" + dbType;
+            const string expectedServiceName = "Samples.SqlServer";
 
             int agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
+            using (var agent = new MockZipkinCollector(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion, envVars: ZipkinEnvVars))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
@@ -36,8 +37,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 {
                     Assert.Equal(expectedOperationName, span.Name);
                     Assert.Equal(expectedServiceName, span.Service);
-                    Assert.Equal(SpanTypes.Sql, span.Type);
+                    Assert.Null(span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
+                    Assert.NotNull(span.Tags[Tags.DbStatement]);
                 }
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -44,6 +44,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Profiler DLL: {EnvironmentHelper.GetProfilerPath()}");
         }
 
+        public Dictionary<string, string> ZipkinEnvVars
+        {
+            get => new Dictionary<string, string>() { { "SIGNALFX_API_TYPE", "zipkin" } };
+        }
+
         protected EnvironmentHelper EnvironmentHelper { get; set; }
 
         protected string TestPrefix => $"{EnvironmentHelper.GetBuildConfiguration()}.{EnvironmentHelper.GetTargetFramework()}";
@@ -80,9 +85,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 envVars: envVars);
         }
 
-        public ProcessResult RunSampleAndWaitForExit(int traceAgentPort, string arguments = null, string packageVersion = "")
+        public ProcessResult RunSampleAndWaitForExit(int traceAgentPort, string arguments = null, string packageVersion = "", Dictionary<string, string> envVars = null)
         {
-            Process process = StartSample(traceAgentPort, arguments, packageVersion, aspNetCorePort: 5000);
+            Process process = StartSample(traceAgentPort, arguments, packageVersion, aspNetCorePort: 5000, envVars);
 
             string standardOutput = process.StandardOutput.ReadToEnd();
             string standardError = process.StandardError.ReadToEnd();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Linq;
 using Datadog.Trace.ExtensionMethods;
@@ -41,8 +42,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal("redis.command", span.Name);
                     Assert.Equal("Samples.ServiceStack.Redis-redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
-                    Assert.Equal(host, span.Tags.GetValueOrDefault("out.host"));
-                    Assert.Equal(port, span.Tags.GetValueOrDefault("out.port"));
+                    Assert.Equal(host, span.Tags.GetValueOrDefault("peer.hostname"));
+                    Assert.Equal(port, span.Tags.GetValueOrDefault("peer.port"));
                 }
 
                 var expected = new TupleList<string, string>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -259,8 +260,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal("redis.command", span.Name);
                     Assert.Equal("Samples.StackExchange.Redis-redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
-                    Assert.Equal(host, span.Tags.GetValueOrDefault<string>("out.host"));
-                    Assert.Equal(port, span.Tags.GetValueOrDefault<string>("out.port"));
+                    Assert.Equal(host, span.Tags.GetValueOrDefault<string>("peer.hostname"));
+                    Assert.Equal(port, span.Tags.GetValueOrDefault<string>("peer.port"));
                 }
 
                 var spanLookup = new Dictionary<Tuple<string, string>, int>();


### PR DESCRIPTION
These changes update the ADO.NET instrumentation helpers to conform closer to OT conventions by:
* Setting a truncated `db.statement` tag value over the current resource name
* Setting the `db.instance` over `db.name` tag
* Use the `peer.hostname` and `peer.port` tags over `out.host` and `out.port`
* No longer set the nonstandard `span.type` tag.

They also adopt the zipkin test collector over the messagepack mock agent.