### PR TITLE
Switch AssertHttpSpan to MockZipkinCollector

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private Process _iisExpress;
 
-        public MockTracerAgent Agent { get; private set; }
+        public MockZipkinCollector Agent { get; private set; }
 
         public int HttpPort { get; private set; }
 
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 if (_iisExpress == null)
                 {
                     var initialAgentPort = TcpPortProvider.GetOpenPort();
-                    Agent = new MockTracerAgent(initialAgentPort);
+                    Agent = new MockZipkinCollector(initialAgentPort);
 
                     HttpPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -236,7 +236,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected async Task AssertHttpSpan(
             string path,
-            MockTracerAgent agent,
+            MockZipkinCollector agent,
             int httpPort,
             HttpStatusCode expectedHttpStatusCode,
             string expectedSpanType,


### PR DESCRIPTION
All ASP.NET related tests go through these, so switching them to MockZipkinCollector.