### PR TITLE
Fix new race in MockZipkinCollector

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace.TestHelpers
                     ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
                     ctx.Response.Close();
                 }
-                catch (Exception ex) when (ex is OperationCanceledException || ex is AggregateException)
+                catch (Exception ex) when (ex is HttpListenerException || ex is OperationCanceledException || ex is AggregateException)
                 {
                     lock (_listener)
                     {


### PR DESCRIPTION
This race was introduced on the previous PR since HttpListenerException can still be raised if the _listener is disposed of but the code still tries to write to the output stream.
