### PR TITLE
Update ES span content to include db.statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This library provides an OpenTracing-compatible tracer and automatically configu
 | ---     | ---                | ---   |
 | ADO.NET | Supported .NET Core versions | |
 | ASP.NET Core MVC | 2.0+ | `Microsoft.AspNet.Mvc.Core` NuGet and built-in packages |
+| Elasticsearch.Net | `Elasticsearch.Net` Nuget 5.3 - 6.x | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES=false` (`true` by default, which may introduce overhead for direct streaming users). |
 | HttpClient | Supported .NET Core versions | by way of `System.Net.Http.HttpClientHandler` and `HttpMessageHandler` instrumentations |
 | MongoDB | `MongoDB.Driver.Core` Nuget 2.1.0+ | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS=false` (`true` by default). |
 | WebClient | Supported .NET Core versions | by way of `System.Net.WebRequest` instrumentation |

--- a/samples/Samples.Elasticsearch.V5/Program.cs
+++ b/samples/Samples.Elasticsearch.V5/Program.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -173,6 +174,24 @@ namespace Samples.Elasticsearch.V5
                 () => elastic.IndicesStats("test_index_1"),
                 () => elastic.DeleteIndex("test_index_1"),
                 () => elastic.GetAlias(new GetAliasRequest()),
+                () => elastic.ReindexOnServer(new ReindexOnServerRequest
+                {
+                    Source = new ReindexSource
+                    {
+                        Remote = new RemoteSource
+                        {
+                            Host = new Uri("http://" + Host()),
+                            Username = "test_user_1",
+                            Password = "supersecret"
+                        },
+                        Index = "some_index",
+                        Size = 10
+                    },
+                    Destination = new ReindexDestination
+                    {
+                        Index = "some_index_clone",
+                    }
+                })
             };
         }
 
@@ -222,6 +241,24 @@ namespace Samples.Elasticsearch.V5
                 () => elastic.IndicesStatsAsync("test_index_1"),
                 () => elastic.DeleteIndexAsync("test_index_1"),
                 () => elastic.GetAliasAsync(new GetAliasRequest()),
+                () => elastic.ReindexOnServerAsync(new ReindexOnServerRequest
+                {
+                    Source = new ReindexSource
+                    {
+                        Remote = new RemoteSource
+                        {
+                            Host = new Uri("http://" + Host()),
+                            Username = "test_user_1",
+                            Password = "supersecret"
+                        },
+                        Index = "some_index",
+                        Size = 10
+                    },
+                    Destination = new ReindexDestination
+                    {
+                        Index = "some_index_clone",
+                    }
+                })
             };
         }
 

--- a/samples/Samples.Elasticsearch/Program.cs
+++ b/samples/Samples.Elasticsearch/Program.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -180,6 +181,24 @@ namespace Samples.Elasticsearch
                 () => elastic.IndicesStats("test_index_1"),
                 () => elastic.DeleteIndex("test_index_1"),
                 () => elastic.GetAlias(new GetAliasRequest()),
+                () => elastic.ReindexOnServer(new ReindexOnServerRequest
+                {
+                    Source = new ReindexSource
+                    {
+                        Remote = new RemoteSource
+                        {
+                            Host = new Uri("http://" + Host()),
+                            Username = "test_user_1",
+                            Password = "supersecret"
+                        },
+                        Index = "some_index",
+                        Size = 10
+                    },
+                    Destination = new ReindexDestination
+                    {
+                        Index = "some_index_clone",
+                    }
+                })
             };
         }
 
@@ -232,6 +251,24 @@ namespace Samples.Elasticsearch
                 () => elastic.IndicesStatsAsync("test_index_1"),
                 () => elastic.DeleteIndexAsync("test_index_1"),
                 () => elastic.GetAliasAsync(new GetAliasRequest()),
+                () => elastic.ReindexOnServerAsync(new ReindexOnServerRequest
+                {
+                    Source = new ReindexSource
+                    {
+                        Remote = new RemoteSource
+                        {
+                            Host = new Uri("http://" + Host()),
+                            Username = "test_user_1",
+                            Password = "supersecret"
+                        },
+                        Index = "some_index",
+                        Size = 10
+                    },
+                    Destination = new ReindexDestination
+                    {
+                        Index = "some_index_clone",
+                    }
+                })
             };
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,7 +83,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 try
                 {
-                    return callElasticSearch(pipeline, requestData);
+                    var returned = callElasticSearch(pipeline, requestData);
+                    scope?.Span.SetDbStatementFromRequestData(requestData);
+                    return returned;
                 }
                 catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
                 {
@@ -175,7 +178,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 try
                 {
-                    return await callElasticSearchAsync(pipeline, requestData, cancellationToken).ConfigureAwait(false);
+                    var returned = await callElasticSearchAsync(pipeline, requestData, cancellationToken).ConfigureAwait(false);
+                    if (scope != null)
+                    {
+                        await scope.Span.SetDbStatementFromRequestDataAsync(requestData);
+                    }
+
+                    return returned;
                 }
                 catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
@@ -112,10 +112,24 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             return postDataType.GetMethod(methodName);
         }
 
+        public static string SanitizePostData(string data)
+        {
+            return data;
+        }
+
         public static void SetDbStatement(Span span, object writtenBytes)
         {
-            string data = System.Text.Encoding.UTF8.GetString((byte[])writtenBytes);
-            string statement = data.Length > 1024 ? data.Substring(0, 1024) : data;
+            string data = null;
+            if (writtenBytes.Length > 1024)
+            {
+                data = System.Text.Encoding.UTF8.GetString((byte[])writtenBytes, 0, 1024);
+            }
+            else
+            {
+                data = System.Text.Encoding.UTF8.GetString((byte[])writtenBytes);
+            }
+
+            string statement = SanitizePostData(data);
             span.SetTag(Tags.DbStatement, statement);
         }
 

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -166,11 +166,18 @@ namespace Datadog.Trace.Configuration
         public const string TracerMetricsEnabled = "SIGNALFX_TRACE_METRICS_ENABLED";
 
         /// <summary>
-        /// Configuration key for enabling or disabling the automatic injection
-        /// of correlation identifiers into the logging context.
+        /// Configuration key for enabling or disabling the tagging of
+        /// a Mongo command BsonDocument as db.statement.
         /// </summary>
         /// <seealso cref="TracerSettings.TagMongoCommands"/>
         public const string TagMongoCommands = "SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS";
+
+        /// <summary>
+        /// Configuration key for enabling or disabling tagging Elasticsearch
+        /// PostData as db.statement.
+        /// </summary>
+        /// <seealso cref="TracerSettings.TagElasticsearchQueries"/>
+        public const string TagElasticsearchQueries = "SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES";
 
         /// <summary>
         /// Configuration key for setting the approximate maximum size,

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -130,6 +130,8 @@ namespace Datadog.Trace.Configuration
                                       true;
 
             TagMongoCommands = source?.GetBool(ConfigurationKeys.TagMongoCommands) ?? true;
+
+            TagElasticsearchQueries = source?.GetBool(ConfigurationKeys.TagElasticsearchQueries) ?? true;
         }
 
         /// <summary>
@@ -256,6 +258,14 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TagMongoCommands"/>
         public bool TagMongoCommands { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Elasticsearch integration
+        /// should tag PostData as db.statement.
+        /// Default is <c>true</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.TagElasticsearchQueries"/>
+        public bool TagElasticsearchQueries { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the use

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -1,3 +1,5 @@
+// Modified by SignalFx
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.TestHelpers;
@@ -15,15 +17,29 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
         }
 
+        public static IEnumerable<object[]> TestParameters()
+        {
+            foreach (var versions in PackageVersions.ElasticSearch5)
+            {
+                foreach (var version in versions)
+                {
+                    yield return new object[] { version, "true" };
+                    yield return new object[] { version, "false" };
+                }
+            }
+        }
+
         [Theory]
-        [MemberData(nameof(PackageVersions.ElasticSearch5), MemberType = typeof(PackageVersions))]
+        [MemberData(nameof(TestParameters))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion)
+        public void SubmitsTraces(string packageVersion, string tagQueries)
         {
             int agentPort = TcpPortProvider.GetOpenPort();
+            var envVars = ZipkinEnvVars;
+            envVars["SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES"] = tagQueries;
 
-            using (var agent = new MockTracerAgent(agentPort))
-            using (var processResult = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
+            using (var agent = new MockZipkinCollector(agentPort))
+            using (var processResult = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion, envVars: envVars))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
@@ -122,18 +138,45 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 var spans = agent.WaitForSpans(expected.Count)
-                                 .Where(s => s.Type == "elasticsearch")
+                                 .Where(s => s.Tags.GetValueOrDefault(Tags.InstrumentationName) == "elasticsearch-net")
                                  .OrderBy(s => s.Start)
                                  .ToList();
 
+                var statementNames = new List<string>
+                {
+                    "Bulk",
+                    "BulkAlias",
+                    "ClusterAllocationExplain",
+                    "ClusterPutSettings",
+                    "ClusterReroute",
+                    "Create",
+                    "CreateIndex",
+                    "DeleteByQuery",
+                    "PutAlias",
+                    "PutIndexTemplate",
+                    "PutRole",
+                    "PutRole",
+                    "Search",
+                    "UpdateIndexSettings"
+                };
+
                 foreach (var span in spans)
                 {
-                    Assert.Equal("elasticsearch.query", span.Name);
-                    Assert.Equal("Samples.Elasticsearch.V5-elasticsearch", span.Service);
-                    Assert.Equal("elasticsearch", span.Type);
+                    Assert.Equal("Samples.Elasticsearch.V5", span.Service);
+                    Assert.Equal("elasticsearch", span.Tags["db.type"]);
+
+                    span.Tags.TryGetValue(Tags.DbStatement, out string statement);
+                    if (tagQueries.Equals("true") && statementNames.Contains(span.Name))
+                    {
+                        Assert.NotNull(statement);
+                    }
+                    else
+                    {
+                        Assert.Null(statement);
+                    }
                 }
 
-                ValidateSpans(spans, (span) => span.Resource, expected);
+                ValidateSpans(spans, (span) => span.Name, expected);
             }
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -76,6 +76,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         "IndicesStats",
                         "DeleteIndex",
                         "GetAlias",
+                        "ReindexOnServer",
 
                         "CatAliases",
                         "CatAllocation",
@@ -146,6 +147,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 {
                     "Bulk",
                     "BulkAlias",
+                    "ChangePassword",
                     "ClusterAllocationExplain",
                     "ClusterPutSettings",
                     "ClusterReroute",
@@ -156,6 +158,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     "PutIndexTemplate",
                     "PutRole",
                     "PutRole",
+                    "PutUser",
+                    "ReindexOnServer",
                     "Search",
                     "UpdateIndexSettings"
                 };
@@ -169,6 +173,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     if (tagQueries.Equals("true") && statementNames.Contains(span.Name))
                     {
                         Assert.NotNull(statement);
+                        Assert.NotEqual(string.Empty, statement);
+                        Assert.DoesNotContain(statement, "test_user");
+                        Assert.DoesNotContain(statement, "supersecret");
                     }
                     else
                     {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -75,6 +75,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         "IndicesStats",
                         "DeleteIndex",
                         "GetAlias",
+                        "ReindexOnServer",
 
                         "CatAliases",
                         "CatAllocation",
@@ -152,6 +153,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 {
                     "Bulk",
                     "BulkAlias",
+                    "ChangePassword",
                     "ClusterAllocationExplain",
                     "ClusterPutSettings",
                     "ClusterReroute",
@@ -168,7 +170,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     "PutIndexTemplate",
                     "PutJob",
                     "PutRole",
+                    "PutUser",
                     "PutRoleMapping",
+                    "ReindexOnServer",
                     "Search",
                     "UpdateIndexSettings",
                     "ValidateJob",
@@ -183,6 +187,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     if (tagQueries.Equals("true") && statementNames.Contains(span.Name))
                     {
                         Assert.NotNull(statement);
+                        Assert.DoesNotContain(statement, "test_user");
+                        Assert.DoesNotContain(statement, "supersecret");
                     }
                     else
                     {


### PR DESCRIPTION
These changes introduce the `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES` environment variable to allow tagging `db.statement` from query post data.  Also updates the operation name taken from the source request parameters to be more informative.