### PR TITLE
update docs for trace injection in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ The SignalFx-Tracing Library for .NET implements the
 [Profiling API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/)
 and should only require basic configuration of your application environment.
 
+You can link individual log entries with trace IDs and span IDs associated with
+corresponding events. If your application uses a supported logger, enable trace
+injection to automatically include trace context in your application's logs.
+For more information, see [Inject traces in logs](/customer-samples/AutomaticTraceIdInjection/README.md).
+
 ## Supported libraries and frameworks
 
 .NET Core is supported while .NET Framework is in beta. There are
@@ -66,11 +71,16 @@ manager:
 5. Set the endpoint of a Smart Agent or OpenTelemetry Collector:
     ```bash
     $ export SIGNALFX_ENDPOINT_URL='http://<YourSmartAgentOrCollector>:9080/v1/trace'
-6. Optionally, create the default logging directory:
+    ```
+6. Optionally, enable trace injection in logs:
+    ```bash
+    $ export SIGNALFX_LOGS_INJECTION=true
+    ```
+7. Optionally, create the default logging directory:
     ```bash
     $ source /opt/signalfx-dotnet-tracing/createLogPath.sh
     ```
-7. Run your application:
+8. Run your application:
     ```bash
     $ dotnet run
     ```
@@ -148,7 +158,11 @@ the trace data:
    ```batch
    set SIGNALFX_ENDPOINT_URL='http://<YourSmartAgentOrCollector>:9080/v1/trace'
    ```
-5. Restart your application ensuring that all environment variables above are properly
+5. Optionally, enable trace injection in logs:
+   ```bash
+   $ export SIGNALFX_LOGS_INJECTION=true
+   ```
+6. Restart your application ensuring that all environment variables above are properly
 configured. If you need to check the environment variables for a process use a tool
 like [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer).
 

--- a/customer-samples/AutomaticTraceIdInjection/README.md
+++ b/customer-samples/AutomaticTraceIdInjection/README.md
@@ -1,21 +1,47 @@
-# Automatic Trace ID injection
-Follow the official documentation steps to set up [C# log collection](https://docs.datadoghq.com/logs/log_collection/csharp/) and [automatic trace ID injection](https://docs.datadoghq.com/tracing/connect_logs_and_traces/?tab=net), then run these samples to see the feature in action!
+# Inject traces in logs
 
-If there is a logging layout that you would like to see documented here, please feel free to reach out with an issue or contribution!
+To inject traces in logs, enable log correlation by setting the environment variable
+``SIGNALFX_LOGS_INJECTION=true`` before running your instrumented application.
+
+For more information about instrumenting a .NET application, see
+[Configure the SignalFx Tracing Library for .NET](/README.md#Configure-the-SignalFx-Tracing-Library-for-.NET).
+
+If your logger uses JSON, the tracing library automatically handles trace ID
+injection.
+
+If your logger uses a raw format, manually configure your logger to include
+the trace ID and span ID. For examples that show you how to do this for each
+supported logger, see these configurations:
+- [Log4Net](/customer-samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config)
+- [NLog45](/customer-samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config)
+- [NLog46](/customer-samples/AutomaticTraceIdInjection/NLog46Example/NLog.config)
+- [Serilog](/customer-samples/AutomaticTraceIdInjection/SerilogExample/Program.cs)
 
 ## Supported Logging Frameworks
+
+These are the supported logging frameworks.
+
 ### Log4Net
+
+Version 2.0.8
+
 Layouts configured in the sample:
 - JSON format: `SerializedLayout` (from the `log4net.Ext.Json` NuGet package)
-- Raw format: `PatternLayout` (requires a custom Datadog Log Pipeline for processing)
+- Raw format: `PatternLayout` (requires manual configuration)
 
 ### NLog
+
+Versions 4.5.11 and 4.6.7
+
 Layouts configured in the sample:
 - JSON format: `JsonLayout`
-- Raw format: Custom layout (requires a custom Datadog Log Pipeline for processing)
+- Raw format: Custom layout (requires manual configuration)
 
 ### Serilog
+
+Versions 2.5.0 and 2.9.0
+
 Layouts configured in the sample:
 - JSON format: `JsonFormatter`
 - JSON format: `CompactJsonFormatter` (from the `Serilog.Formatting.Compact` NuGet package)
-- Raw format: output template (requires a custom Datadog Log Pipeline for processing)
+- Raw format: output template (requires manual configuration)


### PR DESCRIPTION
two changes:
- updates the root README.md to include information and steps to enable trace injection in logs
- updates /customer-samples/AutomaticTraceIdInjection/README.md to provide more context and sfx-specific info.




@signalfx/instrumentation