### PR TITLE
Adopt ADO.NET updates and add SQL sanitization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library provides an OpenTracing-compatible tracer and automatically configu
 
 | Library | Versions Supported | Notes |
 | ---     | ---                | ---   |
-| ADO.NET | Supported .NET Core versions | |
+| ADO.NET | Supported .NET Core versions | Disable sanitization of `db.statement` with `SIGNALFX_SANITIZE_SQL_STATEMENTS=false` (`true` by default) |
 | ASP.NET Core MVC | 2.0+ | `Microsoft.AspNet.Mvc.Core` NuGet and built-in packages |
 | Elasticsearch.Net | `Elasticsearch.Net` Nuget 5.3 - 6.x | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES=false` (`true` by default, which may introduce overhead for direct streaming users). |
 | HttpClient | Supported .NET Core versions | by way of `System.Net.Http.HttpClientHandler` and `HttpMessageHandler` instrumentations |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This library provides an OpenTracing-compatible tracer and automatically configu
 | Elasticsearch.Net | `Elasticsearch.Net` Nuget 5.3 - 6.x | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES=false` (`true` by default, which may introduce overhead for direct streaming users). |
 | HttpClient | Supported .NET Core versions | by way of `System.Net.Http.HttpClientHandler` and `HttpMessageHandler` instrumentations |
 | MongoDB | `MongoDB.Driver.Core` Nuget 2.1.0+ | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS=false` (`true` by default). |
+| Npgsql | `Npqsql` Nuget 4.0+ | Provided via enhanced ADO.NET instrumentation |
 | ServiceStack.Redis | `ServiceStack.Redis` Nuget 4.0+ | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS=false` (`true` by default). |
 | StackExchange.Redis | `StackExchange.Redis` Nuget 1.0+ | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS=false` (`true` by default). |
 | WebClient | Supported .NET Core versions | by way of `System.Net.WebRequest` instrumentation |

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 VERSION=0.0.3
 
 mkdir -p $DIR/../deploy/linux
-for target in integrations.json defaults.env LICENSE NOTICE ; do
+for target in integrations.json defaults.env LICENSE NOTICE createLogPath.sh ; do
     cp $DIR/../$target $DIR/../src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64/
 done
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -1,5 +1,6 @@
 // Modified by SignalFx
 using System;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
@@ -44,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 if (Tracer.Instance.Settings.TagRedisCommands)
                 {
-                    span.SetTag(Tags.DbStatement, rawCommand.Substring(0, Math.Min(rawCommand.Length, 1024)));
+                    span.SetTag(Tags.DbStatement, rawCommand.Truncate());
                 }
 
                 span.SetTag(Tags.OutHost, host);

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -108,7 +108,11 @@ namespace Datadog.Trace.ClrProfiler
 
                 Span parent = tracer.ActiveScope?.Span;
 
-                string statement = command.CommandText.Length > 1024 ? command.CommandText.Substring(0, 1024) : command.CommandText;
+                string statement = command.CommandText.Truncate();
+                if (tracer.Settings.SanitizeSqlStatements)
+                {
+                    statement = statement.SanitizeSqlStatement();
+                }
 
                 if (parent != null &&
                     parent.GetTag(Tags.DbType) == dbType &&

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -195,6 +195,12 @@ namespace Datadog.Trace.Configuration
         public const string TagRedisCommands = "SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS";
 
         /// <summary>
+        /// Configuration key for disabling sanitizing SQL db.statement
+        /// </summary>
+        /// <seealso cref="TracerSettings.SanitizeSqlStatements"/>
+        public const string SanitizeSqlStatements = "SIGNALFX_SANITIZE_SQL_STATEMENTS";
+
+        /// <summary>
         /// Configuration key for setting the approximate maximum size,
         /// in bytes, for Tracer log files.
         /// Default value is 10 MB.

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -132,6 +132,8 @@ namespace Datadog.Trace.Configuration
             TagElasticsearchQueries = source?.GetBool(ConfigurationKeys.TagElasticsearchQueries) ?? true;
 
             TagRedisCommands = source?.GetBool(ConfigurationKeys.TagRedisCommands) ?? true;
+
+            SanitizeSqlStatements = source?.GetBool(ConfigurationKeys.SanitizeSqlStatements) ?? true;
         }
 
         /// <summary>
@@ -275,6 +277,12 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TagRedisCommands"/>
         public bool TagRedisCommands { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to sanitize SQL db.statement
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.SanitizeSqlStatements"/>
+        public bool SanitizeSqlStatements { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the use

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -45,7 +45,11 @@ namespace Datadog.Trace.ExtensionMethods
                 }
             }
 
-            span.SetTag(Tags.DbStatement, statement);
+            if (!string.IsNullOrEmpty(statement))
+            {
+                span.SetTag(Tags.DbStatement, statement);
+            }
+
             span.SetTag(Tags.SpanKind, SpanKinds.Client);
 
             // parse the connection string

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -30,12 +30,19 @@ namespace Datadog.Trace.ExtensionMethods
         /// </summary>
         /// <param name="span">The span to add the tags to.</param>
         /// <param name="command">The db command to get tags values from.</param>
-        /// <param name="statement">The db statement to use over command.CommandText.</param>
-        public static void AddTagsFromDbCommand(this Span span, IDbCommand command, string statement = "")
+        /// <param name="statement">The db statement to use over command.CommandText. Will not be truncated or sanitized.</param>
+        /// <param name="sanitize">Whether to sanitize tagged statements.</param>
+        public static void AddTagsFromDbCommand(this Span span, IDbCommand command, string statement = "", bool sanitize = true)
         {
             if (string.IsNullOrEmpty(statement))
             {
-                statement = command.CommandText.Length > 1024 ? command.CommandText.Substring(0, 1024) : command.CommandText;
+                statement = command.CommandText ?? string.Empty;
+                statement = statement.Truncate();
+
+                if (sanitize)
+                {
+                    statement = statement.SanitizeSqlStatement();
+                }
             }
 
             span.SetTag(Tags.DbStatement, statement);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
@@ -20,12 +20,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 4 : 7;
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.Dapper-" + dbType;
+            const string expectedServiceName = "Samples.Dapper";
 
             int agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port))
+            using (var agent = new MockZipkinCollector(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, envVars: ZipkinEnvVars))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
@@ -37,6 +37,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedOperationName, span.Name);
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
+                    Assert.Null(span.Type);
+                    Assert.NotNull(span.Tags[Tags.DbStatement]);
                 }
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 process.BeginErrorReadLine();
 
                 // wait for server to start
-                wh.WaitOne(5000);
+                wh.WaitOne(10000);
 
                 SubmitRequests(aspNetCorePort);
                 var graphQLValidateSpans = agent.WaitForSpans(_expectedGraphQLValidateSpanCount, operationName: _graphQLValidateOperationName, returnAllOperations: false)

--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -257,7 +257,11 @@ namespace Datadog.Trace.TestHelpers
 
             public ulong? ParentId
             {
-                get => Convert.ToUInt64(_zipkinData["parentId"].ToString(), 16);
+                get
+                {
+                    ((IDictionary)_zipkinData).TryGetValue<string>("parentId", out string parentId);
+                    return parentId == null ? null : (ulong?)Convert.ToUInt64(parentId.ToString(), 16);
+                }
             }
 
             public byte Error { get; set; }
@@ -282,6 +286,42 @@ namespace Datadog.Trace.TestHelpers
             }
 
             public Dictionary<string, double> Metrics { get; set; }
+
+            public override string ToString()
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine($"TraceId: {TraceId}");
+                sb.AppendLine($"ParentId: {ParentId}");
+                sb.AppendLine($"SpanId: {SpanId}");
+                sb.AppendLine($"Service: {Service}");
+                sb.AppendLine($"Name: {Name}");
+                sb.AppendLine($"Resource: {Resource}");
+                sb.AppendLine($"Type: {Type}");
+                sb.AppendLine($"Start: {Start}");
+                sb.AppendLine($"Duration: {Duration}");
+                sb.AppendLine($"Error: {Error}");
+                sb.AppendLine("Tags:");
+
+                if (Tags?.Count > 0)
+                {
+                    foreach (var kv in Tags)
+                    {
+                        sb.Append($"\t{kv.Key}:{kv.Value}\n");
+                    }
+                }
+
+                sb.AppendLine("Logs:");
+                foreach (var e in Logs)
+                {
+                    sb.Append($"\t{e.Key}:\n");
+                    foreach (var kv in e.Value)
+                    {
+                        sb.Append($"\t\t{kv.Key}:{kv.Value}\n");
+                    }
+                }
+
+                return sb.ToString();
+            }
 
             [OnDeserialized]
             private void OnDeserialized(StreamingContext context)

--- a/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -1,0 +1,49 @@
+// Modified by SignalFx
+using System;
+using System.Collections;
+using System.Data;
+using System.Linq;
+using Datadog.Trace.ExtensionMethods;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ExtensionMethods
+{
+    public class SpanExtensionsTests
+    {
+        private string statement = string.Concat(Enumerable.Repeat("SELECT * FROM TABLE123 WHERE Field='123' ", 1000));
+
+        [Fact]
+        public void AddTagsFromDbCommandWithoutStatement()
+        {
+            var traceContext = new TraceContext(Tracer.Instance);
+            var spanContext = new SpanContext(null, traceContext, "UsesCommandText");
+            var span = new Span(spanContext, null);
+            var command = new Mock<IDbCommand>();
+            command.Setup(cmd => cmd.Connection.ConnectionString).Returns("Provider=Some.Provider.1.0;Data Source=Source.mdb");
+            command.Setup(cmd => cmd.CommandText).Returns(statement);
+            span.AddTagsFromDbCommand(command.Object);
+
+            // Known length of truncated, then sanitized statement
+            Assert.Equal(924, span.Tags["db.statement"].Length);
+            Assert.Contains("Field=?", span.Tags["db.statement"]);
+            Assert.DoesNotContain("Field='123'", span.Tags["db.statement"]);
+        }
+
+        [Fact]
+        public void AddTagsFromDbCommandWithStatement()
+        {
+            var traceContext = new TraceContext(Tracer.Instance);
+            var spanContext = new SpanContext(null, traceContext, "UsesStatement");
+            var span = new Span(spanContext, null);
+            var command = new Mock<IDbCommand>();
+            command.Setup(cmd => cmd.CommandText).Returns("Undesired Command Text");
+            command.Setup(cmd => cmd.Connection.ConnectionString).Returns("Provider=Some.Provider.1.0;Data Source=Source.mdb");
+            span.AddTagsFromDbCommand(command.Object, statement);
+
+            Assert.Equal(statement.Length, span.Tags["db.statement"].Length);
+            Assert.DoesNotContain("Field=?", span.Tags["db.statement"]);
+            Assert.Contains("Field='123'", span.Tags["db.statement"]);
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
@@ -1,5 +1,7 @@
 // Modified by SignalFx
 using System;
+using System.Collections;
+using System.Linq;
 using Datadog.Trace.ExtensionMethods;
 using Xunit;
 
@@ -69,7 +71,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             Assert.Equal(expected, actual);
         }
 
-        [Theory]
+        [Fact]
         public void TruncateExtension()
         {
             var a = string.Concat(Enumerable.Repeat("0", 10000));

--- a/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using Datadog.Trace.ExtensionMethods;
 using Xunit;
@@ -19,6 +20,63 @@ namespace Datadog.Trace.Tests.ExtensionMethods
         {
             string actual = original.TrimEnd(suffix, StringComparison.Ordinal);
             Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE WHERE FIELD=?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = 1234", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD>=-1234", "SELECT * FROM TABLE WHERE FIELD>=?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD<-1234", "SELECT * FROM TABLE WHERE FIELD<?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD <.1234", "SELECT * FROM TABLE WHERE FIELD <?")]
+        [InlineData("SELECT 1.2", "SELECT ?")]
+        [InlineData("SELECT -1.2", "SELECT ?")]
+        [InlineData("SELECT -1.2e-9", "SELECT ?")]
+        [InlineData("SELECT 2E+9", "SELECT ?")]
+        [InlineData("SELECT +0.2", "SELECT ?")]
+        [InlineData("SELECT .2", "SELECT ?")]
+        [InlineData("7", "?")]
+        [InlineData(".7", "?")]
+        [InlineData("-7", "?")]
+        [InlineData("+7", "?")]
+        [InlineData("SELECT 0x0af764", "SELECT ?")]
+        [InlineData("SELECT 0xdeadbeef", "SELECT ?")]
+        [InlineData("SELECT A + B", "SELECT A + B")]
+        [InlineData("SELECT -- comment", "SELECT -- comment")]
+        [InlineData("SELECT * FROM TABLE123", "SELECT * FROM TABLE123")]
+        [InlineData("SELECT FIELD2 FROM TABLE_123 WHERE X<>7", "SELECT FIELD2 FROM TABLE_123 WHERE X<>?")]
+        [InlineData("SELECT --83--...--8e+76e3E-1", "SELECT ?")]
+        [InlineData("SELECT DEADBEEF", "SELECT DEADBEEF")]
+        [InlineData("SELECT 123-45-6789", "SELECT ?")]
+        [InlineData("SELECT 1/2/34", "SELECT ?/?/?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = ''", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = 'words and spaces'", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = ' an escaped '' quote mark inside'", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = '\\\\'", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = '\"inside doubles\"'", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = '\"\"'", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = 'a single \" doublequote inside'", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = \"\"", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = \"words and spaces'\"", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = \" an escaped \"\" quote mark inside\"", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = \"\\\\\"", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = \"'inside singles'\"", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = \"''\"", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD = \"a single ' singlequote inside\"", "SELECT * FROM TABLE WHERE FIELD = ?")]
+        public void SqlStatementsAreSanitized(string original, string expected)
+        {
+            string actual = original.SanitizeSqlStatement();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        public void TruncateExtension()
+        {
+            var a = string.Concat(Enumerable.Repeat("0", 10000));
+            Assert.Equal(1024, a.Truncate().Length);
+
+            var b = "fewer than 1024 chars";
+            Assert.Same(b, b.Truncate());
         }
     }
 }


### PR DESCRIPTION
Verifies upstream ADO.NET and Npqsql updates as well as ports the sql sanitization regexes and tests* from https://github.com/signalfx/signalfx-java-tracing/commit/123b8104d361f07d87a0caf445479a07e203bf5a.  I'm providing an opt-out mechanism as well for services that aren't dealing with PII.

Also bumps up the graphql timeout to reduce flake until we source the most recent improvements.