### PR TITLE
Fix net45 builds

### DIFF
--- a/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
@@ -22,7 +22,9 @@ namespace Datadog.Trace.ExtensionMethods
         /// <returns>The number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.</returns>
         public static long ToUnixTimeMicroseconds(this DateTimeOffset dateTimeOffset)
         {
-            return ToUnixTimeNanoseconds(dateTimeOffset) / 1000;
+            const long microsecondsPerMillisecond = 1000;
+            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / microsecondsPerMillisecond;
+            return (dateTimeOffset.Ticks - TimeConstants.UnixEpochInTicks) / ticksPerMicrosecond;
         }
 
         public static long ToNanoseconds(this TimeSpan ts)
@@ -33,16 +35,6 @@ namespace Datadog.Trace.ExtensionMethods
         public static long ToMicroseconds(this TimeSpan ts)
         {
             return ToNanoseconds(ts) / 1000;
-        }
-
-        /// <summary>
-        /// Reconverts a long timestamp from ToUnixTimeMicroseconds.
-        /// </summary>
-        /// <param name="ts">The unix time in microseconds.</param>
-        /// <returns>The corresponding DateTimeOffset.</returns>
-        public static DateTimeOffset ToDateTimeOffset(this long ts)
-        {
-            return DateTimeOffset.FromUnixTimeMilliseconds(ts / 1000);
         }
     }
 }

--- a/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
@@ -18,8 +18,8 @@ namespace Datadog.Trace.ExtensionMethods
         /// <summary>
         /// Returns the number of microseconds that have elapsed since 1970-01-01T00:00:00.000Z.
         /// </summary>
-        /// <param name="dateTimeOffset">The value to get the number of elapsed nanoseconds for.</param>
-        /// <returns>The number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.</returns>
+        /// <param name="dateTimeOffset">The value to get the number of elapsed microseconds for.</param>
+        /// <returns>The number of microseconds that have elapsed since 1970-01-01T00:00:00.000Z.</returns>
         public static long ToUnixTimeMicroseconds(this DateTimeOffset dateTimeOffset)
         {
             const long microsecondsPerMillisecond = 1000;

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -55,8 +55,8 @@ namespace Datadog.Trace.OpenTracing.Tests
             var exDict = new Dictionary<string, object>() { { "another event name", ex } };
             span.Log(exDict);
 
-            var now = DateTime.UtcNow;
-            var then = DateTime.UtcNow;
+            var now = DateTime.UtcNow.AddMilliseconds(1); // Add 1 msec to ensure different time than calls above.
+            var then = now.AddMilliseconds(2); // TODO: currently if Log receives same timestamp previous are overwritten.
             span.Log(now, "Another Event");
             span.Log(then, exDict);
 

--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -261,7 +261,7 @@ namespace Datadog.Trace.TestHelpers
                     var logs = new Dictionary<DateTimeOffset, Dictionary<string, string>>();
                     foreach (var item in annotations)
                     {
-                        DateTimeOffset timestamp = ((long)item["timestamp"]).ToDateTimeOffset();
+                        DateTimeOffset timestamp = TimeHelpers.UnixMicrosecondsToDateTimeOffset((long)item["timestamp"]);
                         Dictionary<string, string> fields = JsonConvert.DeserializeObject<Dictionary<string, string>>(item["value"].ToString());
                         logs[timestamp] = fields;
                     }

--- a/test/Datadog.Trace.TestHelpers/TimeHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/TimeHelpers.cs
@@ -1,0 +1,21 @@
+// Modified by SignalFx
+using System;
+
+namespace Datadog.Trace.TestHelpers
+{
+    internal static class TimeHelpers
+    {
+        /// <summary>
+        /// Reconverts a long timestamp from TimeExtensions.ToUnixTimeMicroseconds.
+        /// </summary>
+        /// <param name="ts">The unix time in microseconds.</param>
+        /// <returns>The corresponding DateTimeOffset.</returns>
+        public static DateTimeOffset UnixMicrosecondsToDateTimeOffset(long ts)
+        {
+            const long microsecondsPerMillisecond = 1000;
+            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / microsecondsPerMillisecond;
+            var ticks = (ts * ticksPerMicrosecond) + TimeConstants.UnixEpochInTicks;
+            return new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+}

--- a/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.TestHelpers
             foreach (var item in annotations)
             {
                 // Zipkin timestamps are in µS
-                var timestamp = ((long)item["timestamp"]).ToDateTimeOffset();
+                var timestamp = TimeHelpers.UnixMicrosecondsToDateTimeOffset((long)item["timestamp"]);
                 var fields = JsonConvert.DeserializeObject<Dictionary<string, string>>(item["value"].ToString());
                 logs[timestamp] = fields;
             }
@@ -134,7 +134,7 @@ namespace Datadog.Trace.TestHelpers
                 var actualLogs = actual.Logs();
                 foreach (var item in expected.Logs)
                 {
-                    var truncatedTimestamp = item.Key.ToUnixTimeMicroseconds().ToDateTimeOffset();
+                    var truncatedTimestamp = TimeHelpers.UnixMicrosecondsToDateTimeOffset(item.Key.ToUnixTimeMicroseconds());
                     Assert.Equal(item.Value, actualLogs[truncatedTimestamp]);
                 }
             }


### PR DESCRIPTION
The implementation in TimeExtensions was depending on a method not available on net45, however, that was only needed in tests so created a TimeHelpers on the test helpers to cover that old extension method that needed to be removed.




