### PR TITLE
Tracing library and version tags only on root spans

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+  <!-- Modified by SignalFx -->
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -1,6 +1,7 @@
 // Modified by SignalFx
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
 using Datadog.Trace;
@@ -71,6 +72,8 @@ namespace Datadog.Trace.Agent
         [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
         internal class ZipkinSpan
         {
+            private static IDictionary<string, string> emptyTags = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+
             private readonly Span _span;
             private readonly TracerSettings _settings;
             private readonly IDictionary<string, string> _tags;
@@ -79,10 +82,7 @@ namespace Datadog.Trace.Agent
             {
                 _span = span;
                 _settings = settings;
-                if (span.Tags != null)
-                {
-                    _tags = BuildTags(span);
-                }
+                _tags = span.Tags != null ? BuildTags(span) : emptyTags;
             }
 
             public string Id

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -108,12 +108,7 @@ namespace Datadog.Trace.Configuration
 
             Integrations = new IntegrationSettingsCollection(source);
 
-            GlobalTags = source?.GetDictionary(ConfigurationKeys.GlobalTags) ??
-                         // default value (empty)
-                         new ConcurrentDictionary<string, string>();
-
-            GlobalTags.Add(Tags.Language, TracerConstants.Language);
-            GlobalTags.Add(Tags.Version, TracerConstants.AssemblyVersion);
+            GlobalTags = source?.GetDictionary(ConfigurationKeys.GlobalTags);
 
             DogStatsdPort = source?.GetInt32(ConfigurationKeys.DogStatsdPort) ??
                             // default value

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -83,7 +83,6 @@ namespace Datadog.Trace.ExtensionMethods
             span.SetTag(Tags.HttpMethod, method);
             span.SetTag(Tags.HttpRequestHeadersHost, host);
             span.SetTag(Tags.HttpUrl, httpUrl);
-            span.SetTag(Tags.Language, TracerConstants.Language);
         }
 
         private static string GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -319,6 +319,7 @@ namespace Datadog.Trace
             // try to get the trace context (from local spans) or
             // sampling priority (from propagated spans),
             // otherwise start a new trace context
+            var isRootSpan = false;
             if (parent is SpanContext parentSpanContext)
             {
                 traceContext = parentSpanContext.TraceContext ??
@@ -329,6 +330,7 @@ namespace Datadog.Trace
             }
             else
             {
+                isRootSpan = true;
                 traceContext = new TraceContext(this);
             }
 
@@ -348,8 +350,15 @@ namespace Datadog.Trace
                 span.SetTag(Tags.Env, env);
             }
 
+            // Apply root span tags
+            if (isRootSpan)
+            {
+                span.SetTag(Tags.Language, TracerConstants.Language);
+                span.SetTag(Tags.Version, TracerConstants.AssemblyVersion);
+            }
+
             // Apply any global tags
-            if (Settings.GlobalTags.Count > 0)
+            if (Settings.GlobalTags?.Count > 0)
             {
                 foreach (var entry in Settings.GlobalTags)
                 {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             RegisterTagExpectation(
                 key: Tags.Language,
                 expected: TracerConstants.Language,
-                when: s => GetTag(s, Tags.SpanKind) != SpanKinds.Client);
+                when: s => s.ParentId == 0);
         }
 
         public Func<IMockSpan, bool> Always => s => true;

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -123,6 +123,13 @@ namespace Datadog.Trace.IntegrationTests
                 var trace = _httpRecorder.ZipkinTraces;
                 ZipkinHelpers.AssertSpanEqual(scope1.Span, trace[0][0]);
                 ZipkinHelpers.AssertSpanEqual(scope2.Span, trace[0][1]);
+
+                // Check root span for mandatory tags.
+                Assert.Contains(scope1.Span.Tags, kvp => kvp.Key == Tags.Language && kvp.Value == TracerConstants.Language);
+                Assert.Contains(scope1.Span.Tags, kvp => kvp.Key == Tags.Version && kvp.Value == TracerConstants.AssemblyVersion);
+
+                // Child spans should not have root spans tags.
+                Assert.Null(scope2.Span.Tags);
             }
         }
 

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,12 +33,12 @@ namespace Datadog.Trace.Tests
             // TODO:bertrand it is too complicated to setup such a simple test
             var trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(3));
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
 
             trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(3));
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
         }
 

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
-            yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 2 };
+            yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 0 };
             yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
             yield return new object[] { CreateFunc(s => s.CustomSamplingRules), null };
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests.Configuration
 
             yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1;integration2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
 
-            yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags.Count), 4 };
+            yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags.Count), 2 };
 
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "true", CreateFunc(s => s.AnalyticsEnabled), true };
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "false", CreateFunc(s => s.AnalyticsEnabled), false };
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Tests.Configuration
         // JsonConfigurationSource needs to be tested with JSON data, which cannot be used with the other IConfigurationSource implementations.
         public static IEnumerable<object[]> GetJsonTestData()
         {
-            yield return new object[] { @"{ ""SIGNALFX_TRACE_GLOBAL_TAGS"": { ""name1"":""value1"", ""name2"": ""value2""} }", CreateFunc(s => s.GlobalTags.Count), 4 };
+            yield return new object[] { @"{ ""SIGNALFX_TRACE_GLOBAL_TAGS"": { ""name1"":""value1"", ""name2"": ""value2""} }", CreateFunc(s => s.GlobalTags.Count), 2 };
         }
 
         public static IEnumerable<object[]> GetBadJsonTestData1()

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
-            yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 0 };
+            yield return new object[] { CreateFunc(s => s.GlobalTags), null };
             yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
             yield return new object[] { CreateFunc(s => s.CustomSamplingRules), null };
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
@@ -95,7 +95,7 @@ namespace Datadog.Trace.Tests.Configuration
         public static IEnumerable<object[]> GetBadJsonTestData3()
         {
             // Json doesn't represent dictionary of string to string
-            yield return new object[] { @"{ ""SIGNALFX_TRACE_GLOBAL_TAGS"": { ""name1"": { ""name2"": [ ""vers"" ] } } }", CreateFunc(s => s.GlobalTags.Count), 2 };
+            yield return new object[] { @"{ ""SIGNALFX_TRACE_GLOBAL_TAGS"": { ""name1"": { ""name2"": [ ""vers"" ] } } }", CreateFunc(s => s.GlobalTags), null };
         }
 
         public static Func<TracerSettings, object> CreateFunc(Func<TracerSettings, object> settingGetter)


### PR DESCRIPTION
Avoid redundant tags on all spans for the Tracing library name and version. Now only root spans will have that information.

@signalfx/instrumentation