### PR TITLE
Fix race on MockZipkinCollector HttpListener

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -140,7 +140,6 @@ namespace Datadog.Trace.TestHelpers
             {
                 _listenerCts.Cancel();
                 _listener.Stop();
-                _listenerCts.Dispose();
             }
         }
 

--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.TestHelpers
     {
         private readonly HttpListener _listener;
         private readonly Thread _listenerThread;
-        private readonly CancellationTokenSource _listenerCts = CancellationTokenSource();
+        private readonly CancellationTokenSource _listenerCts = new CancellationTokenSource();
 
         public MockZipkinCollector(int port = 9080, int retries = 5)
         {


### PR DESCRIPTION
Trying a minimal fix for issues that I found running on Windows and I suspect it also to be related to Linux Azure Pipeline not finishing. This is basically a quick workaround on the limited HttpListener type, that said there is no good and simple alternative to it to use in tests.