### PR TITLE
Add sfx token support

### DIFF
--- a/src/Datadog.Trace/Agent/ZipkinApi.cs
+++ b/src/Datadog.Trace/Agent/ZipkinApi.cs
@@ -3,13 +3,12 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.StatsdClient;
 using MsgPack.Serialization;
 using Newtonsoft.Json;
-using SignalFx.Tracing.Configuration;
-
 
 namespace Datadog.Trace.Agent
 {

--- a/src/Datadog.Trace/Agent/ZipkinContent.cs
+++ b/src/Datadog.Trace/Agent/ZipkinContent.cs
@@ -15,10 +15,14 @@ namespace Datadog.Trace.Agent
         private readonly ZipkinSerializer _serializer = new ZipkinSerializer();
         private readonly Span[][] _spans;
 
-        public ZipkinContent(Span[][] spans)
+        public ZipkinContent(Span[][] spans, string signalFxAccessToken)
         {
             _spans = spans;
             Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            if (!string.IsNullOrWhiteSpace(signalFxAccessToken))
+            {
+                Headers.Add("X-Sf-Token", signalFxAccessToken);
+            }
         }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -263,6 +263,13 @@ namespace Datadog.Trace.Configuration
         public const string UseWebServerResourceAsOperationName = "SIGNALFX_USE_WEBSERVER_RESOURCE_AS_OPERATION_NAME";
 
         /// <summary>
+        /// Configuration key to set the SignalFx access token. This is to be used when sending data
+        /// directly to ingestion URL, ie.: no agent or collector is being used.
+        /// </summary>
+        /// <seealso cref="TracerSettings.SignalFxAccessToken"/>
+        public const string SignalFxAccessToken = "SIGNALFX_ACCESS_TOKEN";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -41,6 +41,8 @@ namespace Datadog.Trace.Configuration
 
             ServiceName = source?.GetString(ConfigurationKeys.ServiceName);
 
+            SignalFxAccessToken = source?.GetString(ConfigurationKeys.SignalFxAccessToken);
+
             TraceEnabled = source?.GetBool(ConfigurationKeys.TraceEnabled) ??
                            // default value
                            true;
@@ -324,6 +326,13 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.UseWebServerResourceAsOperationName"/>
         /// <seealso cref="ExtensionMethods.SpanExtensions.DecorateWebServerSpan(Span, string, string, string, string)"/>
         public bool UseWebServerResourceAsOperationName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value with the SignalFx access token. This is to be used when sending data
+        /// directly to ingestion URL, ie.: no agent or collector is being used.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.SignalFxAccessToken"/>
+        public string SignalFxAccessToken { get; set; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -113,7 +113,7 @@ namespace Datadog.Trace
             {
                 if (Settings.ApiType.ToLower().Equals("zipkin"))
                 {
-                    apiClient = new ZipkinApi(Settings.EndpointUrl, delegatingHandler: null, Statsd);
+                    apiClient = new ZipkinApi(Settings, delegatingHandler: null, Statsd);
                 }
                 else
                 {

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.IntegrationTests
         {
             var settings = new TracerSettings();
             _httpRecorder = new RecordHttpHandler();
-            var api = new ZipkinApi(settings.EndpointUrl, _httpRecorder, statsd: null);
+            var api = new ZipkinApi(settings, _httpRecorder, statsd: null);
             var agentWriter = new AgentWriter(api, statsd: null);
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }


### PR DESCRIPTION
To work in scenarios like Lambda and Functions we need to support configuration of the sfx token. Adding this new env var we can then use two env vars to export directly to ingest: 

- SIGNALFX_ENDPOINT_URL
- SIGNALFX_ACCESS_TOKEN

@signalfx/instrumentation