### PR TITLE
Migrate error tags to sfx.error.*

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -330,7 +331,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 span.Error = true;
 
                 span.SetTag(Trace.Tags.ErrorMsg, $"{errorCount} error(s)");
-                span.SetTag(Trace.Tags.ErrorType, errorType);
+                span.SetTag(Trace.Tags.ErrorKind, errorType);
                 span.SetTag(Trace.Tags.ErrorStack, ConstructErrorMessage(executionErrors));
             }
         }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -428,7 +428,7 @@ namespace Datadog.Trace
 
                 SetTag(Trace.Tags.ErrorMsg, exception.Message);
                 SetTag(Trace.Tags.ErrorStack, exception.ToString());
-                SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
+                SetTag(Trace.Tags.ErrorKind, exception.GetType().ToString());
             }
         }
 

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -68,17 +68,17 @@ namespace Datadog.Trace
         /// <summary>
         /// The error message of an exception
         /// </summary>
-        public const string ErrorMsg = "error.msg";
+        public const string ErrorMsg = "sfx.error.message";
 
         /// <summary>
-        /// The type of an exception
+        /// The kind of exception
         /// </summary>
-        public const string ErrorType = "error.type";
+        public const string ErrorKind = "sfx.error.kind";
 
         /// <summary>
         /// The stack trace of an exception
         /// </summary>
-        public const string ErrorStack = "error.stack";
+        public const string ErrorStack = "sfx.error.stack";
 
         /// <summary>
         /// The type of database (e.g. mssql, mysql)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                         failures.Add($"Expected Error flag set within {span.Resource}");
                     }
 
-                    if (SpanExpectation.GetTag(span, Tags.ErrorType) != "System.Exception")
+                    if (SpanExpectation.GetTag(span, Tags.ErrorKind) != "System.Exception")
                     {
                         failures.Add($"Expected specific exception within {span.Resource}");
                     }

--- a/test/Datadog.Trace.TestHelpers/TestSpan.cs
+++ b/test/Datadog.Trace.TestHelpers/TestSpan.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.TestHelpers
 
             SetTagInternal(Trace.Tags.ErrorMsg, exception.Message);
             SetTagInternal(Trace.Tags.ErrorStack, exception.StackTrace);
-            SetTagInternal(Trace.Tags.ErrorType, exception.GetType().ToString());
+            SetTagInternal(Trace.Tags.ErrorKind, exception.GetType().ToString());
         }
 
         private void SetTagInternal(string key, string value)


### PR DESCRIPTION
Adopts error analyzer tag names* similar to previous java and node updates.