### PR TITLE
Add VS Code Development Container settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,45 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0
+
+# [Option] Install zsh
+ARG INSTALL_ZSH="true"
+# [Option] Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="false"
+# [Option] Enable non-root Docker access in container
+ARG ENABLE_NONROOT_DOCKER="true"
+# [Option] Use the OSS Moby Engine instead of the licensed Docker Engine
+ARG USE_MOBY="true"
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your
+# own dependencies. A user of "automatic" attempts to reuse an user ID if one already exists.
+ARG USERNAME=automatic
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+COPY library-scripts/*.sh /tmp/library-scripts/
+RUN apt-get update \
+    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    # Use Docker script from script library to set things up
+    && /bin/bash /tmp/library-scripts/docker-in-docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "${USERNAME}" "${USE_MOBY}" \
+    # Clean up
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/
+    
+VOLUME [ "/var/lib/docker" ]
+
+# Setting the ENTRYPOINT to docker-init.sh will start up the Docker Engine 
+# inside the container "overrideCommand": false is set in devcontainer.json. 
+# The script will also execute CMD if you need to alter startup behaviors.
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]
+
+# Instructions to install .NET Core runtimes from
+# https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-debian10
+RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get update && apt-get install -y \
+        apt-transport-https \
+        aspnetcore-runtime-2.1 \
+        aspnetcore-runtime-3.0 \
+        aspnetcore-runtime-3.1
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "dotnet restore Datadog.Trace.sln",
+	"postCreateCommand": "dotnet build Datadog.Trace.sln || true",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "docker --version",
+	"postCreateCommand": "dotnet restore Datadog.Trace.sln",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.158.0/containers/docker-in-docker
+{
+	"name": "Docker in Docker",
+	"dockerFile": "Dockerfile",
+	"runArgs": ["--init", "--privileged"],
+	"overrideCommand": false,
+	
+	// Use this environment variable if you need to bind mount your local source code into a new container.
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/zsh"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"ms-dotnettools.csharp"
+	],
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "docker --version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/library-scripts/common-debian.sh
+++ b/.devcontainer/library-scripts/common-debian.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+#
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My *! flag]
+
+INSTALL_ZSH=${1:-"true"}
+USERNAME=${2:-"automatic"}
+USER_UID=${3:-"automatic"}
+USER_GID=${4:-"automatic"}
+UPGRADE_PACKAGES=${5:-"true"}
+INSTALL_OH_MYS=${6:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+# If in automatic mode, determine if a user already exists, if not use vscode
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=vscode
+    fi
+elif [ "${USERNAME}" = "none" ]; then
+    USERNAME=root
+    USER_UID=0
+    USER_GID=0
+fi
+
+# Load markers to see which steps have already run
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
+if [ -f "${MARKER_FILE}" ]; then
+    echo "Marker file found:"
+    cat "${MARKER_FILE}"
+    source "${MARKER_FILE}"
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Function to call apt-get if needed
+apt-get-update-if-needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Run install apt-utils to avoid debconf warning then verify presence of other common developer tools and dependencies
+if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
+    apt-get-update-if-needed
+
+    PACKAGE_LIST="apt-utils \
+        git \
+        openssh-client \
+        gnupg2 \
+        iproute2 \
+        procps \
+        lsof \
+        htop \
+        net-tools \
+        psmisc \
+        curl \
+        wget \
+        rsync \
+        ca-certificates \
+        unzip \
+        zip \
+        nano \
+        vim-tiny \
+        less \
+        jq \
+        lsb-release \
+        apt-transport-https \
+        dialog \
+        libc6 \
+        libgcc1 \
+        libkrb5-3 \
+        libgssapi-krb5-2 \
+        libicu[0-9][0-9] \
+        liblttng-ust0 \
+        libstdc++6 \
+        zlib1g \
+        locales \
+        sudo \
+        ncdu \
+        man-db \
+        strace"
+
+    # Install libssl1.1 if available
+    if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
+        PACKAGE_LIST="${PACKAGE_LIST}       libssl1.1"
+    fi
+    
+    # Install appropriate version of libssl1.0.x if available
+    LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 || echo '')
+    if [ "$(echo "$LIBSSL" | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort | wc -l)" -eq 0 ]; then
+        if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
+            # Debian 9
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.2"
+        elif [[ ! -z $(apt-cache --names-only search ^libssl1.0.0$) ]]; then
+            # Ubuntu 18.04, 16.04, earlier
+            PACKAGE_LIST="${PACKAGE_LIST}       libssl1.0.0"
+        fi
+    fi
+
+    echo "Packages to verify are installed: ${PACKAGE_LIST}"
+    apt-get -y install --no-install-recommends ${PACKAGE_LIST} 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
+        
+    PACKAGES_ALREADY_INSTALLED="true"
+fi
+
+# Get to latest versions of all packages
+if [ "${UPGRADE_PACKAGES}" = "true" ]; then
+    apt-get-update-if-needed
+    apt-get -y upgrade --no-install-recommends
+    apt-get autoremove -y
+fi
+
+# Ensure at least the en_US.UTF-8 UTF-8 locale is available.
+# Common need for both applications and things like the agnoster ZSH theme.
+if [ "${LOCALE_ALREADY_SET}" != "true" ] && ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
+    locale-gen
+    LOCALE_ALREADY_SET="true"
+fi
+
+# Create or update a non-root user to match UID/GID.
+if id -u ${USERNAME} > /dev/null 2>&1; then
+    # User exists, update if needed
+    if [ "${USER_GID}" != "automatic" ] && [ "$USER_GID" != "$(id -G $USERNAME)" ]; then 
+        groupmod --gid $USER_GID $USERNAME 
+        usermod --gid $USER_GID $USERNAME
+    fi
+    if [ "${USER_UID}" != "automatic" ] && [ "$USER_UID" != "$(id -u $USERNAME)" ]; then 
+        usermod --uid $USER_UID $USERNAME
+    fi
+else
+    # Create user
+    if [ "${USER_GID}" = "automatic" ]; then
+        groupadd $USERNAME
+    else
+        groupadd --gid $USER_GID $USERNAME
+    fi
+    if [ "${USER_UID}" = "automatic" ]; then 
+        useradd -s /bin/bash --gid $USERNAME -m $USERNAME
+    else
+        useradd -s /bin/bash --uid $USER_UID --gid $USERNAME -m $USERNAME
+    fi
+fi
+
+# Add add sudo support for non-root user
+if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}" ]; then
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+    chmod 0440 /etc/sudoers.d/$USERNAME
+    EXISTING_NON_ROOT_USER="${USERNAME}"
+fi
+
+# ** Shell customization section **
+if [ "${USERNAME}" = "root" ]; then 
+    USER_RC_PATH="/root"
+else
+    USER_RC_PATH="/home/${USERNAME}"
+fi
+
+# .bashrc/.zshrc snippet
+RC_SNIPPET="$(cat << EOF
+export USER=\$(whoami)
+if [[ "\${PATH}" != *"\$HOME/.local/bin"* ]]; then export PATH="\${PATH}:\$HOME/.local/bin"; fi
+EOF
+)"
+
+# code shim, it fallbacks to code-insiders if code is not available
+cat << 'EOF' > /usr/local/bin/code
+#!/bin/sh
+
+get_in_path_except_current() {
+    which -a "$1" | grep -A1 "$0" | grep -v "$0"
+}
+
+code="$(get_in_path_except_current code)"
+
+if [ -n "$code" ]; then
+    exec "$code" "$@"
+elif [ "$(command -v code-insiders)" ]; then
+    exec code-insiders "$@"
+else
+    echo "code or code-insiders is not installed" >&2
+    exit 127
+fi
+EOF
+chmod +x /usr/local/bin/code
+
+# Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+CODESPACES_BASH="$(cat \
+<<EOF
+#!/usr/bin/env bash
+prompt() {
+    if [ "\$?" != "0" ]; then
+        local arrow_color=\${bold_red}
+    else
+        local arrow_color=\${reset_color}
+    fi
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="@\${GITHUB_USER}"
+    else
+        local USERNAME="\\u"
+    fi
+    local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
+    PS1="\${green}\${USERNAME} \${arrow_color}➜\${reset_color} \${bold_blue}\${cwd}\${reset_color} \$(scm_prompt_info)\${white}$ \${reset_color}"
+    
+    # Prepend Python virtual env version to prompt
+    if [[ -n \$VIRTUAL_ENV ]]; then
+        if [ -z "\${VIRTUAL_ENV_DISABLE_PROMPT:-}" ]; then
+            PS1="(\`basename \"\$VIRTUAL_ENV\"\`) \${PS1:-}"
+        fi
+    fi
+}
+
+SCM_THEME_PROMPT_PREFIX="\${reset_color}\${cyan}(\${bold_red}"
+SCM_THEME_PROMPT_SUFFIX="\${reset_color} "
+SCM_THEME_PROMPT_DIRTY=" \${bold_yellow}✗\${reset_color}\${cyan})"
+SCM_THEME_PROMPT_CLEAN="\${reset_color}\${cyan})"
+SCM_GIT_SHOW_MINIMAL_INFO="true"
+safe_append_prompt_command prompt
+EOF
+)"
+CODESPACES_ZSH="$(cat \
+<<EOF
+prompt() {
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="@\${GITHUB_USER}"
+    else
+        local USERNAME="%n"
+    fi
+    PROMPT="%{\$fg[green]%}\${USERNAME} %(?:%{\$reset_color%}➜ :%{\$fg_bold[red]%}➜ )"
+    PROMPT+='%{\$fg_bold[blue]%}%~%{\$reset_color%} \$(git_prompt_info)%{\$fg[white]%}$ %{\$reset_color%}'
+}
+ZSH_THEME_GIT_PROMPT_PREFIX="%{\$fg_bold[cyan]%}(%{\$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{\$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{\$fg_bold[yellow]%}✗%{\$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{\$fg_bold[cyan]%})"
+prompt
+EOF
+)"
+
+# Adapted Oh My Zsh! install step to work with both "Oh Mys" rather than relying on an installer script
+# See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+install-oh-my()
+{
+    local OH_MY=$1
+    local OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-${OH_MY}"
+    local TEMPLATE="${OH_MY_INSTALL_DIR}/templates/$2"
+    local OH_MY_GIT_URL=$3
+    local USER_RC_FILE="${USER_RC_PATH}/.${OH_MY}rc"
+
+    if [ -d "${OH_MY_INSTALL_DIR}" ] || [ "${INSTALL_OH_MYS}" != "true" ]; then
+        return 0
+    fi
+
+    umask g-w,o-w
+    mkdir -p ${OH_MY_INSTALL_DIR}
+    git clone --depth=1 \
+        -c core.eol=lf \
+        -c core.autocrlf=false \
+        -c fsck.zeroPaddedFilemode=ignore \
+        -c fetch.fsck.zeroPaddedFilemode=ignore \
+        -c receive.fsck.zeroPaddedFilemode=ignore \
+        ${OH_MY_GIT_URL} ${OH_MY_INSTALL_DIR} 2>&1
+    echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
+    if [ "${OH_MY}" = "bash" ]; then
+        sed -i -e 's/OSH_THEME=.*/OSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes/codespaces
+        echo "${CODESPACES_BASH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces/codespaces.theme.sh
+    else
+        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+        echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
+    fi
+    # Shrink git while still enabling updates
+    cd ${OH_MY_INSTALL_DIR} 
+    git repack -a -d -f --depth=1 --window=1
+
+    if [ "${USERNAME}" != "root" ]; then
+        cp -rf ${USER_RC_FILE} ${OH_MY_INSTALL_DIR} /root
+        chown -R ${USERNAME}:${USERNAME} ${USER_RC_PATH}
+    fi
+}
+
+if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
+    echo "${RC_SNIPPET}" >> /etc/bash.bashrc
+    RC_SNIPPET_ALREADY_ADDED="true"
+fi
+install-oh-my bash bashrc.osh-template https://github.com/ohmybash/oh-my-bash
+
+# Optionally install and configure zsh and Oh My Zsh!
+if [ "${INSTALL_ZSH}" = "true" ]; then
+    if ! type zsh > /dev/null 2>&1; then
+        apt-get-update-if-needed
+        apt-get install -y zsh
+    fi
+    if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
+        echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
+        ZSH_ALREADY_INSTALLED="true"
+    fi
+    install-oh-my zsh zshrc.zsh-template https://github.com/ohmyzsh/ohmyzsh
+fi
+
+# Write marker file
+mkdir -p "$(dirname "${MARKER_FILE}")"
+echo -e "\
+    PACKAGES_ALREADY_INSTALLED=${PACKAGES_ALREADY_INSTALLED}\n\
+    LOCALE_ALREADY_SET=${LOCALE_ALREADY_SET}\n\
+    EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
+    RC_SNIPPET_ALREADY_ADDED=${RC_SNIPPET_ALREADY_ADDED}\n\
+    ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"
+
+echo "Done!"

--- a/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md
+#
+# Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby]
+
+ENABLE_NONROOT_DOCKER=${1:-"true"}
+USERNAME=${2:-"automatic"}
+USE_MOBY=${3:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+# Function to run apt-get if needed
+apt-get-update-if-needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install docker/dockerd dependencies if missing
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release lxc pigz iptables > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    apt-get-update-if-needed
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release lxc pigz iptables gnupg2 
+fi
+
+# Swap to legacy iptables for compatibility
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Install Docker / Moby CLI if not already installed
+if type docker > /dev/null 2>&1 && type dockerd > /dev/null 2>&1; then
+    echo "Docker / Moby CLI and Engine already installed."
+else
+    if [ "${USE_MOBY}" = "true" ]; then
+        DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+        CODENAME=$(lsb_release -cs)
+        curl -s https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+        apt-get update
+        apt-get -y install --no-install-recommends moby-cli moby-engine
+    else
+        curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+        echo "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
+        apt-get update
+        apt-get -y install --no-install-recommends docker-ce-cli docker-ce
+    fi
+fi
+
+echo "Finished installing docker / moby"
+
+# Install Docker Compose if not already installed 
+if type docker-compose > /dev/null 2>&1; then
+    echo "Docker Compose already installed."
+else
+    LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")')
+    curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+fi
+
+# If init file already exists, exit
+if [ -f "/usr/local/share/docker-init.sh" ]; then
+    echo "/usr/local/share/docker-init.sh already exists, so exiting."
+    exit 0
+fi
+echo "docker-init doesnt exist..."
+
+# Add user to the docker group
+if [ "${ENABLE_NONROOT_DOCKER}" = "true" ]; then
+    if ! getent group docker > /dev/null 2>&1; then
+        groupadd docker
+    fi
+        usermod -aG docker ${USERNAME}
+fi
+
+tee /usr/local/share/docker-init.sh > /dev/null \
+<< EOF 
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+sudoIf()
+{
+    if [ "\$(id -u)" -ne 0 ]; then
+        sudo "\$@"
+    else
+        "\$@"
+    fi
+}
+
+# explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
+# ie: docker kill <ID>
+find /run /var/run -iname 'docker*.pid' -delete || :
+find /run /var/run -iname 'container*.pid' -delete || :
+
+set -e
+
+## Dind wrapper script from docker team
+# Maintained: https://github.com/moby/moby/blob/master/hack/dind
+
+export container=docker
+
+if [ -d /sys/kernel/security ] && ! sudoIf mountpoint -q /sys/kernel/security; then
+	sudoIf mount -t securityfs none /sys/kernel/security || {
+		echo >&2 'Could not mount /sys/kernel/security.'
+		echo >&2 'AppArmor detection and --privileged mode might break.'
+	}
+fi
+
+# Mount /tmp (conditionally)
+if ! sudoIf mountpoint -q /tmp; then
+	sudoIf mount -t tmpfs none /tmp
+fi
+
+# cgroup v2: enable nesting
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	# move the init process (PID 1) from the root group to the /init group,
+	# otherwise writing subtree_control fails with EBUSY.
+	sudoIf mkdir -p /sys/fs/cgroup/init
+	sudoIf echo 1 > /sys/fs/cgroup/init/cgroup.procs
+	# enable controllers
+	sudoIf sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+		> /sys/fs/cgroup/cgroup.subtree_control
+fi
+## Dind wrapper over.
+
+# Start docker/moby engine
+( sudoIf dockerd > /tmp/dockerd.log 2>&1 ) &
+
+set +e
+
+# Execute whatever commands were passed in (if any). This allows us 
+# to set this script to ENTRYPOINT while still executing the default CMD.
+exec "\$@"
+EOF
+
+chmod +x /usr/local/share/docker-init.sh
+chown ${USERNAME}:root /usr/local/share/docker-init.sh

--- a/.gitignore
+++ b/.gitignore
@@ -259,8 +259,15 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
-# vscode
-.vscode/
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
 # Benchmark results
 BenchmarkDotNet.Artifacts/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "razor.disabled": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "dotnet test",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "test",
+                "${fileDirname}",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -274,10 +274,12 @@ For more examples and information on how to do manual instrumentation see:
 Check if you are not hitting one of the issues listed below.
 
 ### IIS applications not instrumenting expected services
+
 Set the environment variable `SIGNALFX_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` to `true` - without it
 the CLR profiler can't instrument many libraries/frameworks under IIS.
 
 ### Linux instrumentation not working
+
 The proper binary needs to be selected when deploying to Linux, eg.: the default Microsoft .NET images are
 based on Debian and should use the `deb` package, see the [Linux](#Linux) setup section.
 
@@ -290,6 +292,7 @@ $ cat /proc/version
 ```
 
 ### High CPU usage
+
 The default installation of auto-instrumentation enables tracing all .NET processes on the box.
 In the typical scenarios (dedicated VMs or containers), this is not a problem.
 Use the environment variables `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` and `SIGNALFX_PROFILER_PROCESSES`
@@ -297,6 +300,7 @@ to include/exclude applications from the tracing auto-instrumentation.
 These are ";" delimited lists that control the inclusion/exclusion of processes.
 
 ### Investigating other issues
+
 If none of the suggestions above solves your issue, detailed logs are necessary.
 Follow the steps below to get the detailed logs from SignalFx Tracing for .NET:
 
@@ -308,9 +312,13 @@ On Windows, the default log location is `%ProgramData%\SignalFx .NET Tracing\log
 Compress the whole folder to capture the multiple log files and send the compressed folder to us.
 After obtaining the logs, remember to remove the environment variable `SIGNALFX_TRACE_DEBUG` to avoid unnecessary overhead.
 
+## Contributing
+
+See [docs/README.md](docs/README.md) and [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
+
 ## About
-The SignalFx-Tracing Library for .NET is a fork of the .NET
-Tracer for Datadog APM that has been modified to provide Zipkin v2 JSON
-formatting, a complete OpenTracing API implementation, B3 propagation, and
-properly annotated trace data for handling by
+
+The SignalFx-Tracing Library for .NET is a fork of the [.NET Tracer for Datadog APM](https://github.com/DataDog/dd-trace-dotnet)
+that has been modified to provide Zipkin v2 JSON formatting, a complete OpenTracing API implementation, B3 propagation,
+and properly annotated trace data for handling by 
 [SignalFx Microservices APM](https://docs.signalfx.com/en/latest/apm/apm-overview/index.html).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,10 +6,13 @@
 
 The repository contains configuration for [developing inside a Container](https://code.visualstudio.com/docs/remote/containers) using [Visual Studio Code Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
-- [Installation](https://code.visualstudio.com/docs/remote/containers#_installation)
-- [Official Development Container Definitions](https://github.com/microsoft/vscode-dev-containers)
+- [Installation](https://code.visualstudio.com/docs/remote/containers#_installation) 
 
-The Development Container configuration mixes [Docker in Docker](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-in-docker) and [C# (.NET)](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnet) definitions.
+The Development Container configuration mixes [Docker in Docker](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-in-docker) and [C# (.NET)](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnet) definitions. Use the [Official Development Container Definitions](https://github.com/microsoft/vscode-dev-containers) if more is needed.
+
+There may be a lot of errors, because some projects target .NET Framework. Switch to `Datadog.Trace.Minimal.sln` or `Datadog.Trace.Native.sln` using `F1 -> OmniSharp: Select Project` in Visual Studio Code to load a subset of projects which work without any issues. You can also try building the projects which have errors as it sometimes helps.
+
+If for whatever reason you need to use `Datadog.Trace.sln` you can run `for i in **/*.csproj; do dotnet build $i; done` to decrease the number of errors.
 
 ## Releasing
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,17 @@
-### Preparing release
+# Contributing
+
+> Modified by SignalFx
+
+## Development Container
+
+The repository contains configuration for [developing inside a Container](https://code.visualstudio.com/docs/remote/containers) using [Visual Studio Code Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+
+- [Installation](https://code.visualstudio.com/docs/remote/containers#_installation)
+- [Official Development Container Definitions](https://github.com/microsoft/vscode-dev-containers)
+
+The Development Container configuration mixes [Docker in Docker](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-in-docker) and [C# (.NET)](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnet) definitions.
+
+## Releasing
 
 1. Update the desired version in [`Datadog.Core.Tools.TracerVersion`](../tools/Datadog.Core.Tools/TracerVersion.cs).
 2. In build container (`docker-compose run build bash`):
@@ -6,9 +19,4 @@
     * `dotnet run --project . versions`
 3. Submit a PR updating the version with the changes above.
 4. Approve and merge PR above.
-5. Create the label for the release and add all the CircleCI artifacts from the PR above.
-There are artifacts: under `Alpine`, `Linux`, and `Windows`.
-6. Publish the release on GH.
-7. Publish `SignalFx.NET.Tracing.Azure.Site.Extension.*.nupkg`, `SignalFx.Tracing.*.nupkg`, and `SignalFx.Tracing.OpenTracing.*.nupkg` (from `Windows` artifacts) to https://www.nuget.org/
-
-*Modified by SignalFx*
+5. Publish a new GitHub Release and describe what has changed. CircleCI will automatically add artifacts and publish a new NuGet package.


### PR DESCRIPTION
## Why

An automated way to have a [dev environment inside a container](https://code.visualstudio.com/docs/remote/containers) that would not clutter your host OS.
It makes it also possible to test/build stuff on Windows as it was on Linux. Personally, I use Win10 with WSL2. The only stuff currently that I saw not working is IPv6. Here is why: https://docs.docker.com/config/daemon/ipv6/
This config may also be used in future to develop using [GitHub Codespaces](https://github.com/features/codespaces) in the browser once it will hit the production.

I feel that it is cool for an open-source repo to have the "environment setup" as easy as possible to welcome contributions. Especially bugfixes 😉 

## What

Add VS Code development container setting including Docker in Docker and .NET 5.0 with additional .NET Core runtimes.
The development container does not contain the Native (C++) stuff, however, Docker and Docker Compose are available inside. I can work in improving the Dockerfile to make writing C++ more pleasant, but I do not know if it is worth the effort.

The stuff required to this are:
- Docker
- VS Code with [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)

Little more info: https://github.com/microsoft/vscode-dev-containers
