### PR TITLE
Fix CircleCI on Windows

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Adding a nuget.config is good practice and also fixes the Windows build on CircleCI, see https://discuss.circleci.com/t/workaround-for-nuget-restore-error-available-as-windows-image-edge-release/39904

Observed on https://github.com/signalfx/signalfx-dotnet-tracing/pull/96
