### PR TITLE
Ensure no redundant span.kind tag for Zipkin spans

### DIFF
--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -32,6 +32,7 @@ namespace Datadog.Trace.IntegrationTests
             using (var agent = new MockZipkinCollector(collectorPort))
             {
                 var scope = _tracer.StartActive("Operation");
+                scope.Span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 scope.Dispose();
 
                 await _httpRecorder.WaitForCompletion(1);

--- a/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
@@ -113,10 +113,20 @@ namespace Datadog.Trace.TestHelpers
             if (expected.Tags != null)
             {
                 var actualTags = new Dictionary<string, string>(actual.Tags());
+                var expectedTags = new Dictionary<string, string>(expected.Tags);
                 actualTags.Remove("span.type");
                 actualTags.Remove("resource.name");
                 actualTags.Remove("error");
-                Assert.Equal(expected.Tags, actualTags);
+
+                var expectedSpanKind = DictionaryExtensions.GetValueOrDefault(expectedTags, Datadog.Trace.Tags.SpanKind);
+                if (expectedSpanKind != null)
+                {
+                    var actualSpanKind = actual.FirstDictionary()["kind"];
+                    Assert.Equal(expectedSpanKind.ToUpper(), actualSpanKind);
+                    expectedTags.Remove(Datadog.Trace.Tags.SpanKind);
+                }
+
+                Assert.Equal(expectedTags, actualTags);
             }
 
             if (expected.Logs != null)

--- a/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
@@ -112,7 +112,11 @@ namespace Datadog.Trace.TestHelpers
 
             if (expected.Tags != null)
             {
-                Assert.Equal(expected.Tags, actual.Tags());
+                var actualTags = new Dictionary<string, string>(actual.Tags());
+                actualTags.Remove("span.type");
+                actualTags.Remove("resource.name");
+                actualTags.Remove("error");
+                Assert.Equal(expected.Tags, actualTags);
             }
 
             if (expected.Logs != null)


### PR DESCRIPTION
Prevents the `span.kind` OT tag used to determine the Zipkin span kind from being sent w/ Zipkin spans.  Also ensures the Zipkin kind is uppercase.