### PR TITLE
Add HttpClient support

### DIFF
--- a/samples/Samples.HttpMessageHandler/Program.cs
+++ b/samples/Samples.HttpMessageHandler/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -24,8 +23,6 @@ namespace Samples.HttpMessageHandler
 #endif
         public static void Main(string[] args)
         {
-            DumpEnvVars();
-
             bool tracingDisabled = args.Any(arg => arg.Equals("TracingDisabled", StringComparison.OrdinalIgnoreCase));
             Console.WriteLine($"TracingDisabled {tracingDisabled}");
 
@@ -198,21 +195,6 @@ namespace Samples.HttpMessageHandler
                     // ignore to let the loop end and the method return
                 }
             }
-        }
-
-        private static void DumpEnvVars()
-        {
-            IDictionary envVars = System.Environment.GetEnvironmentVariables();
-            foreach(var key in envVars.Keys)
-            {
-                var keyStr = key.ToString();
-                if (keyStr.Contains("SIGNALFX") || keyStr.Contains("CORCLR") || keyStr.Contains("DOTNET"))
-                {
-                    Console.WriteLine(key  + ":" + envVars[key]);
-                }
-            }
-
-            Console.WriteLine();
         }
     }
 }

--- a/samples/Samples.HttpMessageHandler/Program.cs
+++ b/samples/Samples.HttpMessageHandler/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -23,6 +24,8 @@ namespace Samples.HttpMessageHandler
 #endif
         public static void Main(string[] args)
         {
+            DumpEnvVars();
+
             bool tracingDisabled = args.Any(arg => arg.Equals("TracingDisabled", StringComparison.OrdinalIgnoreCase));
             Console.WriteLine($"TracingDisabled {tracingDisabled}");
 
@@ -195,6 +198,21 @@ namespace Samples.HttpMessageHandler
                     // ignore to let the loop end and the method return
                 }
             }
+        }
+
+        private static void DumpEnvVars()
+        {
+            IDictionary envVars = System.Environment.GetEnvironmentVariables();
+            foreach(var key in envVars.Keys)
+            {
+                var keyStr = key.ToString();
+                if (keyStr.Contains("SIGNALFX") || keyStr.Contains("CORCLR") || keyStr.Contains("DOTNET"))
+                {
+                    Console.WriteLine(key  + ":" + envVars[key]);
+                }
+            }
+
+            Console.WriteLine();
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         scope.Span.SetTag(Tags.HttpStatusCode, ((int)response.StatusCode).ToString());
                         if (!response.IsSuccessStatusCode && !string.IsNullOrWhiteSpace(response.ReasonPhrase))
                         {
-                            scope.Span.SetTag(Tags.HttpStatusText, response.ReasonPhrase);
+                            scope.Span.SetTag(Tags.HttpStatusText, response.ReasonPhrase.Truncate());
                         }
                     }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -172,7 +172,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (!(handler is HttpClientHandler || reportedType.FullName.Equals("System.Net.Http.SocketsHttpHandler", StringComparison.OrdinalIgnoreCase)) ||
+            if (!(handler is HttpClientHandler || "System.Net.Http.SocketsHttpHandler".Equals(reportedType.FullName, StringComparison.OrdinalIgnoreCase)) ||
                 !IsTracingEnabled(request))
             {
                 // skip instrumentation
@@ -195,8 +195,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     HttpResponseMessage response = await sendAsync(handler, request, cancellationToken).ConfigureAwait(false);
 
-                    // this tag can only be set after the response is returned
-                    scope?.Span.SetTag(Tags.HttpStatusCode, ((int)response.StatusCode).ToString());
+                    if (scope != null)
+                    {
+                        // this tag can only be set after the response is returned
+                        scope.Span.SetTag(Tags.HttpStatusCode, ((int)response.StatusCode).ToString());
+                        if (!response.IsSuccessStatusCode && !string.IsNullOrWhiteSpace(response.ReasonPhrase))
+                        {
+                            scope.Span.SetTag(Tags.HttpStatusText, response.ReasonPhrase);
+                        }
+                    }
 
                     return response;
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -51,7 +51,13 @@ namespace Datadog.Trace.ClrProfiler
                     return null;
                 }
 
-                scope = tracer.StartActive(OperationName);
+                var spanName = httpMethod ?? OperationName;
+                if (tracer.Settings.AppendUrlPathToName)
+                {
+                    spanName += ":" + requestUri.AbsolutePath;
+                }
+
+                scope = tracer.StartActive(spanName);
                 var span = scope.Span;
 
                 span.ServiceName = $"{tracer.DefaultServiceName}-{ServiceName}";

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -248,6 +248,13 @@ namespace Datadog.Trace.Configuration
         public const string DiagnosticSourceEnabled = "SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED";
 
         /// <summary>
+        /// Configuration key for enabling or disabling appending the absolute URI path to the span name.
+        /// Default is value is false (disabled).
+        /// </summary>
+        /// <seealso cref="TracerSettings.AppendUrlPathToName"/>
+        public const string AppendUrlPathToName = "SIGNALFX_APPEND_URL_PATH_TO_NAME";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -139,6 +139,10 @@ namespace Datadog.Trace.Configuration
                                                  ?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                                                  .Select(s => s.Trim()).ToArray() ??
                                             new string[0];
+
+            AppendUrlPathToName = source?.GetBool(ConfigurationKeys.AppendUrlPathToName) ??
+                           // default value
+                           false;
         }
 
         /// <summary>
@@ -301,6 +305,13 @@ namespace Datadog.Trace.Configuration
         /// of <see cref="System.Diagnostics.DiagnosticSource"/> is enabled.
         /// </summary>
         public bool DiagnosticSourceEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the absolute URL path should be
+        /// appended to the span name.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.AppendUrlPathToName"/>
+        public bool AppendUrlPathToName { get; set; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -46,9 +46,14 @@ namespace Datadog.Trace
         public const string HttpRequestHeadersHost = "http.request.headers.host";
 
         /// <summary>
-        /// The status code of an HTTP response
+        /// The status code of an HTTP response.
         /// </summary>
         public const string HttpStatusCode = "http.status_code";
+
+        /// <summary>
+        /// The HTTP response reason phrase, eg: "OK".
+        /// </summary>
+        public const string HttpStatusText = "http.status_text";
 
         /// <summary>
         /// The span.Resource for span encoding without applicable field.

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -472,7 +472,7 @@ namespace Datadog.Trace
         {
             try
             {
-                Assembly asm = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=0.0.3.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"));
+                Assembly asm = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=0.1.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"));
                 Type openTracingTracerFactory = asm.GetType("Datadog.Trace.OpenTracing.OpenTracingTracerFactory");
                 var methodInfo = openTracingTracerFactory.GetMethod("RegisterGlobalTracer");
                 object[] args = new object[] { instance };

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public void HttpClient()
         {
             int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 2 : 1;
-            const string expectedOperationName = "http.request";
+            const string expectedOperationName = "POST";
             const string expectedServiceName = "Samples.HttpMessageHandler";
 
             int agentPort = TcpPortProvider.GetOpenPort();
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 // inspect the top-level span, underlying spans can be HttpMessageHandler in .NET Core
                 var firstSpan = spans.First();
-                Assert.Equal("http.request", firstSpan.Name);
+                Assert.Equal("GET", firstSpan.Name);
                 Assert.Equal("Samples.HttpMessageHandler", firstSpan.Service);
                 Assert.Null(firstSpan.Type);
                 Assert.Equal(nameof(WebRequest), firstSpan.Tags[Tags.InstrumentationName]);

--- a/tools/PrepareRelease/SetAllVersions.cs
+++ b/tools/PrepareRelease/SetAllVersions.cs
@@ -36,6 +36,10 @@ namespace PrepareRelease
                 NugetVersionReplace);
 
             SynchronizeVersion(
+                "src/Datadog.Trace/Tracer.cs",
+                PartialAssemblyNameReplace);
+
+            SynchronizeVersion(
                 "src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj",
                 NugetVersionReplace);
 


### PR DESCRIPTION
This was already supported by the code this change just put it closer to OpenTelemetry current specs for HTTP spans by changing the span name and also adding `http.status_text` for failed status codes.
