### PR TITLE
Fix strong name for non-Windows builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,6 @@
     <!-- Strong name signature -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Datadog.Trace.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DelaySign>false</DelaySign>
   </PropertyGroup>
 


### PR DESCRIPTION
The package was being built with "public sign" (see
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/publicsign-compiler-option)
ouside of Windows. However, this is not real strong name signing.

This change ensures that the build has the strong name on any platform where the packages are built.

@signalfx/instrumentation