### PR TITLE
Low-hanging opt: avoid allocation on default sampler

### DIFF
--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -10,6 +10,7 @@ namespace SignalFx.Tracing
     internal class TraceContext : ITraceContext
     {
         private static readonly SignalFx.Tracing.Vendors.Serilog.ILogger Log = SignalFxLogging.For<TraceContext>();
+        private static readonly Tracing.SamplingPriority? DefaultSamplingPriority = new Tracing.SamplingPriority?(Tracing.SamplingPriority.AutoKeep);
 
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
         private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
@@ -70,8 +71,9 @@ namespace SignalFx.Tracing
                         {
                             // this is a local root span (i.e. not propagated).
                             // determine an initial sampling priority for this trace, but don't lock it yet
-                            _samplingPriority =
-                                Tracer.Sampler?.GetSamplingPriority(RootSpan);
+                            _samplingPriority = Tracer.Sampler == null
+                                ? DefaultSamplingPriority
+                                : Tracer.Sampler.GetSamplingPriority(RootSpan);
                         }
                     }
                 }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -102,12 +102,14 @@ namespace SignalFx.Tracing
 
             _agentWriter = agentWriter ?? new AgentWriter(apiClient, Statsd, Settings.SynchronousSend);
             _scopeManager = scopeManager ?? new AsyncLocalScopeManager();
-            Sampler = sampler ?? new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));
+            Sampler = sampler;
 
             Propagator = ContextPropagatorBuilder.BuildPropagator(Settings.Propagator);
 
             if (!string.IsNullOrWhiteSpace(Settings.CustomSamplingRules))
             {
+                Sampler = Sampler ?? new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));
+
                 // User has opted in, ensure rate limiter is used
                 RuleBasedSampler.OptInTracingWithoutLimits();
 
@@ -127,6 +129,7 @@ namespace SignalFx.Tracing
                 }
                 else
                 {
+                    Sampler = Sampler ?? new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));
                     Sampler.RegisterRule(new GlobalSamplingRule(globalRate));
                 }
             }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -108,7 +108,7 @@ namespace SignalFx.Tracing
 
             if (!string.IsNullOrWhiteSpace(Settings.CustomSamplingRules))
             {
-                Sampler = Sampler ?? new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));
+                Sampler ??= new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));
 
                 // User has opted in, ensure rate limiter is used
                 RuleBasedSampler.OptInTracingWithoutLimits();
@@ -129,7 +129,7 @@ namespace SignalFx.Tracing
                 }
                 else
                 {
-                    Sampler = Sampler ?? new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));
+                    Sampler ??= new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));
                     Sampler.RegisterRule(new GlobalSamplingRule(globalRate));
                 }
             }


### PR DESCRIPTION
A low-risk and simple change to avoid allocations from the typical sampler usage: just avoiding creating and calling it on the typical case. We can look at removing the samplers since we go for high-fidelity but that will require a major version bump since it will remove some current capability (granted that I'm not aware of usage for it).
