### PR TITLE
Prepare release 0.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 # First install the package. This example downloads the latest version
 # alternatively download a specific version or use a local copy.
-ARG TRACER_VERSION=0.1.9
+ARG TRACER_VERSION=0.1.10
 ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
 RUN dpkg -i /signalfx-package/signalfx-dotnet-tracing.deb
 RUN rm -rf /signalfx-package

--- a/customer-samples/ConsoleApp/Alpine3.10.dockerfile
+++ b/customer-samples/ConsoleApp/Alpine3.10.dockerfile
@@ -17,7 +17,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=0.1.9
+ARG TRACER_VERSION=0.1.10
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/customer-samples/ConsoleApp/Alpine3.9.dockerfile
+++ b/customer-samples/ConsoleApp/Alpine3.9.dockerfile
@@ -17,7 +17,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=0.1.9
+ARG TRACER_VERSION=0.1.10
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/customer-samples/ConsoleApp/Debian.dockerfile
+++ b/customer-samples/ConsoleApp/Debian.dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Set up Datadog APM
-ARG TRACER_VERSION=0.1.9
+ARG TRACER_VERSION=0.1.10
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb

--- a/deploy/Azure.Site.Extension/Azure.Site.Extension.nuspec
+++ b/deploy/Azure.Site.Extension/Azure.Site.Extension.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>SignalFx.NET.Tracing.Azure.Site.Extension</id>
-    <version>0.1.9.0</version>
+    <version>0.1.10.0</version>
     <title>SignalFx .NET Tracing [PreRelease]</title>
     <authors>SignalFx</authors>
     <icon>icon.png</icon>

--- a/deploy/Azure.Site.Extension/applicationHost.xdt
+++ b/deploy/Azure.Site.Extension/applicationHost.xdt
@@ -26,18 +26,18 @@
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.1.9\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.9\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.9\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.1.10\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.10\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.10\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.9\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.9\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.10\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.10\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
-        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.1.9" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.1.9\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.1.9\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.1.10" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.1.10\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.1.10\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
       </environmentVariables>

--- a/deploy/Azure.Site.Extension/install.cmd
+++ b/deploy/Azure.Site.Extension/install.cmd
@@ -8,7 +8,7 @@ echo Extension directory is %extensionBaseDir%
 echo Site root directory is %siteHome%
 
 REM Create version specific tracer directory
-SET tracerDir=%siteHome%\signalfx\tracing\v0.1.9
+SET tracerDir=%siteHome%\signalfx\tracing\v0.1.10
 if not exist %tracerDir% mkdir %tracerDir%
 
 REM Copy tracer to version specific directory

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -15,11 +15,11 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>signalfx-dotnet-tracing-0.1.9-$(Platform)</OutputName>
+    <OutputName>signalfx-dotnet-tracing-0.1.10-$(Platform)</OutputName>
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>InstallerVersion=0.1.9</DefineConstants>
+    <DefineConstants>InstallerVersion=0.1.10</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/deployments/cloudfoundry/buildpack-linux/README.md
+++ b/deployments/cloudfoundry/buildpack-linux/README.md
@@ -42,5 +42,5 @@ If you want to use a specific version of the tracing library in your application
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.9"
+$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.10"
 ```

--- a/deployments/cloudfoundry/buildpack-linux/bin/supply
+++ b/deployments/cloudfoundry/buildpack-linux/bin/supply
@@ -7,7 +7,7 @@ from urllib.request import build_opener, HTTPRedirectHandler
 from tarfile import TarFile
 
 # Please don't change the formatting of this line - it's automatically updated by SetAllVersions.cs
-LATEST_VERSION = "0.1.9"
+LATEST_VERSION = "0.1.10"
 DOTNET_AGENT_VERSION = ENV.get("SIGNALFX_DOTNET_TRACING_VERSION", default=LATEST_VERSION)
 DOTNET_AGENT_ARCHIVE_NAME=f"signalfx-dotnet-tracing-{DOTNET_AGENT_VERSION}.tar.gz"
 DOTNET_AGENT_URL=f"https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v{DOTNET_AGENT_VERSION}/{DOTNET_AGENT_ARCHIVE_NAME}"

--- a/deployments/cloudfoundry/buildpack-windows/README.md
+++ b/deployments/cloudfoundry/buildpack-windows/README.md
@@ -50,7 +50,7 @@ If you want to use a specific version of the tracing library in your application
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.9"
+$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.10"
 ```
 
 If you want to use this buildpack in a .NET Framework application deployment you have to enable HWC support by setting the `SIGNALFX_USE_HWC` environment variable to `true` either using `cf set-env` or the `manifest.yml` file:

--- a/deployments/cloudfoundry/buildpack-windows/src/supply/supply.go
+++ b/deployments/cloudfoundry/buildpack-windows/src/supply/supply.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Please don't change the formatting of this line - it's automatically updated by SetAllVersions.cs
-const LatestVersion = "0.1.9"
+const LatestVersion = "0.1.10"
 
 func getAgentVersion() string {
 	version, ok := os.LookupEnv("SIGNALFX_DOTNET_TRACING_VERSION")

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-VERSION=0.1.9
+VERSION=0.1.10
 
 mkdir -p $DIR/../deploy/linux
 for target in integrations.json defaults.env LICENSE NOTICE createLogPath.sh ; do

--- a/integrations.json
+++ b/integrations.json
@@ -25,7 +25,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "BeginInvokeAction",
           "signature": "00 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -52,7 +52,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "EndInvokeAction",
           "signature": "00 05 02 1C 1C 08 08 0A",
@@ -83,7 +83,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
           "method": "ExecuteAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -112,7 +112,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -136,7 +136,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -161,7 +161,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -186,7 +186,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -212,7 +212,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -238,7 +238,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -262,7 +262,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -286,7 +286,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -311,7 +311,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -336,7 +336,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -360,7 +360,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -384,7 +384,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -409,7 +409,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -434,7 +434,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -466,7 +466,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearch",
           "signature": "10 01 05 1C 1C 1C 08 08 0A",
@@ -494,7 +494,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearchAsync",
           "signature": "10 01 06 1C 1C 1C 1C 08 08 0A",
@@ -526,7 +526,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearch",
           "signature": "10 01 05 1C 1C 1C 08 08 0A",
@@ -554,7 +554,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearchAsync",
           "signature": "10 01 06 1C 1C 1C 1C 08 08 0A",
@@ -589,7 +589,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "Validate",
           "signature": "00 0A 1C 1C 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -614,7 +614,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "ExecuteAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -645,7 +645,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpMessageHandler_SendAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -671,7 +671,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpClientHandler_SendAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -700,7 +700,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -724,7 +724,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -748,7 +748,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -773,7 +773,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -798,7 +798,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -823,7 +823,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -847,7 +847,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -871,7 +871,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -895,7 +895,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -919,7 +919,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -943,7 +943,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -967,7 +967,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -998,7 +998,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1024,7 +1024,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteGeneric",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1050,7 +1050,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1076,7 +1076,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsyncGeneric",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1105,7 +1105,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1130,7 +1130,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1155,7 +1155,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1181,7 +1181,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderAsyncTwoParams",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1205,7 +1205,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1230,7 +1230,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1254,7 +1254,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1279,7 +1279,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1304,7 +1304,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1331,7 +1331,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.OpenTracingIntegration",
           "method": "NoopWithoutMatchingMethod",
           "signature": "00 03 1C 08 08 0A",
@@ -1366,7 +1366,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ServiceStackRedisIntegration",
           "method": "SendReceive",
           "signature": "10 01 08 1E 00 1C 1D 1D 05 1C 1C 02 08 08 0A",
@@ -1395,7 +1395,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1419,7 +1419,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1444,7 +1444,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1469,7 +1469,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1495,7 +1495,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1521,7 +1521,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1545,7 +1545,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1569,7 +1569,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1594,7 +1594,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1619,7 +1619,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1643,7 +1643,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1667,7 +1667,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1692,7 +1692,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1717,7 +1717,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1751,7 +1751,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A",
@@ -1780,7 +1780,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A",
@@ -1810,7 +1810,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -1840,7 +1840,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -1869,7 +1869,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
           "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -1898,7 +1898,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
           "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -1929,7 +1929,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WcfIntegration",
           "method": "HandleRequest",
           "signature": "00 06 02 1C 1C 1C 08 08 0A",
@@ -1958,7 +1958,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetRequestStream",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1982,7 +1982,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetRequestStream",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2006,7 +2006,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2030,7 +2030,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2054,7 +2054,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2078,7 +2078,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
           "signature": "00 04 1C 1C 08 08 0A",

--- a/reproductions/AutomapperTest/Dockerfile
+++ b/reproductions/AutomapperTest/Dockerfile
@@ -1,6 +1,6 @@
 # Modified by SignalFx
 FROM mcr.microsoft.com/dotnet/core/runtime:2.1-stretch-slim AS base
-ARG TRACER_VERSION=0.1.9
+ARG TRACER_VERSION=0.1.10
 RUN mkdir -p /opt/datadog
 RUN mkdir -p /var/log/signalfx/dotnet
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v$TRACER_VERSION/datadog-dotnet-apm-$TRACER_VERSION.tar.gz | tar xzf - -C /opt/datadog

--- a/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net45</TargetFrameworks>
 
     <!-- NuGet -->
-    <Version>0.1.9</Version>
+    <Version>0.1.10</Version>
     <Title>SignalFx Tracing for ASP.NET</Title>
     <AssemblyName>SignalFx.Tracing.AspNet</AssemblyName>
     <PackageDescription>

--- a/src/Datadog.Trace.ClrProfiler.Managed.Core/Datadog.Trace.ClrProfiler.Managed.Core.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Core/Datadog.Trace.ClrProfiler.Managed.Core.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>SignalFx.Tracing.ClrProfiler.Managed.Core</AssemblyName>
 
     <!-- NuGet -->
-    <Version>0.1.9</Version>
+    <Version>0.1.10</Version>
     <IsPackable>false</IsPackable>
 
     <!-- Allow the GenerateAssemblyInfo task in the .NET SDK to generate all

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -8,7 +8,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>0.1.9</Version>
+    <Version>0.1.10</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         {
             try
             {
-                var assembly = Assembly.Load("SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+                var assembly = Assembly.Load("SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
                 if (assembly != null)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>SignalFx.Tracing.ClrProfiler.Managed</AssemblyName>
 
     <!-- NuGet -->
-    <Version>0.1.9</Version>
+    <Version>0.1.10</Version>
     <Title>Datadog APM - ClrProfiler</Title>
     <PackageDescription>
 DEPRECATED. This package exists only for backwards compatibility. If your project references this package ("Datadog.Trace.ClrProfiler.Managed") or "Datadog.Trace.AspNet", you can remove them both.

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required (VERSION 3.8)
 cmake_policy(SET CMP0015 NEW)
 
-project("Datadog.Trace.ClrProfiler.Native" VERSION 0.1.9)
+project("Datadog.Trace.ClrProfiler.Native" VERSION 0.1.10)
 
 add_compile_options(-std=c++11 -fPIC -fms-extensions)
 add_compile_options(-DBIT64 -DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)

--- a/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,1,9,0
- PRODUCTVERSION 0,1,9,0
+ FILEVERSION 0,1,10,0
+ PRODUCTVERSION 0,1,10,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "SignalFx"
             VALUE "FileDescription", "SignalFx CLR Profiler"
-            VALUE "FileVersion", "0.1.9.0"
+            VALUE "FileVersion", "0.1.10.0"
             VALUE "InternalName", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "LegalCopyright", "Copyright (C) 2020-2022"
             VALUE "OriginalFilename", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "ProductName", "SignalFx .NET Tracing"
-            VALUE "ProductVersion", "0.1.9"
+            VALUE "ProductVersion", "0.1.10"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/Datadog.Trace.ClrProfiler.Native/version.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/version.h
@@ -1,4 +1,4 @@
 // Modified by SignalFx
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.1.9";
+constexpr auto PROFILER_VERSION = "0.1.10";

--- a/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>0.1.9</Version>
+    <Version>0.1.10</Version>
     <Title>SignalFx Tracing OpenTracing</Title>
     <Description>Provides OpenTracing support for SignalFx Tracing</Description>
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>0.1.9</Version>
+    <Version>0.1.10</Version>
     <Title>SignalFx Tracing</Title>
     <Description>Manual instrumentation library for SignalFx Tracing</Description>
     <AssemblyName>SignalFx.Tracing</AssemblyName>

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -502,7 +502,7 @@ namespace SignalFx.Tracing
         {
             try
             {
-                Assembly asm = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=0.1.9.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"));
+                Assembly asm = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=0.1.10.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"));
                 Type openTracingTracerFactory = asm.GetType("SignalFx.Tracing.OpenTracing.OpenTracingTracerFactory");
                 var methodInfo = openTracingTracerFactory.GetMethod("RegisterGlobalTracer");
                 object[] args = new object[] { instance };

--- a/tools/Datadog.Core.Tools/TracerVersion.cs
+++ b/tools/Datadog.Core.Tools/TracerVersion.cs
@@ -19,7 +19,7 @@ namespace Datadog.Core.Tools
         /// <summary>
         /// The patch portion of the current version.
         /// </summary>
-        public const int Patch = 9;
+        public const int Patch = 10;
 
         /// <summary>
         /// Whether the current release is a pre-release


### PR DESCRIPTION
Preparation for the next release. Changes visible to users in this upcoming release:

* Support for 128-bit TraceId.
* W3C propagation support.
* Server-Timing (and Access-Control-Expose-Headers) header support. 

