### PR TITLE
Version 0.1.0

### DIFF
--- a/customer-samples/ConsoleApp/Alpine3.10.dockerfile
+++ b/customer-samples/ConsoleApp/Alpine3.10.dockerfile
@@ -17,7 +17,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=0.0.3
+ARG TRACER_VERSION=0.1.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/customer-samples/ConsoleApp/Alpine3.9.dockerfile
+++ b/customer-samples/ConsoleApp/Alpine3.9.dockerfile
@@ -17,7 +17,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=0.0.3
+ARG TRACER_VERSION=0.1.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/customer-samples/ConsoleApp/Debian.dockerfile
+++ b/customer-samples/ConsoleApp/Debian.dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Set up Datadog APM
-ARG TRACER_VERSION=0.0.3
+ARG TRACER_VERSION=0.1.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -15,11 +15,11 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>signalfx-dotnet-tracing-0.0.3-$(Platform)</OutputName>
+    <OutputName>signalfx-dotnet-tracing-0.1.0-$(Platform)</OutputName>
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>InstallerVersion=0.0.3</DefineConstants>
+    <DefineConstants>InstallerVersion=0.1.0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-VERSION=0.0.3
+VERSION=0.1.0
 
 mkdir -p $DIR/../deploy/linux
 for target in integrations.json defaults.env LICENSE NOTICE createLogPath.sh ; do

--- a/integrations.json
+++ b/integrations.json
@@ -19,7 +19,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -43,7 +43,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -68,7 +68,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -93,7 +93,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -119,7 +119,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -145,7 +145,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -169,7 +169,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -193,7 +193,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -218,7 +218,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -243,7 +243,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -267,7 +267,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -291,7 +291,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -316,7 +316,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -341,7 +341,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -373,7 +373,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearch",
           "signature": "10 01 05 1C 1C 1C 08 08 0A",
@@ -401,7 +401,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearchAsync",
           "signature": "10 01 06 1C 1C 1C 1C 08 08 0A",
@@ -433,7 +433,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearch",
           "signature": "10 01 05 1C 1C 1C 08 08 0A",
@@ -461,7 +461,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearchAsync",
           "signature": "10 01 06 1C 1C 1C 1C 08 08 0A",
@@ -496,7 +496,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "Validate",
           "signature": "00 0A 1C 1C 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -521,7 +521,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "ExecuteAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -552,7 +552,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpMessageHandler_SendAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -578,7 +578,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpClientHandler_SendAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -607,7 +607,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -631,7 +631,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -655,7 +655,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -680,7 +680,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -705,7 +705,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -730,7 +730,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -754,7 +754,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -778,7 +778,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -802,7 +802,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -826,7 +826,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -850,7 +850,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -874,7 +874,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -905,7 +905,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -931,7 +931,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteGeneric",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -957,7 +957,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -983,7 +983,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsyncGeneric",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1012,7 +1012,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1037,7 +1037,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1062,7 +1062,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1088,7 +1088,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderAsyncTwoParams",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1112,7 +1112,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1137,7 +1137,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1161,7 +1161,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1186,7 +1186,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1211,7 +1211,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1246,7 +1246,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ServiceStackRedisIntegration",
           "method": "SendReceive",
           "signature": "10 01 08 1E 00 1C 1D 1D 05 1C 1C 02 08 08 0A",
@@ -1275,7 +1275,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1299,7 +1299,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1324,7 +1324,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1349,7 +1349,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1375,7 +1375,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1401,7 +1401,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1425,7 +1425,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1449,7 +1449,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1474,7 +1474,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1499,7 +1499,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1523,7 +1523,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1547,7 +1547,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1572,7 +1572,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1597,7 +1597,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1631,7 +1631,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A",
@@ -1660,7 +1660,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A",
@@ -1690,7 +1690,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -1720,7 +1720,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -1749,7 +1749,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
           "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -1778,7 +1778,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
           "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -1807,7 +1807,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1831,7 +1831,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1855,7 +1855,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1879,7 +1879,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
           "signature": "00 04 1C 1C 08 08 0A",

--- a/reproductions/AutomapperTest/Dockerfile
+++ b/reproductions/AutomapperTest/Dockerfile
@@ -1,6 +1,6 @@
 # Modified by SignalFx
 FROM mcr.microsoft.com/dotnet/core/runtime:2.1-stretch-slim AS base
-ARG TRACER_VERSION=0.0.3
+ARG TRACER_VERSION=0.1.0
 RUN mkdir -p /opt/datadog
 RUN mkdir -p /var/log/signalfx/dotnet
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v$TRACER_VERSION/datadog-dotnet-apm-$TRACER_VERSION.tar.gz | tar xzf - -C /opt/datadog

--- a/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net45</TargetFrameworks>
 
     <!-- NuGet -->
-    <Version>0.0.3</Version>
+    <Version>0.1.0</Version>
     <Title>SignalFx Tracing for ASP.NET</Title>
     <AssemblyName>SignalFx.Tracing.AspNet</AssemblyName>
     <PackageDescription>

--- a/src/Datadog.Trace.ClrProfiler.Managed.Core/Datadog.Trace.ClrProfiler.Managed.Core.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Core/Datadog.Trace.ClrProfiler.Managed.Core.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>SignalFx.Tracing.ClrProfiler.Managed.Core</AssemblyName>
 
     <!-- NuGet -->
-    <Version>0.0.3</Version>
+    <Version>0.1.0</Version>
     <IsPackable>false</IsPackable>
 
     <!-- Allow the GenerateAssemblyInfo task in the .NET SDK to generate all

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -8,7 +8,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>0.0.3</Version>
+    <Version>0.1.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         {
             try
             {
-                var assembly = Assembly.Load("SignalFx.Tracing.ClrProfiler.Managed, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+                var assembly = Assembly.Load("SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
                 if (assembly != null)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>SignalFx.Tracing.ClrProfiler.Managed</AssemblyName>
 
     <!-- NuGet -->
-    <Version>0.0.3</Version>
+    <Version>0.1.0</Version>
     <Title>Datadog APM - ClrProfiler</Title>
     <PackageDescription>
 DEPRECATED. This package exists only for backwards compatibility. If your project references this package ("Datadog.Trace.ClrProfiler.Managed") or "Datadog.Trace.AspNet", you can remove them both.

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required (VERSION 3.8)
 cmake_policy(SET CMP0015 NEW)
 
-project("Datadog.Trace.ClrProfiler.Native" VERSION 0.0.3)
+project("Datadog.Trace.ClrProfiler.Native" VERSION 0.1.0)
 
 add_compile_options(-std=c++11 -fPIC -fms-extensions)
 add_compile_options(-DBIT64 -DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)

--- a/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,0,3,0
- PRODUCTVERSION 0,0,3,0
+ FILEVERSION 0,1,0,0
+ PRODUCTVERSION 0,1,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "SignalFx"
             VALUE "FileDescription", "SignalFx CLR Profiler"
-            VALUE "FileVersion", "0.0.3.0"
+            VALUE "FileVersion", "0.1.0.0"
             VALUE "InternalName", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "LegalCopyright", "Copyright (C) 2020-2022"
             VALUE "OriginalFilename", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "ProductName", "SignalFx .NET Tracing"
-            VALUE "ProductVersion", "0.0.3"
+            VALUE "ProductVersion", "0.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/Datadog.Trace.ClrProfiler.Native/version.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/version.h
@@ -1,4 +1,4 @@
 // Modified by SignalFx
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.0.3";
+constexpr auto PROFILER_VERSION = "0.1.0";

--- a/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>0.0.3</Version>
+    <Version>0.1.0</Version>
     <Title>SignalFx Tracing OpenTracing</Title>
     <Description>Provides OpenTracing support for SignalFx Tracing</Description>
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>0.0.3</Version>
+    <Version>0.1.0</Version>
     <Title>SignalFx Tracing</Title>
     <Description>Manual instrumentation library for SignalFx Tracing</Description>
     <AssemblyName>SignalFx.Tracing</AssemblyName>

--- a/tools/Datadog.Core.Tools/TracerVersion.cs
+++ b/tools/Datadog.Core.Tools/TracerVersion.cs
@@ -14,12 +14,12 @@ namespace Datadog.Core.Tools
         /// <summary>
         /// The minor portion of the current version.
         /// </summary>
-        public const int Minor = 0;
+        public const int Minor = 1;
 
         /// <summary>
         /// The patch portion of the current version.
         /// </summary>
-        public const int Patch = 3;
+        public const int Patch = 0;
 
         /// <summary>
         /// Whether the current release is a pre-release


### PR DESCRIPTION
** Breaking Change: Migrates error tags to `sfx.error.*` **
* Add additional ASP.NET Core Diagnostic Listener configurable.
* Rename managed modules.
* Add db.statement sanitization for SQL statements.
* Update for initial .msi builds.
* Adopt upstream 1.16.0  with updated PropertyFetcher reversion.