### PR TITLE
Add ASP.NET Web Forms

### DIFF
--- a/samples-aspnet/Samples.WebForms/Web.config
+++ b/samples-aspnet/Samples.WebForms/Web.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Modified by SignalFx -->
 <configuration>
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
@@ -41,6 +42,7 @@
     <modules>
       <remove name="FormsAuthentication" />
       <add name="DDArbitrarynameForCustomLoggingModule" type="Samples.WebForms.DDCustomLoggingModule, Samples.WebForms" />
+      <add name="SignalFxTracingModule" type="Datadog.Trace.AspNet.TracingHttpModule,SignalFx.Tracing.AspNet,Version=1.0.0.0,Culture=neutral,PublicKeyToken=def86d061d0d2eeb" />
     </modules>
   </system.webServer>
   <runtime>


### PR DESCRIPTION
Fixes the test to validate ASP.NET Web Forms instrumentation. This is only available on Windows and happens by injecting an `IHttpModule` on the ASP.NET stack via IIS configuration. Typically this is done via the MSI installation, however, in the case of the test, this was added directly to the web.config file so it doesn't depend on the IIS install and can work in a dev box configured with IIS express or IIS.

Since the related methods were already updated to properly set the operation name and use the mock Zipkin to test no other changes were needed.

@signalfx/instrumentation