### PR TITLE
Add cfg to add client IP to ASP.NET server spans

### DIFF
--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -1,5 +1,7 @@
+// Modified by SignalFx
 using System;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Web;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
@@ -124,7 +126,14 @@ namespace Datadog.Trace.AspNet
                 string resourceName = $"{httpMethod} {path.ToLowerInvariant()}";
 
                 scope = tracer.StartActive(_requestOperationName, propagatedContext);
-                scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url);
+
+                IPAddress remoteIp = null;
+                if (Tracer.Instance.Settings.AddClientIpToServerSpans)
+                {
+                    IPAddress.TryParse(httpRequest.UserHostAddress, out remoteIp);
+                }
+
+                scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, remoteIp);
 
                 // set analytics sample rate if enabled
                 var analyticsSampleRate = tracer.Settings.GetIntegrationAnalyticsSampleRate(IntegrationName, enabledWithGlobalSetting: true);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetAmbientContext.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetAmbientContext.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
@@ -88,11 +89,19 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 var span = _rootScope.Span;
 
+                IPAddress remoteIp = null;
+                if (Tracer.Instance.Settings.AddClientIpToServerSpans)
+                {
+                    var userHostAddress = request.GetProperty<string>("UserHostAddress").GetValueOrDefault();
+                    IPAddress.TryParse(userHostAddress, out remoteIp);
+                }
+
                 span.DecorateWebServerSpan(
                     resourceName: resourceName,
                     method: httpMethod,
                     host: host,
-                    httpUrl: absoluteUri);
+                    httpUrl: absoluteUri,
+                    remoteIp: remoteIp);
 
                 var statusCode = response.GetProperty<int>("StatusCode");
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Web;
 using System.Web.Routing;
 using Datadog.Trace.ClrProfiler.Emit;
@@ -134,11 +135,18 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Replace("{controller}", controllerName)
                        .Replace("{action}", actionName);
 
+                IPAddress remoteIp = null;
+                if (Tracer.Instance.Settings.AddClientIpToServerSpans)
+                {
+                    IPAddress.TryParse(httpContext.Request.UserHostAddress, out remoteIp);
+                }
+
                 span.DecorateWebServerSpan(
                     resourceName: resourceName,
                     method: httpMethod,
                     host: host,
-                    httpUrl: url);
+                    httpUrl: url,
+                    remoteIp: remoteIp);
                 span.SetTag(Tags.AspNetRoute, route?.Url);
                 span.SetTag(Tags.AspNetController, controllerName);
                 span.SetTag(Tags.AspNetAction, actionName);

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -265,10 +265,19 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key to control whether the resource name is going to be used as the span name.
         /// This applies to "AspNetMvc" and "AspNetWebApi" instrumentations.
-        /// Default is value is true.
+        /// Default is value is <c>true</c>.
         /// </summary>
         /// <seealso cref="TracerSettings.UseWebServerResourceAsOperationName"/>
         public const string UseWebServerResourceAsOperationName = "SIGNALFX_USE_WEBSERVER_RESOURCE_AS_OPERATION_NAME";
+
+        /// <summary>
+        /// Configuration key to control whether the instrumentations creating server spans, eg.:
+        /// "AspNetMvc", "AspNetWebApi", etc, are going to try to add the client IP as tag using
+        /// the keys "peer.ipv4" or "peer.ipv6" according to the type of client IP (if available).
+        /// Default is value is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="TracerSettings.AddClientIpToServerSpans"/>
+        public const string AddClientIpToServerSpans = "SIGNALFX_ADD_CLIENT_IP_TO_SERVER_SPANS";
 
         /// <summary>
         /// Configuration key to set the SignalFx access token. This is to be used when sending data

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -139,13 +139,11 @@ namespace Datadog.Trace.Configuration
                                                  .Select(s => s.Trim()).ToArray() ??
                                             new string[0];
 
-            AppendUrlPathToName = source?.GetBool(ConfigurationKeys.AppendUrlPathToName) ??
-                           // default value
-                           false;
+            AppendUrlPathToName = source?.GetBool(ConfigurationKeys.AppendUrlPathToName) ?? false;
 
-            UseWebServerResourceAsOperationName = source?.GetBool(ConfigurationKeys.UseWebServerResourceAsOperationName) ??
-                // default value
-                true;
+            UseWebServerResourceAsOperationName = source?.GetBool(ConfigurationKeys.UseWebServerResourceAsOperationName) ?? true;
+
+            AddClientIpToServerSpans = source?.GetBool(ConfigurationKeys.AddClientIpToServerSpans) ?? false;
         }
 
         /// <summary>
@@ -328,8 +326,18 @@ namespace Datadog.Trace.Configuration
         /// This applies to "AspNetMvc" and "AspNetWebApi" instrumentations.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.UseWebServerResourceAsOperationName"/>
-        /// <seealso cref="ExtensionMethods.SpanExtensions.DecorateWebServerSpan(Span, string, string, string, string)"/>
+        /// <seealso cref="ExtensionMethods.SpanExtensions.DecorateWebServerSpan(Span, string, string, string, string, System.Net.IPAddress)"/>
         public bool UseWebServerResourceAsOperationName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the instrumentations creating server spans, eg.:
+        /// "AspNetMvc", "AspNetWebApi", etc, are going to try to add the client IP as tag using
+        /// the keys "peer.ipv4" or "peer.ipv6" according to the type of client IP (if available).
+        /// Default is value is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.AddClientIpToServerSpans"/>
+        /// <seealso cref="ExtensionMethods.SpanExtensions.DecorateWebServerSpan(Span, string, string, string, string, System.Net.IPAddress)"/>
+        public bool AddClientIpToServerSpans { get; set; }
 
         /// <summary>
         /// Gets or sets a value with the SignalFx access token. This is to be used when sending data

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -1,6 +1,7 @@
 // Modified by SignalFx
 #if NETSTANDARD
 using System;
+using System.Net;
 using Datadog.Trace.Abstractions;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
@@ -161,7 +162,13 @@ namespace Datadog.Trace.DiagnosticListeners
                 Span span = _tracer.StartSpan(HttpRequestInOperationName, propagatedContext)
                                    .SetTag(Tags.InstrumentationName, ComponentName);
 
-                span.DecorateWebServerSpan(null, httpMethod, host, url);
+                IPAddress remoteIp = null;
+                if (Trace.Tracer.Instance.Settings.AddClientIpToServerSpans)
+                {
+                    remoteIp = httpContext?.Connection?.RemoteIpAddress;
+                }
+
+                span.DecorateWebServerSpan(null, httpMethod, host, url, remoteIp);
                 span.SetTag(Tags.InstrumentationName, IntegrationName);
 
                 // set analytics sample rate if enabled

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Net;
+using System.Net.Sockets;
 
 namespace Datadog.Trace.ExtensionMethods
 {
@@ -70,7 +72,8 @@ namespace Datadog.Trace.ExtensionMethods
             string resourceName,
             string method,
             string host,
-            string httpUrl)
+            string httpUrl,
+            IPAddress remoteIp = null)
         {
             span.Type = SpanTypes.Web;
             span.ResourceName = resourceName?.Trim();
@@ -83,6 +86,16 @@ namespace Datadog.Trace.ExtensionMethods
             span.SetTag(Tags.HttpMethod, method);
             span.SetTag(Tags.HttpRequestHeadersHost, host);
             span.SetTag(Tags.HttpUrl, httpUrl);
+
+            switch (remoteIp?.AddressFamily)
+            {
+                case AddressFamily.InterNetwork:
+                    span.SetTag(Tags.PeerIpV4, remoteIp.ToString());
+                    break;
+                case AddressFamily.InterNetworkV6:
+                    span.SetTag(Tags.PeerIpV6, remoteIp.ToString());
+                    break;
+            }
         }
 
         private static string GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -136,6 +136,16 @@ namespace Datadog.Trace
         public const string OutHost = "peer.hostname";
 
         /// <summary>
+        /// The IP v4 address of the remote peer.
+        /// </summary>
+        public const string PeerIpV4 = "peer.ipv4";
+
+        /// <summary>
+        /// The IP v6 address of the remote peer.
+        /// </summary>
+        public const string PeerIpV6 = "peer.ipv6";
+
+        /// <summary>
         /// The port of a outgoing server connection.
         /// </summary>
         public const string OutPort = "peer.port";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -8,15 +8,17 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    public class AspNetMvc4Tests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetMvc4Tests : TestHelper
     {
         private readonly IisFixture _iisFixture;
+        private readonly bool _addClientIp;
 
-        public AspNetMvc4Tests(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc4Tests(IisFixture iisFixture, ITestOutputHelper output, bool addClientIp)
             : base("AspNetMvc4", "samples-aspnet", output)
         {
             _iisFixture = iisFixture;
-            _iisFixture.TryStartIis(this);
+            _iisFixture.TryStartIis(this, addClientIp);
+            _addClientIp = addClientIp;
         }
 
         [Theory]
@@ -34,7 +36,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 HttpStatusCode.OK,
                 "web",
                 expectedOperationName: expectedResourceName,
-                expectedResourceName);
+                expectedResourceName,
+                _addClientIp);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4TestsAddClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4TestsAddClientIp.cs
@@ -1,0 +1,18 @@
+// Modified by SignalFx
+#if NET461
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public abstract class AspNetMvc4TestsAddClientIp : AspNetMvc4Tests, IClassFixture<IisFixture>
+    {
+        public AspNetMvc4TestsAddClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: true)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4TestsNoClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4TestsNoClientIp.cs
@@ -1,0 +1,18 @@
+// Modified by SignalFx
+#if NET461
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public abstract class AspNetMvc4TestsNoClientIp : AspNetMvc4Tests, IClassFixture<IisFixture>
+    {
+        public AspNetMvc4TestsNoClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: false)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -8,16 +8,17 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    [Collection("IisTests")]
-    public class AspNetMvc5Tests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetMvc5Tests : TestHelper
     {
         private readonly IisFixture _iisFixture;
+        private readonly bool _addClientIp;
 
-        public AspNetMvc5Tests(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc5Tests(IisFixture iisFixture, ITestOutputHelper output, bool addClientIp)
             : base("AspNetMvc5", "samples-aspnet", output)
         {
             _iisFixture = iisFixture;
-            _iisFixture.TryStartIis(this);
+            _iisFixture.TryStartIis(this, addClientIp);
+            _addClientIp = addClientIp;
         }
 
         [Theory]
@@ -39,7 +40,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 HttpStatusCode.OK,
                 "web",
                 expectedOperationName: expectedResourceName,
-                expectedResourceName);
+                expectedResourceName,
+                _addClientIp);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5TestsAddClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5TestsAddClientIp.cs
@@ -1,0 +1,19 @@
+// Modified by SignalFx
+#if NET461
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [Collection("IisTests")]
+    public class AspNetMvc5TestsAddClientIp : AspNetMvc5Tests, IClassFixture<IisFixture>
+    {
+        public AspNetMvc5TestsAddClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: true)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5TestsNoClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5TestsNoClientIp.cs
@@ -1,0 +1,19 @@
+// Modified by SignalFx
+#if NET461
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [Collection("IisTests")]
+    public class AspNetMvc5TestsNoClientIp : AspNetMvc5Tests, IClassFixture<IisFixture>
+    {
+        public AspNetMvc5TestsNoClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: false)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -8,16 +8,17 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    [Collection("IisTests")]
-    public class AspNetWebApi2Tests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetWebApi2Tests : TestHelper
     {
         private readonly IisFixture _iisFixture;
+        private readonly bool _addClientIp;
 
-        public AspNetWebApi2Tests(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetWebApi2Tests(IisFixture iisFixture, ITestOutputHelper output, bool addClientIp)
             : base("AspNetMvc5", "samples-aspnet", output)
         {
             _iisFixture = iisFixture;
-            _iisFixture.TryStartIis(this);
+            _iisFixture.TryStartIis(this, addClientIp);
+            _addClientIp = addClientIp;
         }
 
         [Theory]
@@ -40,7 +41,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 expectedHttpStatusCode,
                 "web",
                 expectedOperationName: expectedResourceName,
-                expectedResourceName);
+                expectedResourceName,
+                _addClientIp);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2TestsAddClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2TestsAddClientIp.cs
@@ -1,0 +1,19 @@
+// Modified by SignalFx
+#if NET461
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [Collection("IisTests")]
+    public class AspNetWebApi2TestsAddClientIp : AspNetWebApi2Tests, IClassFixture<IisFixture>
+    {
+        public AspNetWebApi2TestsAddClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: true)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2TestsNoClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2TestsNoClientIp.cs
@@ -1,0 +1,19 @@
+// Modified by SignalFx
+#if NET461
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [Collection("IisTests")]
+    public class AspNetWebApi2TestsNoClientIp : AspNetWebApi2Tests, IClassFixture<IisFixture>
+    {
+        public AspNetWebApi2TestsNoClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: false)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -11,17 +11,19 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    public class AspNetWebFormsTests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetWebFormsTests : TestHelper
     {
         private readonly IisFixture _iisFixture;
+        private readonly bool _addClientIp;
 
         // NOTE: Would pass this in addition to the name/output to the new constructor if we removed the Samples.WebForms copied project in favor of the demo repo source project...
         // $"../dd-trace-demo/dotnet-coffeehouse/Datadog.Coffeehouse.WebForms",
-        public AspNetWebFormsTests(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetWebFormsTests(IisFixture iisFixture, ITestOutputHelper output, bool addClientIp)
             : base("WebForms", "samples-aspnet", output)
         {
             _iisFixture = iisFixture;
-            _iisFixture.TryStartIis(this);
+            _iisFixture.TryStartIis(this, addClientIp);
+            _addClientIp = addClientIp;
         }
 
         [Theory]
@@ -39,7 +41,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 HttpStatusCode.OK,
                 SpanTypes.Web,
                 expectedOperationName: expectedResourceName,
-                expectedResourceName);
+                expectedResourceName,
+                _addClientIp);
         }
 
         [Fact]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTestsAddClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTestsAddClientIp.cs
@@ -1,0 +1,18 @@
+// Modified by SignalFx
+#if NET461 || NET452
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class AspNetWebFormsTestsAddClientIp : AspNetWebFormsTests, IClassFixture<IisFixture>
+    {
+        public AspNetWebFormsTestsAddClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: true)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTestsNoClientIp.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTestsNoClientIp.cs
@@ -1,0 +1,18 @@
+// Modified by SignalFx
+#if NET461 || NET452
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class AspNetWebFormsTestsNoClientIp : AspNetWebFormsTests, IClassFixture<IisFixture>
+    {
+        public AspNetWebFormsTestsNoClientIp(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, addClientIp: false)
+        {
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,13 +12,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
         }
 
-        [TargetFrameworkVersionsFact("netcoreapp2.1")]
+        [TargetFrameworkVersionsTheory("netcoreapp2.1")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void MeetsAllAspNetCoreMvcExpectations()
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeetsAllAspNetCoreMvcExpectations(bool addClientIp)
         {
             // No package versions are relevant because this is built-in
-            RunTraceTestOnSelfHosted(string.Empty);
+            RunTraceTestOnSelfHosted(string.Empty, addClientIp);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,13 +13,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             // EnableDebugMode();
         }
 
-        [TargetFrameworkVersionsFact("netcoreapp3.0")]
+        [TargetFrameworkVersionsTheory("netcoreapp3.0")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void MeetsAllAspNetCoreMvcExpectations()
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeetsAllAspNetCoreMvcExpectations(bool addClientIp)
         {
             // No package versions are relevant because this is built-in
-            RunTraceTestOnSelfHosted(string.Empty);
+            RunTraceTestOnSelfHosted(string.Empty, addClientIp);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -1,3 +1,4 @@
+// Modified by SignalFx
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,13 +13,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             // EnableDebugMode();
         }
 
-        [TargetFrameworkVersionsFact("netcoreapp3.1")]
+        [TargetFrameworkVersionsTheory("netcoreapp3.1")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void MeetsAllAspNetCoreMvcExpectations()
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeetsAllAspNetCoreMvcExpectations(bool addClientIp)
         {
             // No package versions are relevant because this is built-in
-            RunTraceTestOnSelfHosted(string.Empty);
+            RunTraceTestOnSelfHosted(string.Empty, addClientIp);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
@@ -5,9 +5,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class AspNetCoreMvcSpanExpectation : WebServerSpanExpectation
     {
-        public AspNetCoreMvcSpanExpectation(string serviceName, string operationName, string resourceName, string statusCode, string httpMethod)
-            : base(serviceName, operationName, resourceName, SpanTypes.Web, statusCode, httpMethod)
+        public AspNetCoreMvcSpanExpectation(string serviceName, string operationName, string resourceName, string statusCode, string httpMethod, bool addClientIpExpectation = false)
+            : base(serviceName, operationName, resourceName, SpanTypes.Web, statusCode, httpMethod, addClientIpExpectation)
         {
+            RegisterTagExpectation(Tags.SpanKind, expected: SpanKinds.Server);
         }
 
         public override bool Matches(IMockSpan span)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class GraphQLSpanExpectation : WebServerSpanExpectation
     {
         public GraphQLSpanExpectation(string serviceName, string operationName, string resourceName)
-            : base(serviceName, operationName, resourceName, null)
+            : base(serviceName, operationName, resourceName, type: null, addClientIpExpectation: false)
         {
             RegisterDelegateExpectation(ExpectErrorMatch);
             RegisterTagExpectation(nameof(Tags.GraphQLSource), expected: GraphQLSource);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public int HttpPort { get; private set; }
 
-        public void TryStartIis(TestHelper helper)
+        public void TryStartIis(TestHelper helper, bool addClientIp = false)
         {
             lock (this)
             {
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     HttpPort = TcpPortProvider.GetOpenPort();
 
-                    _iisExpress = helper.StartIISExpress(Agent.Port, HttpPort);
+                    _iisExpress = helper.StartIISExpress(Agent.Port, HttpPort, addClientIp);
                 }
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
@@ -112,6 +112,21 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             });
         }
 
+        public void TagShouldNotExist(string tagKey, Func<IMockSpan, bool> when = null)
+        {
+            when ??= Always;
+
+            Assertions.Add(span =>
+            {
+                if (when(span) && span.Tags.ContainsKey(tagKey))
+                {
+                    return $"Tag {tagKey} was found on span, but it was not expected (Value: {span.Tags[tagKey]})";
+                }
+
+                return null;
+            });
+        }
+
         public void RegisterDelegateExpectation(Func<IMockSpan, IEnumerable<string>> expectation)
         {
             if (expectation == null)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
@@ -1,8 +1,16 @@
+// Modified by SignalFx
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class WebServerSpanExpectation : SpanExpectation
     {
-        public WebServerSpanExpectation(string serviceName, string operationName, string resourceName, string type = SpanTypes.Web, string statusCode = null, string httpMethod = null)
+        public WebServerSpanExpectation(
+            string serviceName,
+            string operationName,
+            string resourceName,
+            string type = SpanTypes.Web,
+            string statusCode = null,
+            string httpMethod = null,
+            bool addClientIpExpectation = true)
         : base(serviceName, operationName, resourceName, type)
         {
             StatusCode = statusCode;
@@ -11,6 +19,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Expectations for all spans of a web server variety should go here
             RegisterTagExpectation(Tags.HttpStatusCode, expected: StatusCode);
             RegisterTagExpectation(Tags.HttpMethod, expected: HttpMethod);
+
+            if (addClientIpExpectation)
+            {
+                TagShouldExist(Tags.PeerIpV4, when: s => !s.Tags.ContainsKey(Tags.PeerIpV6));
+                TagShouldExist(Tags.PeerIpV6, when: s => !s.Tags.ContainsKey(Tags.PeerIpV4));
+            }
+            else
+            {
+                TagShouldNotExist(Tags.PeerIpV4);
+                TagShouldNotExist(Tags.PeerIpV4);
+            }
         }
 
         public string OriginalUri { get; set; }


### PR DESCRIPTION
Adds a configuration setting to attempt to add "peer.ipv4" or "peer.ipv6" if the information is available for ASP.NET Core / Framework MVC and Web API 2.

By default it is disabled the env var "SIGNALFX_ADD_CLIENT_IP_TO_SERVER_SPANS" can be used to enable it.

This information is easily available on ASP.NET Core and since this is more in line with trends for .NET the case is "optimized" for it: legacy needs to create an IPAddress instance that is already available on ASP.NET Core. This simplifies the code while making it forward-looking.

@signalfx/instrumentation