### PR TITLE
Enable WCF integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1908,6 +1908,37 @@
     ]
   },
   {
+    "name": "Wcf",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.ServiceModel",
+          "type": "System.ServiceModel.Dispatcher.ChannelHandler",
+          "method": "HandleRequest",
+          "signature_types": [
+            "System.Boolean",
+            "System.ServiceModel.Channels.RequestContext",
+            "System.ServiceModel.OperationContext"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.WcfIntegration",
+          "method": "HandleRequest",
+          "signature": "00 06 02 1C 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
+      }
+    ]
+  },
+  {
     "name": "WebRequest",
     "method_replacements": [
       {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -139,11 +139,16 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
-                scope = tracer.StartActive("wcf.request", propagatedContext);
+                var operationNameSuffix = requestMessage.Headers.Action ?? requestMessage.Headers.To?.LocalPath;
+                var operationName = !string.IsNullOrEmpty(operationNameSuffix)
+                    ? "wcf.request " + operationNameSuffix
+                    : "wcf.request";
+
+                scope = tracer.StartActive(operationName, propagatedContext);
                 var span = scope.Span;
 
                 span.DecorateWebServerSpan(
-                    resourceName: requestMessage.Headers.Action ?? requestMessage.Headers.To?.LocalPath,
+                    resourceName: null,
                     httpMethod,
                     host,
                     httpUrl: requestMessage.Headers.To?.AbsoluteUri);

--- a/tools/PrepareRelease/PrepareRelease.csproj
+++ b/tools/PrepareRelease/PrepareRelease.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net452;net461;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Enabling WCF instrumentation that already exists on DD. This is to just enable what already exists. There were no automated tests for this integration, this PR does not add one for it. All validations were made manually by enabling profiling for `Samples.Wcf` and `Samples.WcfClient` (they are built when running the cmd to test integrations).

The client-side for `WSHttpBinding` and `BasicHttpBinding` generates client spans via the `WebRequest` instrumentation. Enabling WCF integration creates a span for the server-side. The context is properly flowing between the client and the server. There is no client-side span for `NetTcpBinding`.

The server span looks like a generic HTTP server-side span in order to make clear that this is a WCF span the operation name will be pre-pended with `wcf.request`.

@signalfx/instrumentation