### PR TITLE
Add more details to Windows environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ the [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-functions
 
 ### Windows
 
-**Warning**: pay close attention to the scope of environment variables and ensure they
-are properly set prior to launching the targeted process. The steps below set the environment
-variables at the machine level, with the exception of the variables used for finer control
-of which processes will be instrumented.
+**Warning**: Pay close attention to the scope of environment variables. Ensure they
+are properly set prior to launching the targeted process. The following steps set the
+environment variables at the machine level, with the exception of the variables used
+for finer control of which processes will be instrumented, which are set in the current
+command session.
 
 1. Install the CLR Profiler using an installer file (`.msi` file) from the
 [latest release](https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest).
@@ -208,12 +209,15 @@ the trace data:
     setx SIGNALFX_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION true /m
     ```
 7. Enable instrumentation for the targeted application by setting
-the appropriate __CLR enable profiling__ environment variable,
-according to the .NET runtime being used,
-to **1** for the targeted application.
-The snippet below sets the variable only for the current command
-session (see below for other some alternatives on how
-to set it to different scopes):
+the appropriate __CLR enable profiling__ environment variable.
+You can enable instrumentation at these levels:
+ - For current command session
+ - For a specific Windows Service
+ - For a specific user
+The follow snippet describes how to enable instrumentation for
+the current command session according to the .NET runtime.
+To enable instrumentation at different levels, see
+[this](#enable-instrumentation-at-different-levels) section.
    - For .NET Framework applications:
    ```batch
    set COR_ENABLE_PROFILING=1
@@ -226,7 +230,9 @@ to set it to different scopes):
 configured. If you need to check the environment variables for a process use a tool
 like [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer).
 
-- To enable instrumentation for a specific Windows service:
+#### Enable instrumentation at different levels
+
+Enable instrumentation for a specific Windows service:
    - For .NET Framework applications:
    ```batch
    reg add HKLM\SYSTEM\CurrentControlSet\Services\<ServiceName>\Environment /v COR_ENABLE_PROFILING /d 1
@@ -235,7 +241,8 @@ like [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/
    ```batch
    reg add HKLM\SYSTEM\CurrentControlSet\Services\<ServiceName>\Environment /v CORECLR_ENABLE_PROFILING /d 1
    ```
-- To enable instrumentation for a specific user:
+
+Enable instrumentation for a specific user:
    - For .NET Framework applications:
    ```batch
    setx /s %COMPUTERNAME% /u <[domain/]user> COR_ENABLE_PROFILING 1

--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ the [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-functions
 
 ### Windows
 
+**Warning**: pay close attention to the scope of environment variables and ensure they
+are properly set prior to launching the targeted process. The steps below set the environment
+variables at the machine level, with the exception of the variables used for finer control
+of which processes will be instrumented.
+
 1. Install the CLR Profiler using an installer file (`.msi` file) from the
 [latest release](https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest).
 Choose the installer (x64 or x86) according to the architecture of the application
@@ -179,34 +184,66 @@ you're instrumenting.
 2. Configure the required environment variables to enable the CLR Profiler:
     - For .NET Framework applications:
     ```batch
-    set COR_ENABLE_PROFILING=1
-    set COR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
+    setx COR_PROFILER {B4C89B0F-9908-4F73-9F59-0D77C5A06874} /m
     ```
    - For .NET Core applications:
    ```batch
-   set CORECLR_ENABLE_PROFILING=1
-   set CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
+   setx CORECLR_PROFILER {B4C89B0F-9908-4F73-9F59-0D77C5A06874} /m
    ```
 3. Set the "service name" that better describes your application:
    ```batch
-   set SIGNALFX_SERVICE_NAME=MyServiceName
+   setx SIGNALFX_SERVICE_NAME MyServiceName /m
    ```
 4. Set the endpoint of a Smart Agent or OpenTelemetry Collector that will forward
 the trace data:
    ```batch
-   set SIGNALFX_ENDPOINT_URL=http://localhost:9080/v1/trace
+   setx SIGNALFX_ENDPOINT_URL http://localhost:9080/v1/trace /m
    ```
 5. Optionally, enable trace injection in logs:
    ```batch
-   set SIGNALFX_LOGS_INJECTION=true
+   setx SIGNALFX_LOGS_INJECTION true /m
    ```
 6. Optionally, if instrumenting IIS applications add the following environmet variable set to `true`:
     ```batch
-    set SIGNALFX_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION=true
+    setx SIGNALFX_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION true /m
     ```
-7. Restart your application ensuring that all environment variables above are properly
+7. Enable instrumentation for the targeted application by setting
+the appropriate __CLR enable profiling__ environment variable,
+according to the .NET runtime being used,
+to **1** for the targeted application.
+The snippet below sets the variable only for the current command
+session (see below for other some alternatives on how
+to set it to different scopes):
+   - For .NET Framework applications:
+   ```batch
+   set COR_ENABLE_PROFILING=1
+   ```
+   - For .NET Core applications:
+   ```batch
+   set CORECLR_ENABLE_PROFILING=1
+   ```
+8. Restart your application ensuring that all environment variables above are properly
 configured. If you need to check the environment variables for a process use a tool
 like [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer).
+
+- To enable instrumentation for a specific Windows service:
+   - For .NET Framework applications:
+   ```batch
+   reg add HKLM\SYSTEM\CurrentControlSet\Services\<ServiceName>\Environment /v COR_ENABLE_PROFILING /d 1
+   ```
+   - For .NET Core applications:
+   ```batch
+   reg add HKLM\SYSTEM\CurrentControlSet\Services\<ServiceName>\Environment /v CORECLR_ENABLE_PROFILING /d 1
+   ```
+- To enable instrumentation for a specific user:
+   - For .NET Framework applications:
+   ```batch
+   setx /s %COMPUTERNAME% /u <[domain/]user> COR_ENABLE_PROFILING 1
+   ```
+   - For .NET Core applications:
+   ```batch
+   setx /s %COMPUTERNAME% /u <[domain/]user> CORECLR_ENABLE_PROFILING 1
+   ```
 
 ## Configure custom instrumentation
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ you're instrumenting.
 2. Configure the required environment variables to enable the CLR Profiler:
     - For .NET Framework applications:
     ```batch
-    setx COR_PROFILER {B4C89B0F-9908-4F73-9F59-0D77C5A06874} /m
+    setx COR_PROFILER "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" /m
     ```
    - For .NET Core applications:
    ```batch
-   setx CORECLR_PROFILER {B4C89B0F-9908-4F73-9F59-0D77C5A06874} /m
+   setx CORECLR_PROFILER "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" /m
    ```
 3. Set the "service name" that better describes your application:
    ```batch


### PR DESCRIPTION
@partainta1-splunk a little more information trying to clarify how to properly setup environment variables on Windows. Ideally we should add most of this to the MSI itself. The one that we need to be careful is the "enable" variable since it can cause performance issues by enabling instrumentation for all .NET processes of the box.

~~I will add an item to improve the MSI to our backlog.~~ Actually doing this at the machine level will switch the all the profiling to the instrumentation and the user may already have other CLR profilers in use, we don't want to break that.