### PR TITLE
Update trace and log correlation tag and format

### DIFF
--- a/customer-samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
+++ b/customer-samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+  <!-- Modified by SignalFx -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="1.8.0" />
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.8.3" />
   </ItemGroup>
@@ -15,6 +14,10 @@
     <None Update="log4net.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
 </Project>

--- a/customer-samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
+++ b/customer-samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- Modified by SignalFx -->
 <configuration>
     <configSections>
         <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
     </configSections>
     <log4net>
-        <!-- For the SerializedLayout from the log4net.Ext.Json NuGet package, you can explicitly extract the 'dd.trace_id' and 'dd.span_id' values using new <member> nodes (see: https://github.com/BrightOpen/log4net.Ext.Json#json-stuff) -->
+        <!-- For the SerializedLayout from the log4net.Ext.Json NuGet package, you can explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values using new <member> nodes (see: https://github.com/BrightOpen/log4net.Ext.Json#json-stuff) -->
         <!--
             Additions to layout:
-            - <member value='dd.trace_id' />
-            - <member value='dd.span_id' />
+            - <member value='signalfx.trace_id' />
+            - <member value='signalfx.span_id' />
         -->
         <appender name="jsonFileExplicitPropertiesAppender" type="log4net.Appender.FileAppender" >
             <file value="log-log4net-jsonFile-explicitProperties.log" />
@@ -23,13 +24,13 @@
                 <member value='order-number' />
 
                 <!-- Manual changes: start -->
-                <member value='dd.trace_id' />
-                <member value='dd.span_id' />
+                <member value='signalfx.trace_id' />
+                <member value='signalfx.span_id' />
                 <!-- Manual changes: end -->
             </layout>
         </appender>
 
-        <!-- For the SerializedLayout from the log4net.Ext.Json NuGet package, you can also explicitly extract the 'properties' value, which will automatically emit the `dd.trace_id` and `dd.span_id` values (see: https://github.com/BrightOpen/log4net.Ext.Json#json-stuff) -->
+        <!-- For the SerializedLayout from the log4net.Ext.Json NuGet package, you can also explicitly extract the 'properties' value, which will automatically emit the `signalfx.trace_id` and `signalfx.span_id` values (see: https://github.com/BrightOpen/log4net.Ext.Json#json-stuff) -->
         <!--
             Additions to layout:
             - <member value='properties'/>
@@ -54,9 +55,9 @@
 
 
 
-        <!-- For the default PatternLayout, you must explicitly extract the 'dd.trace_id' and 'dd.span_id' values using the %property{name} syntax (see: https://logging.apache.org/log4net/release/manual/contexts.html) -->
+        <!-- For the default PatternLayout, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values using the %property{name} syntax (see: https://logging.apache.org/log4net/release/manual/contexts.html) -->
         <!--
--            Additions to layout: {traceId=&quot;%property{dd.trace_id}&quot;,spanId=&quot;%property{dd.span_id}&quot;}
+-            Additions to layout: {traceId=&quot;%property{signalfx.trace_id}&quot;,spanId=&quot;%property{signalfx.span_id}&quot;}
 -       -->
         <!--
             Parsing this log line with a custom Pipeline that adds Trace/Log correlation can be done with the following Processors:
@@ -66,7 +67,7 @@
         <appender name="textFileAppender" type="log4net.Appender.FileAppender">
             <file value="log-log4net-textFile.log" />
             <layout type="log4net.Layout.PatternLayout">
-                <conversionPattern value="%date [%thread] %level %logger {traceId=&quot;%property{dd.trace_id}&quot;, spanId=&quot;%property{dd.span_id}&quot;} - %message%newline" />
+                <conversionPattern value="%date [%thread] %level %logger {traceId=&quot;%property{signalfx.trace_id}&quot;, spanId=&quot;%property{signalfx.span_id}&quot;} - %message%newline" />
             </layout>
         </appender>
 

--- a/customer-samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
+++ b/customer-samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- Modified by SignalFx -->
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
-        <!-- For JsonLayout when includeMdc=true, you do not need to do any additional work to extract the 'dd.trace_id' and 'dd.span_id' values (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
+        <!-- For JsonLayout when includeMdc=true, you do not need to do any additional work to extract the 'signalfx.trace_id' and 'signalfx.span_id' values (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
         <!--
             Additions to layout: none
         -->
@@ -15,11 +16,11 @@
             </layout>
         </target>
 
-        <!-- For JsonLayout when includeMdc=false, you must explicitly extract the 'dd.trace_id' and 'dd.span_id' values using new <attribute> nodes (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
+        <!-- For JsonLayout when includeMdc=false, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values using new <attribute> nodes (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
         <!--
             Additions to layout:
-            - <attribute name="dd.trace_id" layout="${mdc:item=dd.trace_id}"/>
-            - <attribute name="dd.span_id" layout="${mdc:item=dd.span_id}"/>
+            - <attribute name="signalfx.trace_id" layout="${mdc:item=signalfx.trace_id}"/>
+            - <attribute name="signalfx.span_id" layout="${mdc:item=signalfx.span_id}"/>
         -->
         <target name="jsonFile-includeMdc-false" xsi:type="File" fileName="log-NLog45-jsonFile-includeMdc-false.log">
             <layout xsi:type="JsonLayout" includeMdc="false">
@@ -29,15 +30,15 @@
                 <attribute name="exception" layout="${exception:format=ToString}" />
 
                 <!-- Manual changes: start -->
-                <attribute name="dd.trace_id" layout="${mdc:item=dd.trace_id}"/>
-                <attribute name="dd.span_id" layout="${mdc:item=dd.span_id}"/>
+                <attribute name="signalfx.trace_id" layout="${mdc:item=signalfx.trace_id}"/>
+                <attribute name="signalfx.span_id" layout="${mdc:item=signalfx.span_id}"/>
                 <!-- Manual changes: end -->
             </layout>
         </target>
 
-        <!-- For a custom layout, you must explicitly extract the 'dd.trace_id' and 'dd.span_id' values -->
+        <!-- For a custom layout, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values -->
         <!--
-            Additions to layout: {traceId=&quot;${mdc:item=dd.trace_id}&quot;,spanId=&quot;${mdc:item=dd.span_id}&quot;}
+            Additions to layout: {traceId=&quot;${mdc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdc:item=signalfx.span_id}&quot;}
         -->
         <!--
             Parsing this log line with a custom Pipeline that adds Trace/Log correlation can be done with the following Processors:
@@ -45,7 +46,7 @@
             2. Trace Id Remapper: Set the trace_id attribute to 'traceId'
         -->
         <target name="textFile" xsi:type="File" fileName="log-NLog45-textFile.log"
-                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdc:item=dd.trace_id}&quot;,spanId=&quot;${mdc:item=dd.span_id}&quot;}|${message}" />
+                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdc:item=signalfx.span_id}&quot;}|${message}" />
     </targets>
 
     <!-- rules to map from logger name to target -->

--- a/customer-samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
+++ b/customer-samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+  <!-- Modified by SignalFx -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="1.8.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 
@@ -14,6 +13,10 @@
     <None Update="NLog.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
 </Project>

--- a/customer-samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
+++ b/customer-samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- Modified by SignalFx -->
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <targets>
-        <!-- For JsonLayout when includeMdlc=true, you do not need to do any additional work to extract the 'dd.trace_id' and 'dd.span_id' values (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
+        <!-- For JsonLayout when includeMdlc=true, you do not need to do any additional work to extract the 'signalfx.trace_id' and 'signalfx.span_id' values (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
         <!--
             Additions to layout: none
         -->
@@ -15,11 +16,11 @@
             </layout>
         </target>
 
-        <!-- For JsonLayout when includeMdlc=false, you must explicitly extract the 'dd.trace_id' and 'dd.span_id' values using new <attribute> nodes (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
+        <!-- For JsonLayout when includeMdlc=false, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values using new <attribute> nodes (see: https://github.com/NLog/NLog/wiki/JsonLayout) -->
         <!--
             Additions to layout:
-            - <attribute name="dd.trace_id" layout="${mdlc:item=dd.trace_id}"/>
-            - <attribute name="dd.span_id" layout="${mdlc:item=dd.span_id}"/>
+            - <attribute name="signalfx.trace_id" layout="${mdlc:item=signalfx.trace_id}"/>
+            - <attribute name="signalfx.span_id" layout="${mdlc:item=signalfx.span_id}"/>
         -->
         <target name="jsonFile-includeMdlc-false" xsi:type="File" fileName="log-NLog46-jsonFile-includeMdlc-false.log">
             <layout xsi:type="JsonLayout" includeMdlc="false">
@@ -29,15 +30,15 @@
                 <attribute name="exception" layout="${exception:format=ToString}" />
 
                 <!-- Manual changes: start -->
-                <attribute name="dd.trace_id" layout="${mdlc:item=dd.trace_id}"/>
-                <attribute name="dd.span_id" layout="${mdlc:item=dd.span_id}"/>
+                <attribute name="signalfx.trace_id" layout="${mdlc:item=signalfx.trace_id}"/>
+                <attribute name="signalfx.span_id" layout="${mdlc:item=signalfx.span_id}"/>
                 <!-- Manual changes: end -->
             </layout>
         </target>
 
-        <!-- For a custom layout, you must explicitly extract the 'dd.trace_id' and 'dd.span_id' values -->
+        <!-- For a custom layout, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values -->
         <!--
-            Additions to layout: {traceId=&quot;${mdlc:item=dd.trace_id}&quot;,spanId=&quot;${mdlc:item=dd.span_id}&quot;}
+            Additions to layout: {traceId=&quot;${mdlc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdlc:item=signalfx.span_id}&quot;}
         -->
         <!--
             Parsing this log line with a custom Pipeline that adds Trace/Log correlation can be done with the following Processors:
@@ -45,7 +46,7 @@
             2. Trace Id Remapper: Set the trace_id attribute to 'trace_id'
         -->
         <target name="textFile" xsi:type="File" fileName="log-NLog46-textFile.log"
-                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdlc:item=dd.trace_id}&quot;,spanId=&quot;${mdlc:item=dd.span_id}&quot;}|${message}" />
+                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdlc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdlc:item=signalfx.span_id}&quot;}|${message}" />
     </targets>
 
     <!-- rules to map from logger name to target -->

--- a/customer-samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
+++ b/customer-samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+   <!-- Modified by SignalFx --> 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="1.8.0" />
     <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
 
@@ -14,6 +13,10 @@
     <None Update="NLog.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
 </Project>

--- a/customer-samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
+++ b/customer-samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System.IO;
 using Datadog.Trace;
 using Serilog;
@@ -12,7 +13,7 @@ namespace SerilogExample
         static void Main(string[] args)
         {
             // Regardless of the output layout, your LoggerConfiguration must be
-            // enriched from the LogContext to extract the `dd.trace_id` and `dd.span_id`
+            // enriched from the LogContext to extract the `signalfx.trace_id` and `signalfx.span_id`
             // properties that are automatically injected by the .NET tracer
             //
             // Additions to LoggerConfiguration:
@@ -21,9 +22,9 @@ namespace SerilogExample
                                           .Enrich.FromLogContext()
                                           .MinimumLevel.Is(Serilog.Events.LogEventLevel.Information);
 
-            // When using a message template, you must emit all properties using the {Properties} syntax in order to emit `dd.trace_id` and `dd.span_id` (see: https://github.com/serilog/serilog/wiki/Formatting-Output#formatting-plain-text)
+            // When using a message template, you must emit all properties using the {Properties} syntax in order to emit `signalfx.trace_id` and `signalfx.span_id` (see: https://github.com/serilog/serilog/wiki/Formatting-Output#formatting-plain-text)
             // This is because Serilog cannot look up these individual keys by name due to the '.' in the key name (see https://github.com/serilog/serilog/wiki/Writing-Log-Events#message-template-syntax)
-            // Additionally, Datadog will only parse log properties if they are in a JSON-like map, and the values for dd.trace_id and dd.span_id must be surrounded by quotes
+            // Additionally, Datadog will only parse log properties if they are in a JSON-like map, and the values for signalfx.trace_id and signalfx.span_id must be surrounded by quotes
             //
             // Additions to layout:
             // - {Properties}
@@ -33,7 +34,7 @@ namespace SerilogExample
                                           "log-Serilog-textFile.log",
                                           outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Properties} {Message:lj} {NewLine}{Exception}");
 
-            // The built-in JsonFormatter will display all properties by default, so no extra work is needed to emit `dd.trace_id` and `dd.span_id`
+            // The built-in JsonFormatter will display all properties by default, so no extra work is needed to emit `signalfx.trace_id` and `signalfx.span_id`
             //
             // Additions to layout: none
             //
@@ -42,7 +43,7 @@ namespace SerilogExample
                                           new JsonFormatter(),
                                           "log-Serilog-jsonFile-allProperties.log");
 
-            // The CompactJsonFormatter from the Serilog.Formatting.Compact NuGet package will display all properties by default, so no extra work is needed to emit `dd.trace_id` and `dd.span_id`
+            // The CompactJsonFormatter from the Serilog.Formatting.Compact NuGet package will display all properties by default, so no extra work is needed to emit `signalfx.trace_id` and `signalfx.span_id`
             //
             // Additions to layout: none
             //

--- a/customer-samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
+++ b/customer-samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  
+  <!-- Modified by SignalFx -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="1.8.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
 </Project>

--- a/reproductions/DataDogThreadTest/Program.cs
+++ b/reproductions/DataDogThreadTest/Program.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using Datadog.Trace.Configuration;
 using log4net;
 using System;
@@ -11,9 +12,9 @@ namespace DataDogThreadTest
 {
     class Program
     {
-        internal static readonly string TraceIdKey = "dd.trace_id";
-        internal static readonly string SpanIdKey = "dd.span_id";
-        internal static readonly string NonTraceMessage = "TraceId: 0, SpanId: 0";
+        internal static readonly string TraceIdKey = "signalfx.trace_id";
+        internal static readonly string SpanIdKey = "signalfx.span_id";
+        internal static readonly string NonTraceMessage = "TraceId: 0000000000000000, SpanId: 0000000000000000";
 
         static int Main(string[] args)
         {
@@ -55,7 +56,7 @@ namespace DataDogThreadTest
                                                 var outerTraceId = outerScope.Span.TraceId;
                                                 var outerSpanId = outerScope.Span.SpanId;
 
-                                                logger.Info($"TraceId: {outerTraceId}, SpanId: {outerSpanId}");
+                                                logger.Info($"TraceId: {outerTraceId:x16}, SpanId: {outerSpanId:x16}");
 
                                                 using (var innerScope = tracer.StartActive("nest-thread-test"))
                                                 {
@@ -72,7 +73,7 @@ namespace DataDogThreadTest
                                                         throw new Exception($"Unexpected SpanId match - outer: {outerSpanId}, inner: {innerSpanId}");
                                                     }
 
-                                                    logger.Info($"TraceId: {innerTraceId}, SpanId: {innerSpanId}");
+                                                    logger.Info($"TraceId: {innerTraceId:x16}, SpanId: {innerSpanId:x16}");
                                                 }
                                             }
                                         }
@@ -144,7 +145,7 @@ namespace DataDogThreadTest
                 var lastLog = RelevantLogs().Last();
                 var lastLogTraceId = lastLog.Properties[TraceIdKey];
                 var lastLogSpanIdId = lastLog.Properties[SpanIdKey];
-                var actual = $"TraceId: {lastLogTraceId}, SpanId: {lastLogSpanIdId}";
+                var actual = $"TraceId: {lastLogTraceId ?? 0:x16}, SpanId: {lastLogSpanIdId ?? 0:x16}";
 
                 if (!actual.Equals(NonTraceMessage))
                 {

--- a/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 
 namespace Datadog.Trace
@@ -7,8 +8,8 @@ namespace Datadog.Trace
     /// </summary>
     public static class CorrelationIdentifier
     {
-        internal static readonly string TraceIdKey = "dd.trace_id";
-        internal static readonly string SpanIdKey = "dd.span_id";
+        internal static readonly string TraceIdKey = "signalfx.trace_id";
+        internal static readonly string SpanIdKey = "signalfx.span_id";
 
         /// <summary>
         /// Gets the trace id

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -28,7 +29,7 @@ namespace Datadog.Trace.Logging
         private bool _safeToAddToMdc = true;
 
         // IMPORTANT: For all logging frameworks, do not set any default values for
-        //            "dd.trace_id" and "dd.span_id" when initializing the subscriber
+        //            "signalfx.trace_id" and "signalfx.span_id" when initializing the subscriber
         //            because the Tracer may be initialized at a time when it is not safe
         //            to add properties logging context of the underlying logging framework.
         //
@@ -141,10 +142,10 @@ namespace Datadog.Trace.Logging
                 // TODO: Debug logs
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.TraceIdKey, traceId.ToString(), destructure: false));
+                        CorrelationIdentifier.TraceIdKey, traceId.ToString("x16"), destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.SpanIdKey, spanId.ToString(), destructure: false));
+                        CorrelationIdentifier.SpanIdKey, spanId.ToString("x16"), destructure: false));
             }
             catch (Exception)
             {

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -47,7 +48,7 @@ namespace Datadog.Trace.Tests.Logging
             int logIndex = 0;
             LoggingEvent logEvent;
 
-            // The first log should not have dd.span_id or dd.trace_id
+            // The first log should not have signalfx.span_id or signalfx.trace_id
             // Scope: N/A
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Globalization;
 using System.IO;
@@ -18,8 +19,8 @@ namespace Datadog.Trace.Tests.Logging
         internal static readonly int CustomPropertyValue = 1;
         internal static readonly string LogPrefix = "[Datadog.Trace.Tests.Logging]";
 
-        private const string Log4NetExpectedStringFormat = "\"{0}\":\"{1}\"";
-        private const string SerilogExpectedStringFormat = "{0}: \"{1}\"";
+        private const string Log4NetExpectedStringFormat = "\"{0}\":\"{1:x16}\"";
+        private const string SerilogExpectedStringFormat = "{0}: \"{1:x16}\"";
 
         internal static Tracer InitializeTracer(bool enableLogsInjection)
         {
@@ -64,9 +65,9 @@ namespace Datadog.Trace.Tests.Logging
         {
             // First, verify that the properties are attached to the LogEvent
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(traceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.Equal<ulong>(traceId, Convert.ToUInt64(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString(), 16));
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(spanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
+            Assert.Equal<ulong>(spanId, Convert.ToUInt64(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString(), 16));
 
             // Second, verify that the message formatting correctly encloses the
             // values in quotes, since they are string values
@@ -85,9 +86,9 @@ namespace Datadog.Trace.Tests.Logging
         {
             // First, verify that the properties are attached to the LogEvent
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal<ulong>(traceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString().Trim(new[] { '\"' })));
+            Assert.Equal<ulong>(traceId, Convert.ToUInt64(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString().Trim(new[] { '\"' }), 16));
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal<ulong>(spanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString().Trim(new[] { '\"' })));
+            Assert.Equal<ulong>(spanId, Convert.ToUInt64(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString().Trim(new[] { '\"' }), 16));
 
             // Second, verify that the message formatting correctly encloses the
             // values in quotes, since they are string values

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System.Collections.Generic;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.LogProviders;
@@ -13,6 +14,7 @@ namespace Datadog.Trace.Tests.Logging
     [TestCaseOrderer("Datadog.Trace.TestHelpers.AlphabeticalOrderer", "Datadog.Trace.TestHelpers")]
     public class NLogLogProviderTests
     {
+        private const string ExpectedIdStringFormat = "\"{0}\": \"{1:x16}\"";
         private const string ExpectedStringFormat = "\"{0}\": \"{1}\"";
 
         private readonly ILogProvider _logProvider;
@@ -59,7 +61,7 @@ namespace Datadog.Trace.Tests.Logging
             int logIndex = 0;
             string logString;
 
-            // The first log should not have dd.span_id or dd.trace_id
+            // The first log should not have signalfx.span_id or signalfx.trace_id
             // Scope: N/A
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
@@ -70,43 +72,43 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: Parent scope
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.TraceIdKey, parentScope.Span.TraceId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, parentScope.Span.TraceId), logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
 
             // Scope: Parent scope
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.TraceIdKey, parentScope.Span.TraceId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, parentScope.Span.TraceId), logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: Child scope
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.SpanIdKey, childScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.TraceIdKey, childScope.Span.TraceId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, childScope.Span.SpanId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, childScope.Span.TraceId), logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: Parent scope
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.TraceIdKey, childScope.Span.TraceId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, childScope.Span.TraceId), logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: Parent scope
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.TraceIdKey, childScope.Span.TraceId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, childScope.Span.TraceId), logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
 
             // Scope: Default values of TraceId=0,SpanId=0
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.SpanIdKey, 0), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.TraceIdKey, 0), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, 0), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, 0), logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
         }
 

--- a/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.Logging;
@@ -44,7 +45,7 @@ namespace Datadog.Trace.Tests.Logging
             var logIndex = 0;
             LogEvent logEvent;
 
-            // The first log should not have dd.span_id or dd.trace_id
+            // The first log should not have signalfx.span_id or signalfx.trace_id
             // Scope: N/A
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];


### PR DESCRIPTION
This change updates the tags and format used to add trace information to logs. Notes:

- Code uses the https://github.com/damianh/LibLog NuGet source package to support 4 very popular logging engines for .NET: NLog, Log4Net, Serilog, and Loupe (the code-base doesn't include any tests for Loupe).

- By default, it automatically adds the “signalfx.trace_id” and “signalfx.span_id” to log statements from the libraries above. The correlation can be disabled via the boolean environment variable SIGNALFX_LOGS_INJECTION.

@signalfx/instrumentation