### PR TITLE
Fix CI issue with .NET Core 3.1.300 SDK (#740)

### DIFF
--- a/samples/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/samples/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -7,6 +7,7 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 

--- a/samples/Samples.Elasticsearch/Samples.Elasticsearch.csproj
+++ b/samples/Samples.Elasticsearch/Samples.Elasticsearch.csproj
@@ -9,6 +9,7 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 

--- a/samples/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/samples/Samples.MongoDB/Samples.MongoDB.csproj
@@ -6,6 +6,7 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.Npgsql/Samples.Npgsql.csproj
+++ b/samples/Samples.Npgsql/Samples.Npgsql.csproj
@@ -5,6 +5,7 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.OpenTracing/Samples.OpenTracing.csproj
+++ b/samples/Samples.OpenTracing/Samples.OpenTracing.csproj
@@ -7,7 +7,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>	
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.OpenTracing/Samples.OpenTracing.csproj
+++ b/samples/Samples.OpenTracing/Samples.OpenTracing.csproj
@@ -5,7 +5,9 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>	
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.ServiceStack.Redis/Samples.ServiceStack.Redis.csproj
+++ b/samples/Samples.ServiceStack.Redis/Samples.ServiceStack.Redis.csproj
@@ -5,6 +5,7 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.SqlServer/Samples.SqlServer.csproj
+++ b/samples/Samples.SqlServer/Samples.SqlServer.csproj
@@ -5,6 +5,7 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 

--- a/samples/Samples.StackExchange.Redis/Samples.StackExchange.Redis.csproj
+++ b/samples/Samples.StackExchange.Redis/Samples.StackExchange.Redis.csproj
@@ -16,6 +16,7 @@
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The .NET Core 3.1.300 SDK was released on 2020-05-19, and since then our CI runs have been failing because we use the latest 3.1 SDK. The failure occurs when building our sample projects in parallel (which are placed in different subdirectories but still share the same obj/bin root directory) with the following error: `error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attribute`

To avoid this issue, I've assigned the property GenerateTargetFrameworkAttribute=false property to each of the affected sample projects.