### PR TITLE
Fixes InvalidProgramException when reading push values outside the boundaries of the array

### DIFF
--- a/docker/native.dockerfile
+++ b/docker/native.dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && \
         git \
         wget
 
-RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+RUN echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 RUN sudo apt-get update
 
 RUN sudo apt-get install -y \

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -101,6 +101,8 @@ static int k_rgnStackPushes[] = {
 #undef PushRef
 #undef VarPush
 #undef OPDEF
+    0,  // CEE_COUNT
+    0   // CEE_SWITCH_ARG
 };
 
 ILRewriter::ILRewriter(


### PR DESCRIPTION
Cherry-picking fix for InvalidProgramException details:

This PR fixes a possible InvalidProgramException when the IL method body contains switch statements due to invalid maxstack header value by reading outside the boundaries of the push values array. To mitigate this we add the missing values to the array.

Fixes: #79 

@signalfx/instrumentation