### PR TITLE
add SIGNALFX_RECORDED_VALUE_MAX_LENGTH to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_ADD_CLIENT_IP_TO_SERVER_SPANS` | `false` | Enable to add the client IP as a span tag when creating a server span. |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | `true` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. |
 | `SIGNALFX_DISABLED_INTEGRATIONS` |  | The integrations you want to disable, if any, separated by a semi-colon. These are the supported integrations: AspNetMvc, AspNetWebApi2, DbCommand, ElasticsearchNet5, ElasticsearchNet6, GraphQL, HttpMessageHandler, IDbCommand, MongoDb, NpgsqlCommand, OpenTracing, ServiceStackRedis, SqlCommand, StackExchangeRedis, Wcf, WebRequest |
+| `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | The maximum length an attribute value can have. Values longer than this are truncated. |
 
 ### Linux
 


### PR DESCRIPTION
Changes proposed in this pull request:

- add SIGNALFX_RECORDED_VALUE_MAX_LENGTH setting to config table in readme

@signalfx/instrumentation