### PR TITLE
Add max "recorded" length

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -259,7 +259,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 scope = tracer.StartActive(ValidateOperationName, serviceName: tracer.DefaultServiceName);
                 var span = scope.Span;
                 DecorateSpan(span);
-                span.SetTag(Tags.GraphQLSource, source.Truncate());
+                span.SetTag(Tags.GraphQLSource, source);
 
                 // set analytics sample rate if enabled
                 var analyticsSampleRate = tracer.Settings.GetIntegrationAnalyticsSampleRate(IntegrationName, enabledWithGlobalSetting: false);
@@ -302,7 +302,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 var span = scope.Span;
                 DecorateSpan(span);
 
-                span.SetTag(Tags.GraphQLSource, source.Truncate());
+                span.SetTag(Tags.GraphQLSource, source);
                 span.SetTag(Tags.GraphQLOperationName, operationName);
                 span.SetTag(Tags.GraphQLOperationType, operationType);
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         scope.Span.SetTag(Tags.HttpStatusCode, ((int)response.StatusCode).ToString());
                         if (!response.IsSuccessStatusCode && !string.IsNullOrWhiteSpace(response.ReasonPhrase))
                         {
-                            scope.Span.SetTag(Tags.HttpStatusText, response.ReasonPhrase.Truncate());
+                            scope.Span.SetTag(Tags.HttpStatusText, response.ReasonPhrase);
                         }
                     }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 if (Tracer.Instance.Settings.TagRedisCommands)
                 {
-                    span.SetTag(Tags.DbStatement, rawCommand.Truncate());
+                    span.SetTag(Tags.DbStatement, rawCommand);
                 }
 
                 span.SetTag(Tags.OutHost, host);

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -113,12 +113,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 Span parent = tracer.ActiveScope?.Span;
 
-                string statement = command.CommandText.Truncate();
-                if (tracer.Settings.SanitizeSqlStatements)
-                {
-                    statement = statement.SanitizeSqlStatement();
-                }
-
+                string statement = command.CommandText;
                 if (parent != null &&
                     parent.GetTag(Tags.DbType) == dbType &&
                     parent.GetTag(Tags.DbStatement) == statement)

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -182,6 +182,29 @@ namespace Datadog.Trace.Agent
                     return annotations;
                 }
             }
+
+            // Methods below are used by Newtonsoft JSON serializer to decide if should serialize
+            // some properties when they are null.
+
+            public bool ShouldSerializeTags()
+            {	
+                return _tags != null;	
+            }	
+
+            public bool ShouldSerializeAnnotations()	
+            {	
+                return _span.Logs != null;	
+            }	
+
+            public bool ShouldSerializeParentId()
+            {
+                return _span.Context.ParentId != null;
+            }
+
+            public bool ShouldSerializeKind()
+            {
+                return _span.Tags != null && _span.Tags.ContainsKey(Trace.Tags.SpanKind);
+            }
         }
     }
 }

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -187,14 +187,14 @@ namespace Datadog.Trace.Agent
             // some properties when they are null.
 
             public bool ShouldSerializeTags()
-            {	
-                return _tags != null;	
-            }	
+            {
+                return _tags != null;
+            }
 
-            public bool ShouldSerializeAnnotations()	
-            {	
-                return _span.Logs != null;	
-            }	
+            public bool ShouldSerializeAnnotations()
+            {
+                return _span.Logs != null;
+            }
 
             public bool ShouldSerializeParentId()
             {

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Datadog.Trace;
 using Datadog.Trace.Configuration;
@@ -19,14 +20,27 @@ namespace Datadog.Trace.Agent
         // Don't serialize with BOM
         private readonly Encoding utf8 = new UTF8Encoding(false);
 
-        public static IDictionary<string, string> BuildTags(Span span)
+        public static IDictionary<string, string> BuildTags(Span span, TracerSettings settings)
         {
             var tags = new Dictionary<string, string>();
+            var recordedValueMaxLength = settings.RecordedValueMaxLength;
             foreach (var entry in span.Tags)
             {
                 if (!entry.Key.Equals(Trace.Tags.SpanKind))
                 {
-                    tags[entry.Key] = entry.Value;
+                    var truncatedValue = entry.Value.Truncate(recordedValueMaxLength);
+                    tags[entry.Key] = truncatedValue;
+                }
+            }
+
+            // Perform any DB statement sanitization only after truncating the string to avoid replacing truncated
+            // part of the statement.
+            if (settings.SanitizeSqlStatements && tags.TryGetValue(Trace.Tags.DbStatement, out var dbStatement))
+            {
+                var sanitizedDbStatement = dbStatement.SanitizeSqlStatement();
+                if (!ReferenceEquals(dbStatement, sanitizedDbStatement))
+                {
+                    tags[Trace.Tags.DbStatement] = sanitizedDbStatement;
                 }
             }
 
@@ -73,6 +87,7 @@ namespace Datadog.Trace.Agent
         internal class ZipkinSpan
         {
             private static IDictionary<string, string> emptyTags = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+            private static ReadOnlyCollection<ReadOnlyDictionary<string, object>> emptyAnnotations = (new List<ReadOnlyDictionary<string, object>>()).AsReadOnly();
 
             private readonly Span _span;
             private readonly TracerSettings _settings;
@@ -82,7 +97,7 @@ namespace Datadog.Trace.Agent
             {
                 _span = span;
                 _settings = settings;
-                _tags = span.Tags != null ? BuildTags(span) : emptyTags;
+                _tags = span.Tags != null ? BuildTags(span, settings) : emptyTags;
             }
 
             public string Id
@@ -117,7 +132,7 @@ namespace Datadog.Trace.Agent
 
             public string Kind
             {
-                get => _span.Tags[Trace.Tags.SpanKind].ToUpper();
+                get => _span.GetTag(Trace.Tags.SpanKind)?.ToUpper();
             }
 
             public Dictionary<string, string> LocalEndpoint
@@ -137,14 +152,27 @@ namespace Datadog.Trace.Agent
                 get => _tags;
             }
 
-            public List<Dictionary<string, object>> Annotations
+            public IEnumerable<IDictionary<string, object>> Annotations
             {
                 get
                 {
-                    List<Dictionary<string, object>> annotations = new List<Dictionary<string, object>>();
+                    if (_span.Logs.Count == 0)
+                    {
+                        return emptyAnnotations;
+                    }
 
+                    var annotations = new List<IDictionary<string, object>>(_span.Logs.Count);
                     foreach (var e in _span.Logs)
                     {
+                        foreach (var kvp in e.Value.ToList())
+                        {
+                            var truncated = kvp.Value.Truncate(_settings.RecordedValueMaxLength);
+                            if (!ReferenceEquals(kvp.Value, truncated))
+                            {
+                                e.Value[kvp.Key] = truncated;
+                            }
+                        }
+
                         var ts = e.Key.ToUnixTimeMicroseconds();
                         var fields = JsonConvert.SerializeObject(e.Value);
                         var item = new Dictionary<string, object>() { { "timestamp", ts }, { "value", fields } };
@@ -153,26 +181,6 @@ namespace Datadog.Trace.Agent
 
                     return annotations;
                 }
-            }
-
-            public bool ShouldSerializeTags()
-            {
-                return _tags != null;
-            }
-
-            public bool ShouldSerializeAnnotations()
-            {
-                return _span.Logs != null;
-            }
-
-            public bool ShouldSerializeParentId()
-            {
-                return _span.Context.ParentId != null;
-            }
-
-            public bool ShouldSerializeKind()
-            {
-                return _span.Tags != null && _span.Tags.ContainsKey(Trace.Tags.SpanKind);
             }
         }
     }

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -287,6 +287,14 @@ namespace Datadog.Trace.Configuration
         public const string SignalFxAccessToken = "SIGNALFX_ACCESS_TOKEN";
 
         /// <summary>
+        /// Configuration key to set maximum length a tag/log value can have.
+        /// Values are completely truncated when set to 0, and ignored when set to negative
+        /// or non-integer string. The default value is 1200.
+        /// </summary>
+        /// <seealso cref="TracerSettings.RecordedValueMaxLength"/>
+        public const string RecordedValueMaxLength = "SIGNALFX_RECORDED_VALUE_MAX_LENGTH";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -22,6 +22,8 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public const string DefaultApiType = "zipkin";
 
+        private const int DefaultRecordedValueMaxLength = 1200;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values.
         /// </summary>
@@ -144,6 +146,12 @@ namespace Datadog.Trace.Configuration
             UseWebServerResourceAsOperationName = source?.GetBool(ConfigurationKeys.UseWebServerResourceAsOperationName) ?? true;
 
             AddClientIpToServerSpans = source?.GetBool(ConfigurationKeys.AddClientIpToServerSpans) ?? false;
+
+            RecordedValueMaxLength = source?.GetInt32(ConfigurationKeys.RecordedValueMaxLength) ?? DefaultRecordedValueMaxLength;
+            if (RecordedValueMaxLength < 0)
+            {
+                RecordedValueMaxLength = DefaultRecordedValueMaxLength;
+            }
         }
 
         /// <summary>
@@ -345,6 +353,14 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.SignalFxAccessToken"/>
         public string SignalFxAccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value with the maximum length a tag/log value can have.
+        /// Values are completely truncated when set to 0, and ignored when set to negative
+        /// or non-integer string. The default value is 1200.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.RecordedValueMaxLength"/>
+        public int RecordedValueMaxLength { get; set; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -33,18 +33,11 @@ namespace Datadog.Trace.ExtensionMethods
         /// <param name="span">The span to add the tags to.</param>
         /// <param name="command">The db command to get tags values from.</param>
         /// <param name="statement">The db statement to use over command.CommandText. Will not be truncated or sanitized.</param>
-        /// <param name="sanitize">Whether to sanitize tagged statements.</param>
-        public static void AddTagsFromDbCommand(this Span span, IDbCommand command, string statement = "", bool sanitize = true)
+        public static void AddTagsFromDbCommand(this Span span, IDbCommand command, string statement = "")
         {
             if (string.IsNullOrEmpty(statement))
             {
                 statement = command.CommandText ?? string.Empty;
-                statement = statement.Truncate();
-
-                if (sanitize)
-                {
-                    statement = statement.SanitizeSqlStatement();
-                }
             }
 
             if (!string.IsNullOrEmpty(statement))

--- a/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -63,15 +63,17 @@ namespace Datadog.Trace.ExtensionMethods
         }
 
         /// <summary>
-        /// Truncates a <see cref="string"/> to 1024 characters, if necessary.
+        /// Truncates a <see cref="string"/> to the given maximum length.
         /// </summary>
-        /// <param name="value">The string to convert.</param>
-        /// <returns>The truncated string</returns>
-        public static string Truncate(this string value)
+        /// <param name="value">The string to truncate.</param>
+        /// <param name="maxLength">The maximum length of the truncated string.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Throw if <paramref name="maxLength"/> is negative.</exception>
+        /// <returns>The truncated string or the original string if its length is less than or equal to <paramref name="maxLength"/>.</returns>
+        public static string Truncate(this string value, int maxLength)
         {
             if (value == null) { throw new ArgumentNullException(nameof(value)); }
 
-            return value.Length > 1024 ? value.Substring(0, 1024) : value;
+            return value.Length > maxLength ? value.Substring(0, maxLength) : value;
         }
 
         /// <summary>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -79,7 +79,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 for (int i = 0; i < expected.Count; i++)
                 {
                     var e1 = expected[i].Item1;
-                    var e2 = expected[i].Item2;
+
+                    // By default all "db.statement" are sanitized - no worries about truncation because
+                    // all tag values here are smaller than the maximum recorded length default.
+                    var e2 = expected[i].Item2.SanitizeSqlStatement();
 
                     var a1 = i < spans.Count
                                  ? spans[i].Name

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -308,17 +308,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var e in expected)
                 {
-                    var found = spanLookup.ContainsKey(e);
+                    // By default all "db.statement" are sanitized - no worries about truncation because
+                    // all tag values here are smaller than the maximum recorded length default.
+                    var expectedKey = new Tuple<string, string>(e.Item1, e.Item2?.SanitizeSqlStatement());
+                    var found = spanLookup.ContainsKey(expectedKey);
                     if (found)
                     {
-                        if (--spanLookup[e] <= 0)
+                        if (--spanLookup[expectedKey] <= 0)
                         {
                             spanLookup.Remove(e);
                         }
                     }
                     else
                     {
-                        missing.Add(e);
+                        missing.Add(expectedKey);
                     }
                 }
 

--- a/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -26,10 +26,8 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             command.Setup(cmd => cmd.CommandText).Returns(statement);
             span.AddTagsFromDbCommand(command.Object);
 
-            // Known length of truncated, then sanitized statement
-            Assert.Equal(924, span.Tags["db.statement"].Length);
-            Assert.Contains("Field=?", span.Tags["db.statement"]);
-            Assert.DoesNotContain("Field='123'", span.Tags["db.statement"]);
+            Assert.Same(statement, span.Tags["db.statement"]);
+            Assert.Contains("Field='123'", span.Tags["db.statement"]);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
@@ -75,10 +75,15 @@ namespace Datadog.Trace.Tests.ExtensionMethods
         public void TruncateExtension()
         {
             var a = string.Concat(Enumerable.Repeat("0", 10000));
-            Assert.Equal(1024, a.Truncate().Length);
+            Assert.Equal(1024, a.Truncate(1024).Length);
 
-            var b = "fewer than 1024 chars";
-            Assert.Same(b, b.Truncate());
+            var b = "Preserved string";
+            Assert.Same(b, b.Truncate(b.Length));
+
+            var c = "Replaced by empty";
+            Assert.Same(string.Empty, c.Truncate(0));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => c.Truncate(-123));
         }
     }
 }

--- a/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
+++ b/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
@@ -1,0 +1,78 @@
+// Modified by SignalFx
+using System.Linq;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class ZipkinSerializerTests
+    {
+        [Theory]
+        [InlineData("log not to be truncated", "log not to be truncated")]
+        [InlineData("log to be truncated", "log to be")]
+        [InlineData("log set to empty", "")]
+        public void TagTruncation(string original, string expected)
+        {
+            var traceContext = new TraceContext(Tracer.Instance);
+            var spanContext = new SpanContext(null, traceContext, $"{nameof(TagTruncation)}");
+            var span = new Span(spanContext, start: null);
+            span.SetTag("test", original);
+
+            var settings = new TracerSettings
+            {
+                RecordedValueMaxLength = expected.Length,
+            };
+            var zipkinSpan = new ZipkinSerializer.ZipkinSpan(span, settings);
+            var tags = zipkinSpan.Tags;
+            Assert.Single(tags);
+            Assert.Equal(expected, tags.First().Value);
+        }
+
+        [Theory]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE WHERE FIELD=?", true)]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE", true)]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD=1234", "", true)]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE WHERE FIELD=1234", false)]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD=1234", "SELECT * FROM TABLE", false)]
+        [InlineData("SELECT * FROM TABLE WHERE FIELD=1234", "", false)]
+        public void DbStatementSanitationAndTruncation(string original, string expected, bool sanitizeSqlStatements)
+        {
+            var traceContext = new TraceContext(Tracer.Instance);
+            var spanContext = new SpanContext(null, traceContext, $"{nameof(TagTruncation)}");
+            var span = new Span(spanContext, start: null);
+            span.SetTag("db.statement", original);
+
+            var settings = new TracerSettings
+            {
+                SanitizeSqlStatements = sanitizeSqlStatements,
+                RecordedValueMaxLength = expected.Length,
+            };
+            var zipkinSpan = new ZipkinSerializer.ZipkinSpan(span, settings);
+            var tags = zipkinSpan.Tags;
+            Assert.Single(tags);
+            Assert.Equal(expected, tags.First().Value);
+        }
+
+        [Theory]
+        [InlineData("log not to be truncated", "log not to be truncated")]
+        [InlineData("log to be truncated", "log to be")]
+        [InlineData("log set to empty", "")]
+        public void AnnotationTruncation(string original, string expected)
+        {
+            var traceContext = new TraceContext(Tracer.Instance);
+            var spanContext = new SpanContext(null, traceContext, $"{nameof(AnnotationTruncation)}");
+            var span = new Span(spanContext, start: null);
+            span.Log(original);
+
+            var settings = new TracerSettings
+            {
+                RecordedValueMaxLength = expected.Length,
+            };
+            var zipkinSpan = new ZipkinSerializer.ZipkinSpan(span, settings);
+            var annotations = zipkinSpan.Annotations;
+            Assert.Single(annotations);
+            Assert.Equal($"{{\"event\":\"{expected}\"}}", annotations.First()["value"]);
+        }
+    }
+}


### PR DESCRIPTION
Add max recorded length for tags and logs following the same pattern that was done for golang.

Moved the truncation to serialization assuming that most of the time nothing will be truncated and reducing the risk of allocating during actual operation being traced.

Separated truncation from SQL sanitation for "db.statement" tag.