### PR TITLE
Allow service name per span as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ automatically become child spans of any existing spans in the same context:
     }
     ```
 
+When using manual instrumentation it is possible to set different service names under the same process.
+This is disabled by default but can be enabled by configuring the environment variable
+`SIGNALFX_SERVICE_NAME_PER_SPAN_ENABLED` to `true` and following the [OpenTracing semantic
+conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#semantic-conventions)
+by setting the tag `service.name` to the desired service name.
+
+For more examples and information on how to do manual instrumentation see:
+
+- https://github.com/signalfx/tracing-examples/tree/master/dotnet-manual-instrumentation
+- https://github.com/signalfx/tracing-examples/tree/master/signalfx-tracing/signalfx-dotnet-tracing
+
 ## About
 The SignalFx-Tracing Library for .NET is a fork of the .NET
 Tracer for Datadog APM that has been modified to provide Zipkin v2 JSON

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
@@ -14,7 +14,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     internal static class ElasticsearchNetCommon
     {
         public const string OperationName = "elasticsearch.query";
-        public const string ServiceName = "elasticsearch";
         public const string SpanType = "elasticsearch";
         public const string ComponentValue = "elasticsearch-net";
         public const string ElasticsearchActionKey = "elasticsearch.action";
@@ -49,14 +48,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             string method = requestData.GetProperty("Method").GetValueOrDefault()?.ToString();
             var url = requestData.GetProperty("Uri").GetValueOrDefault()?.ToString();
 
-            var serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
-
             Scope scope = null;
 
             try
             {
                 var operationName = requestName ?? OperationName;
-                scope = tracer.StartActive(operationName, serviceName: serviceName);
+                scope = tracer.StartActive(operationName, serviceName: tracer.DefaultServiceName);
                 var span = scope.Span;
                 span.SetTag(Tags.InstrumentationName, ComponentValue);
                 span.SetTag(Tags.DbType, SpanType);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -17,7 +17,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     public static class GraphQLIntegration
     {
         private const string IntegrationName = "GraphQL";
-        private const string ServiceName = "graphql";
 
         private const string Major2 = "2";
         private const string Major2Minor3 = "2.3";
@@ -252,13 +251,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             Tracer tracer = Tracer.Instance;
             string source = document.GetProperty<string>("OriginalQuery")
                                     .GetValueOrDefault();
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
 
             Scope scope = null;
 
             try
             {
-                scope = tracer.StartActive(ValidateOperationName, serviceName: serviceName);
+                scope = tracer.StartActive(ValidateOperationName, serviceName: tracer.DefaultServiceName);
                 var span = scope.Span;
                 DecorateSpan(span);
                 span.SetTag(Tags.GraphQLSource, source.Truncate());
@@ -294,14 +292,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                                                        .GetProperty<Enum>("OperationType")
                                                        .GetValueOrDefault()
                                                        .ToString();
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
 
             Scope scope = null;
 
             try
             {
                 var operation = $"{operationType}{(!string.IsNullOrEmpty(operationName) ? $" {operationName}" : string.Empty)}";
-                scope = tracer.StartActive(operation, serviceName: serviceName);
+                scope = tracer.StartActive(operation, serviceName: tracer.DefaultServiceName);
                 var span = scope.Span;
                 DecorateSpan(span);
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -16,7 +16,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     {
         private const string IntegrationName = "MongoDb";
         private const string OperationName = "mongodb.query";
-        private const string ServiceName = "mongodb";
 
         private const string Major2 = "2";
         private const string Major2Minor1 = "2.1";
@@ -467,7 +466,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 Log.Warning(ex, "Unable to access IWireProtocol.Command properties.");
             }
 
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
             operationName = operationName ?? OperationName;
 
             Span parent = tracer.ActiveScope?.Span;
@@ -484,7 +482,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             Scope scope = null;
             try
             {
-                scope = tracer.StartActive(operationName, serviceName: serviceName);
+                scope = tracer.StartActive(operationName, serviceName: tracer.DefaultServiceName);
                 var span = scope.Span;
                 span.SetTag(Tags.DbType, SpanTypes.MongoDb);
                 span.SetTag(Tags.InstrumentationName, IntegrationName);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -8,7 +8,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     internal static class RedisHelper
     {
         private const string OperationName = "redis.command";
-        private const string ServiceName = "redis";
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(RedisHelper));
 
@@ -20,7 +19,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 return null;
             }
 
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
             Scope scope = null;
 
             try
@@ -37,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     command = rawCommand;
                 }
 
-                scope = tracer.StartActive(command ?? OperationName, serviceName: serviceName);
+                scope = tracer.StartActive(command ?? OperationName, serviceName: tracer.DefaultServiceName);
 
                 var span = scope.Span;
                 span.SetTag(Tags.InstrumentationName, componentName);

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -14,7 +14,6 @@ namespace Datadog.Trace.ClrProfiler
     internal static class ScopeFactory
     {
         public const string OperationName = "http.request";
-        public const string ServiceName = "http-client";
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(ScopeFactory));
 
@@ -60,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler
                 scope = tracer.StartActive(spanName);
                 var span = scope.Span;
 
-                span.ServiceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+                span.ServiceName = tracer.DefaultServiceName;
 
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 // Only the span responsible for propagated context should have client span.kind
@@ -130,10 +129,9 @@ namespace Datadog.Trace.ClrProfiler
                     return null;
                 }
 
-                string serviceName = $"{tracer.DefaultServiceName}-{dbType}";
                 string operationName = $"{dbType}.query";
 
-                scope = tracer.StartActive(operationName, serviceName: serviceName);
+                scope = tracer.StartActive(operationName, serviceName: tracer.DefaultServiceName);
                 var span = scope.Span;
                 span.SetTag(Tags.DbType, dbType);
                 span.SetTag(Tags.InstrumentationName, integrationName);

--- a/src/Datadog.Trace/Agent/ZipkinApi.cs
+++ b/src/Datadog.Trace/Agent/ZipkinApi.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Agent
                 try
                 {
                     // re-create content on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
-                    using (var content = new ZipkinContent(traces, _settings.SignalFxAccessToken))
+                    using (var content = new ZipkinContent(traces, _settings))
                     {
                         responseMessage = await _client.PostAsync(_settings.EndpointUrl, content).ConfigureAwait(false);
                         responseMessage.EnsureSuccessStatusCode();

--- a/src/Datadog.Trace/Agent/ZipkinContent.cs
+++ b/src/Datadog.Trace/Agent/ZipkinContent.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 
 namespace Datadog.Trace.Agent
 {
@@ -14,14 +15,16 @@ namespace Datadog.Trace.Agent
     {
         private readonly ZipkinSerializer _serializer = new ZipkinSerializer();
         private readonly Span[][] _spans;
+        private readonly TracerSettings _settings;
 
-        public ZipkinContent(Span[][] spans, string signalFxAccessToken)
+        public ZipkinContent(Span[][] spans, TracerSettings settings)
         {
             _spans = spans;
+            _settings = settings;
             Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            if (!string.IsNullOrWhiteSpace(signalFxAccessToken))
+            if (!string.IsNullOrWhiteSpace(_settings.SignalFxAccessToken))
             {
-                Headers.Add("X-Sf-Token", signalFxAccessToken);
+                Headers.Add("X-Sf-Token", _settings.SignalFxAccessToken);
             }
         }
 
@@ -29,7 +32,7 @@ namespace Datadog.Trace.Agent
         {
             return Task.Factory.StartNew(() =>
                 {
-                    _serializer.Serialize(stream, _spans);
+                    _serializer.Serialize(stream, _spans, _settings);
                 });
         }
 

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Configuration
         /// OpenTracing semantic convention.
         /// </summary>
         /// <seealso cref="TracerSettings.ServiceName"/>
-        public const string ServiceNamePerSpan = "SIGNALFX_SERVICE_NAME_PER_SPAN";
+        public const string ServiceNamePerSpan = "SIGNALFX_SERVICE_NAME_PER_SPAN_ENABLED";
 
         /// <summary>
         /// Configuration key for enabling or disabling the Tracer.

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -28,6 +28,14 @@ namespace Datadog.Trace.Configuration
         public const string ServiceName = "SIGNALFX_SERVICE_NAME";
 
         /// <summary>
+        /// Configuration key for the application's to allow spans to specify
+        /// different service names then the default one using the "service.name"
+        /// OpenTracing semantic convention.
+        /// </summary>
+        /// <seealso cref="TracerSettings.ServiceName"/>
+        public const string ServiceNamePerSpan = "SIGNALFX_SERVICE_NAME_PER_SPAN";
+
+        /// <summary>
         /// Configuration key for enabling or disabling the Tracer.
         /// Default is value is true (enabled).
         /// </summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -41,10 +41,12 @@ namespace Datadog.Trace.Configuration
 
             ServiceName = source?.GetString(ConfigurationKeys.ServiceName);
 
+            ServiceNamePerSpanEnabled = source?.GetBool(ConfigurationKeys.ServiceNamePerSpan) ??
+                                        false;
+
             SignalFxAccessToken = source?.GetString(ConfigurationKeys.SignalFxAccessToken);
 
             TraceEnabled = source?.GetBool(ConfigurationKeys.TraceEnabled) ??
-                           // default value
                            true;
 
             var disabledIntegrationNames = source?.GetString(ConfigurationKeys.DisabledIntegrations)
@@ -162,6 +164,13 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.ServiceName"/>
         public string ServiceName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether setting the service name per span is enabled.
+        /// The default is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.ServiceNamePerSpan"/>
+        public bool ServiceNamePerSpanEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether tracing is enabled.

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -45,24 +45,41 @@ namespace Datadog.Trace.IntegrationTests
             }
         }
 
-        [Fact]
-        public async void CustomServiceName()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void CustomServiceName(bool serviceNamePerSpanEnabled)
         {
-            using (var agent = new MockZipkinCollector(collectorPort))
+            var savedServiceNamePerSpanSetting = _tracer.Settings.ServiceNamePerSpanEnabled;
+            try
             {
-                const string ServiceName = "MyService";
+                _tracer.Settings.ServiceNamePerSpanEnabled = serviceNamePerSpanEnabled;
 
-                var scope = _tracer.StartActive("Operation", serviceName: ServiceName);
-                scope.Span.ResourceName = "This is a resource";
-                scope.Dispose();
+                using (var agent = new MockZipkinCollector(collectorPort))
+                {
+                    const string ServiceName = "MyService";
 
-                await _httpRecorder.WaitForCompletion(1);
-                Assert.Single(_httpRecorder.Requests);
-                Assert.Single(_httpRecorder.Responses);
-                Assert.All(_httpRecorder.Responses, (x) => Assert.Equal(HttpStatusCode.OK, x.StatusCode));
+                    var scope = _tracer.StartActive("Operation", serviceName: ServiceName);
+                    scope.Span.ResourceName = "This is a resource";
+                    scope.Dispose();
 
-                var trace = _httpRecorder.ZipkinTraces.Single();
-                ZipkinHelpers.AssertSpanEqual(scope.Span, trace);
+                    await _httpRecorder.WaitForCompletion(1);
+                    Assert.Single(_httpRecorder.Requests);
+                    Assert.Single(_httpRecorder.Responses);
+                    Assert.All(_httpRecorder.Responses, (x) => Assert.Equal(HttpStatusCode.OK, x.StatusCode));
+
+                    var trace = _httpRecorder.ZipkinTraces.Single();
+
+                    var expectedServiceName = serviceNamePerSpanEnabled
+                                                  ? ServiceName
+                                                  : _tracer.DefaultServiceName;
+
+                    ZipkinHelpers.AssertSpanEqual(scope.Span, trace, expectedServiceName);
+                }
+            }
+            finally
+            {
+                _tracer.Settings.ServiceNamePerSpanEnabled = savedServiceNamePerSpanSetting;
             }
         }
 

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -57,9 +57,9 @@ namespace Datadog.Trace.IntegrationTests
 
                 using (var agent = new MockZipkinCollector(collectorPort))
                 {
-                    const string ServiceName = "MyService";
+                    const string serviceName = "MyService";
 
-                    var scope = _tracer.StartActive("Operation", serviceName: ServiceName);
+                    var scope = _tracer.StartActive("Operation", serviceName: serviceName);
                     scope.Span.ResourceName = "This is a resource";
                     scope.Dispose();
 
@@ -71,7 +71,7 @@ namespace Datadog.Trace.IntegrationTests
                     var trace = _httpRecorder.ZipkinTraces.Single();
 
                     var expectedServiceName = serviceNamePerSpanEnabled
-                                                  ? ServiceName
+                                                  ? serviceName
                                                   : _tracer.DefaultServiceName;
 
                     ZipkinHelpers.AssertSpanEqual(scope.Span, trace, expectedServiceName);

--- a/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/ZipkinHelpers.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.TestHelpers
             return logs;
         }
 
-        public static void AssertSpanEqual(Span expected, JToken actual)
+        public static void AssertSpanEqual(Span expected, JToken actual, string expectedServiceName = null)
         {
             Assert.Equal(expected.Context.TraceId, actual.TraceId());
             Assert.Equal(expected.Context.SpanId, actual.SpanId());
@@ -101,7 +101,7 @@ namespace Datadog.Trace.TestHelpers
 
             Assert.Equal(expected.OperationName, actual.OperationName());
             Assert.Equal(expected.ResourceName, actual.ResourceName());
-            Assert.Equal(Tracer.Instance.DefaultServiceName, actual.ServiceName());
+            Assert.Equal(expectedServiceName ?? Tracer.Instance.DefaultServiceName, actual.ServiceName());
             Assert.Equal(expected.Type, actual.Type());
             Assert.Equal(expected.StartTime.ToUnixTimeMicroseconds(), actual.StartTime());
             Assert.Equal(expected.Duration.ToMicroseconds(), actual.Duration());


### PR DESCRIPTION
In some scenarios, it is desirable to allow service name to be set per span and not globally by the process. This change adds an env var to allow that option.

Before this change "custom integration service names" were hidden because the span service name was ignored. Now we want these to follow the same as the process, otherwise, service name for these instrumentations will change if combined with manual instrumentation and the option to set service name per span.

@signalfx/instrumentation