### PR TITLE
Improve readme for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ you're instrumenting.
     - For .NET Framework applications:
     ```batch
     set COR_ENABLE_PROFILING=1
-    set COR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874} 
+    set COR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
     ```
    - For .NET Core applications:
    ```batch

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ you're instrumenting.
 4. Set the endpoint of a Smart Agent or OpenTelemetry Collector that will forward
 the trace data:
    ```batch
-   set SIGNALFX_ENDPOINT_URL='http://<YourSmartAgentOrCollector>:9080/v1/trace'
+   set SIGNALFX_ENDPOINT_URL=http://localhost:9080/v1/trace
    ```
 5. Optionally, enable trace injection in logs:
    ```batch


### PR DESCRIPTION
Two small things are causing trouble to users following the README on Windows:

1. one extra space at the end of the env var with the profiler GUID
2. quotes around the endpoint URL

