### PR TITLE
Expose service name and environment at injected log context

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_ENDPOINT_URL` | `http://localhost:9080/v1/trace` | The hostname and port for a SignalFx Smart Agent or OpenTelemetry Collector. |
 | `SIGNALFX_ACCESS_TOKEN` |  | The access token for your SignalFx organization. Providing a token enables you to send traces to a SignalFx ingest endpoint. |
 | `SIGNALFX_TRACE_GLOBAL_TAGS` |  | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |
-| `SIGNALFX_LOGS_INJECTION` | `false` | Enable to inject trace IDs and span IDs in logs. This requires a compatible logger or manual configuration. |
+| `SIGNALFX_LOGS_INJECTION` | `false` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. |
 | `SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS` |  | Enable to tag the Mongo command `BsonDocument` as a `db.statement`. |
 | `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES` |  | Enable to tag the Elasticsearch command `PostData` as a `db.statement`. |
 | `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS` |  | Enable to tag Redis commands as a `db.statement`. |

--- a/customer-samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
+++ b/customer-samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
@@ -26,6 +26,8 @@
                 <!-- Manual changes: start -->
                 <member value='signalfx.trace_id' />
                 <member value='signalfx.span_id' />
+                <member value='signalfx.service' />
+                <member value='signalfx.environment' />
                 <!-- Manual changes: end -->
             </layout>
         </appender>
@@ -57,7 +59,7 @@
 
         <!-- For the default PatternLayout, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values using the %property{name} syntax (see: https://logging.apache.org/log4net/release/manual/contexts.html) -->
         <!--
--            Additions to layout: {traceId=&quot;%property{signalfx.trace_id}&quot;,spanId=&quot;%property{signalfx.span_id}&quot;}
+-            Additions to layout: {traceId=&quot;%property{signalfx.trace_id}&quot;,spanId=&quot;%property{signalfx.span_id}&quot;, service=&quot;%property{signalfx.service}&quot;, environment=&quot;%property{signalfx.environment}}
 -       -->
         <!--
             Parsing this log line with a custom Pipeline that adds Trace/Log correlation can be done with the following Processors:
@@ -67,7 +69,7 @@
         <appender name="textFileAppender" type="log4net.Appender.FileAppender">
             <file value="log-log4net-textFile.log" />
             <layout type="log4net.Layout.PatternLayout">
-                <conversionPattern value="%date [%thread] %level %logger {traceId=&quot;%property{signalfx.trace_id}&quot;, spanId=&quot;%property{signalfx.span_id}&quot;} - %message%newline" />
+                <conversionPattern value="%date [%thread] %level %logger {traceId=&quot;%property{signalfx.trace_id}&quot;, spanId=&quot;%property{signalfx.span_id}&quot;, service=&quot;%property{signalfx.service}&quot;, environment=&quot;%property{signalfx.environment}&quot;} - %message%newline" />
             </layout>
         </appender>
 

--- a/customer-samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
+++ b/customer-samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
@@ -32,13 +32,15 @@
                 <!-- Manual changes: start -->
                 <attribute name="signalfx.trace_id" layout="${mdc:item=signalfx.trace_id}"/>
                 <attribute name="signalfx.span_id" layout="${mdc:item=signalfx.span_id}"/>
+                <attribute name="signalfx.service" layout="${mdc:item=signalfx.service}"/>
+                <attribute name="signalfx.environment" layout="${mdc:item=signalfx.environment}"/>
                 <!-- Manual changes: end -->
             </layout>
         </target>
 
         <!-- For a custom layout, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values -->
         <!--
-            Additions to layout: {traceId=&quot;${mdc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdc:item=signalfx.span_id}&quot;}
+            Additions to layout: {traceId=&quot;${mdc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdc:item=signalfx.span_id}&quot;,service=&quot;${mdc:item=signalfx.service}&quot;,environment=&quot;${mdc:item=signalfx.environment}&quot;}
         -->
         <!--
             Parsing this log line with a custom Pipeline that adds Trace/Log correlation can be done with the following Processors:
@@ -46,7 +48,7 @@
             2. Trace Id Remapper: Set the trace_id attribute to 'traceId'
         -->
         <target name="textFile" xsi:type="File" fileName="log-NLog45-textFile.log"
-                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdc:item=signalfx.span_id}&quot;}|${message}" />
+                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdc:item=signalfx.span_id}&quot;,service=&quot;${mdc:item=signalfx.service}&quot;,environment=&quot;${mdc:item=signalfx.environment}&quot;}|${message}" />
     </targets>
 
     <!-- rules to map from logger name to target -->

--- a/customer-samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
+++ b/customer-samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
@@ -32,13 +32,15 @@
                 <!-- Manual changes: start -->
                 <attribute name="signalfx.trace_id" layout="${mdlc:item=signalfx.trace_id}"/>
                 <attribute name="signalfx.span_id" layout="${mdlc:item=signalfx.span_id}"/>
+                <attribute name="signalfx.service" layout="${mdlc:item=signalfx.service}"/>
+                <attribute name="signalfx.environment" layout="${mdlc:item=signalfx.environment}"/>
                 <!-- Manual changes: end -->
             </layout>
         </target>
 
         <!-- For a custom layout, you must explicitly extract the 'signalfx.trace_id' and 'signalfx.span_id' values -->
         <!--
-            Additions to layout: {traceId=&quot;${mdlc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdlc:item=signalfx.span_id}&quot;}
+            Additions to layout: {traceId=&quot;${mdlc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdlc:item=signalfx.span_id}&quot;,service=&quot;${mdlc:item=signalfx.service}&quot;,environment=&quot;${mdlc:item=signalfx.environment}&quot;}
         -->
         <!--
             Parsing this log line with a custom Pipeline that adds Trace/Log correlation can be done with the following Processors:
@@ -46,7 +48,7 @@
             2. Trace Id Remapper: Set the trace_id attribute to 'trace_id'
         -->
         <target name="textFile" xsi:type="File" fileName="log-NLog46-textFile.log"
-                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdlc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdlc:item=signalfx.span_id}&quot;}|${message}" />
+                layout="${longdate}|${uppercase:${level}}|${logger}|{traceId=&quot;${mdlc:item=signalfx.trace_id}&quot;,spanId=&quot;${mdlc:item=signalfx.span_id}&quot;service=&quot;${mdlc:item=signalfx.service}&quot;,environment=&quot;${mdlc:item=signalfx.environment}&quot;}|${message}" />
     </targets>
 
     <!-- rules to map from logger name to target -->

--- a/customer-samples/AutomaticTraceIdInjection/README.md
+++ b/customer-samples/AutomaticTraceIdInjection/README.md
@@ -45,3 +45,10 @@ Layouts configured in the sample:
 - JSON format: `JsonFormatter`
 - JSON format: `CompactJsonFormatter` (from the `Serilog.Formatting.Compact` NuGet package)
 - Raw format: output template (requires manual configuration)
+
+## Fields injected into log context
+
+- `signalfx.trace_id`
+- `signalfx.span_id`
+- `signalfx.service` - [`SIGNALFX_SERVICE_NAME`](/README.md#configuration-values) configuration option
+- `signalfx.environment` - [`SIGNALFX_ENV`](/README.md#configuration-values) configuration option

--- a/customer-samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
+++ b/customer-samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
@@ -13,7 +13,8 @@ namespace SerilogExample
         static void Main(string[] args)
         {
             // Regardless of the output layout, your LoggerConfiguration must be
-            // enriched from the LogContext to extract the `signalfx.trace_id` and `signalfx.span_id`
+            // enriched from the LogContext to extract the `signalfx.trace_id`, `signalfx.span_id`, `signalfx.service`
+            // and `signalfx.environment`
             // properties that are automatically injected by the .NET tracer
             //
             // Additions to LoggerConfiguration:

--- a/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -19,6 +19,16 @@ namespace SignalFx.Tracing
         public static readonly string SpanIdKey = "signalfx.span_id";
 
         /// <summary>
+        /// Key used to correlate the environment on logs.
+        /// </summary>
+        public static readonly string ServiceNameKey = "signalfx.service";
+
+        /// <summary>
+        /// Key used to correlate the environment on logs.
+        /// </summary>
+        public static readonly string ServiceEnvironmentKey = "signalfx.environment";
+
+        /// <summary>
         /// Gets the trace id
         /// </summary>
         public static ulong TraceId

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -53,8 +53,7 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: N/A
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: Parent scope
@@ -94,7 +93,7 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: Default values of TraceId=0,SpanId=0
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            logEvent.Contains(traceId: 0, spanId: 0);
+            logEvent.Contains(traceId: 0, spanId: 0, service: string.Empty, environment: string.Empty);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
         }
 
@@ -118,54 +117,55 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: N/A
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: N/A
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: N/A
             // Custom property: SET
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: N/A
             // Custom property: SET
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: N/A
             // Custom property: SET
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: N/A
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: N/A
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
+            AssertNoCorrelationIdentifiers(logEvent);
+            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+        }
+
+        private static void AssertNoCorrelationIdentifiers(LoggingEvent logEvent)
+        {
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(CorrelationIdentifier.ServiceNameKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(CorrelationIdentifier.ServiceEnvironmentKey, logEvent.Properties.GetKeys());
         }
 
         /// <summary>

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -73,22 +73,19 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: Parent scope
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, parentScope.Span.TraceId), logString);
+            AssertCorrelationIdentifiers(parentScope, logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
 
             // Scope: Parent scope
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, parentScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, parentScope.Span.TraceId), logString);
+            AssertCorrelationIdentifiers(parentScope, logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: Child scope
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, childScope.Span.SpanId), logString);
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, childScope.Span.TraceId), logString);
+            AssertCorrelationIdentifiers(childScope, logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: Parent scope
@@ -110,6 +107,8 @@ namespace Datadog.Trace.Tests.Logging
             logString = filteredLogs[logIndex++];
             Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, 0), logString);
             Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, 0), logString);
+            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.ServiceNameKey, string.Empty), logString);
+            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.ServiceEnvironmentKey, string.Empty), logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
         }
 
@@ -133,51 +132,60 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: N/A
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
+            AssertNoCorrelationIdentifiers(logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
 
             // Scope: N/A
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
+            AssertNoCorrelationIdentifiers(logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
 
             // Scope: N/A
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
+            AssertNoCorrelationIdentifiers(logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: N/A
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
+            AssertNoCorrelationIdentifiers(logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: N/A
             // Custom property: SET
             logString = filteredLogs[logIndex++];
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
+            AssertNoCorrelationIdentifiers(logString);
             Assert.Contains(string.Format(ExpectedStringFormat, LoggingProviderTestHelpers.CustomPropertyName, LoggingProviderTestHelpers.CustomPropertyValue), logString);
 
             // Scope: N/A
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
-            Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
+            AssertNoCorrelationIdentifiers(logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
 
             // Scope: N/A
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
+            AssertNoCorrelationIdentifiers(logString);
+            Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
+        }
+
+        private static void AssertCorrelationIdentifiers(Scope scope, string logString)
+        {
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, scope.Span.SpanId), logString);
+            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, scope.Span.TraceId), logString);
+            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.ServiceNameKey, LoggingProviderTestHelpers.ServiceName), logString);
+            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.ServiceEnvironmentKey, LoggingProviderTestHelpers.ServiceEnvironment), logString);
+        }
+
+        private static void AssertNoCorrelationIdentifiers(string logString)
+        {
             Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
             Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
-            Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
+            Assert.DoesNotContain($"\"{CorrelationIdentifier.ServiceNameKey}\"", logString);
+            Assert.DoesNotContain($"\"{CorrelationIdentifier.ServiceEnvironmentKey}\"", logString);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
@@ -50,8 +50,7 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: N/A
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
             // Scope: Parent scope
@@ -90,8 +89,7 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: N/A
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
         }
 
@@ -114,54 +112,55 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: N/A
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
             // Scope: N/A
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
             // Scope: N/A
             // Custom property: SET
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: N/A
             // Custom property: SET
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: N/A
             // Custom property: SET
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: N/A
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            AssertNoCorrelationIdentifiers(logEvent);
             Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
             // Scope: N/A
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
+            AssertNoCorrelationIdentifiers(logEvent);
+            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+        }
+
+        private static void AssertNoCorrelationIdentifiers(LogEvent logEvent)
+        {
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.ServiceNameKey));
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.ServiceEnvironmentKey));
         }
     }
 }


### PR DESCRIPTION
Expose `SIGNALFX_SERVICE_NAME` and `SIGNALFX_ENV` in addition to trace and span IDs at injected log context to improve correlating logs with spans.

Fixes `APMI-1443`

@signalfx/instrumentation