### PR TITLE
Update GraphQL span content

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class GraphQLSpanExpectation : WebServerSpanExpectation
     {
         public GraphQLSpanExpectation(string serviceName, string operationName, string resourceName)
-            : base(serviceName, operationName, resourceName, SpanTypes.GraphQL)
+            : base(serviceName, operationName, resourceName, null)
         {
             RegisterDelegateExpectation(ExpectErrorMatch);
             RegisterTagExpectation(nameof(Tags.GraphQLSource), expected: GraphQLSource);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
@@ -185,11 +185,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 yield return "Resource must be set.";
             }
 
-            if (string.IsNullOrWhiteSpace(span.Type))
-            {
-                yield return "Type must be set.";
-            }
-
             if (string.IsNullOrWhiteSpace(span.Name))
             {
                 yield return "Name must be set.";

--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -100,13 +100,15 @@ namespace Datadog.Trace.TestHelpers
             int timeoutInMilliseconds = 20000,
             string operationName = null,
             DateTimeOffset? minDateTime = null,
-            bool returnAllOperations = false)
+            bool returnAllOperations = false,
+            string[] operationNameContainsAny = null)
         {
             var deadline = DateTime.Now.AddMilliseconds(timeoutInMilliseconds);
             var minimumOffset = (minDateTime ?? DateTimeOffset.MinValue).ToUnixTimeMicroseconds();
 
             IImmutableList<IMockSpan> relevantSpans = ImmutableList<IMockSpan>.Empty;
 
+            operationNameContainsAny ??= new string[0];
             while (DateTime.Now < deadline)
             {
                 relevantSpans =
@@ -115,7 +117,7 @@ namespace Datadog.Trace.TestHelpers
                        .Where(s => s.Start > minimumOffset)
                        .ToImmutableList();
 
-                if (relevantSpans.Count(s => operationName == null || s.Name == operationName) >= count)
+                if (relevantSpans.Count(s => operationNameContainsAny.Any(contains => s.Name.Contains(contains)) || operationName == null || s.Name == operationName) >= count)
                 {
                     break;
                 }
@@ -127,7 +129,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 relevantSpans =
                     relevantSpans
-                       .Where(s => operationName == null || s.Name == operationName)
+                       .Where(s => operationNameContainsAny.Any(contains => s.Name.Contains(contains)) || operationName == null || s.Name == operationName)
                        .ToImmutableList();
             }
 


### PR DESCRIPTION
These changes include providing more informative operation names, truncating tagged queries, and adopting Zipkin encoding in the corresponding integration test suite.