### PR TITLE
Update ZipkinContent according to SendTracesAsync changes

### DIFF
--- a/src/Datadog.Trace/Agent/ZipkinApi.cs
+++ b/src/Datadog.Trace/Agent/ZipkinApi.cs
@@ -34,13 +34,6 @@ namespace Datadog.Trace.Agent
             var retryCount = 1;
             var sleepDuration = 100; // in milliseconds
 
-            // TODO: Optimize this, right now just a simple conversion.
-            var traceList = new List<List<Span>>(traces.Length);
-            foreach (var spanArray in traces)
-            {
-                traceList.Add(new List<Span>(spanArray));
-            }
-
             while (true)
             {
                 HttpResponseMessage responseMessage;
@@ -48,7 +41,7 @@ namespace Datadog.Trace.Agent
                 try
                 {
                     // re-create content on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
-                    using (var content = new ZipkinContent<IList<List<Span>>>(traceList))
+                    using (var content = new ZipkinContent(traces))
                     {
                         responseMessage = await _client.PostAsync(_tracesEndpoint, content).ConfigureAwait(false);
                         responseMessage.EnsureSuccessStatusCode();

--- a/src/Datadog.Trace/Agent/ZipkinContent.cs
+++ b/src/Datadog.Trace/Agent/ZipkinContent.cs
@@ -12,21 +12,20 @@ namespace Datadog.Trace.Agent
 {
     internal class ZipkinContent : HttpContent
     {
-        private readonly ZipkinSerializer serializer = new ZipkinSerializer();
+        private readonly ZipkinSerializer _serializer = new ZipkinSerializer();
+        private readonly Span[][] _spans;
 
-        public ZipkinContent(Span[][] value)
+        public ZipkinContent(Span[][] spans)
         {
-            Value = value;
+            _spans = spans;
             Headers.ContentType = new MediaTypeHeaderValue("application/json");
         }
-
-        public Span[][] Value { get; }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
             return Task.Factory.StartNew(() =>
                 {
-                    serializer.Serialize(stream, Value);
+                    _serializer.Serialize(stream, _spans);
                 });
         }
 

--- a/src/Datadog.Trace/Agent/ZipkinContent.cs
+++ b/src/Datadog.Trace/Agent/ZipkinContent.cs
@@ -10,24 +10,23 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
-    internal class ZipkinContent<T> : HttpContent
+    internal class ZipkinContent : HttpContent
     {
         private readonly ZipkinSerializer serializer = new ZipkinSerializer();
 
-        public ZipkinContent(T value)
+        public ZipkinContent(Span[][] value)
         {
             Value = value;
             Headers.ContentType = new MediaTypeHeaderValue("application/json");
         }
 
-        public T Value { get; }
+        public Span[][] Value { get; }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
             return Task.Factory.StartNew(() =>
                 {
-                    var traces = (IList<List<Span>>)Value;
-                    serializer.Serialize(stream, traces);
+                    serializer.Serialize(stream, Value);
                 });
         }
 

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Agent
             return tags;
         }
 
-        public void Serialize(Stream stream, IList<List<Span>> traces)
+        public void Serialize(Stream stream, Span[][] traces)
         {
             var zipkinTraces = new List<ZipkinSpan>();
 


### PR DESCRIPTION
The signature of the method was changed upstream and initially only minimal change was made to accomodate the new signature. This change fully updates the stack according to the new signature.
