### PR TITLE
Optimize default context propagation cases

### DIFF
--- a/src/Datadog.Trace.OpenTracing/HttpHeadersCodec.cs
+++ b/src/Datadog.Trace.OpenTracing/HttpHeadersCodec.cs
@@ -1,6 +1,5 @@
 // Modified by SignalFx
 using System;
-using System.Globalization;
 using OpenTracing.Propagation;
 using SignalFx.Tracing.Headers;
 using SignalFx.Tracing.Propagation;
@@ -9,7 +8,6 @@ namespace SignalFx.Tracing.OpenTracing
 {
     internal class HttpHeadersCodec : ICodec
     {
-        private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
         private readonly IPropagator _propagator;
 
         public HttpHeadersCodec(IPropagator propagator)

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -398,7 +398,7 @@ namespace SignalFx.Tracing.Configuration
 
         /// <summary>
         /// Gets or sets the propagator logic to be used.
-        /// Default is <c>Datadog</c>
+        /// Default is <c>B3</c>.
         /// <seealso cref="ConfigurationKeys.Propagator"/>
         /// </summary>
         public PropagatorType Propagator { get; set; }

--- a/src/Datadog.Trace/Propagation/B3SpanContextPropagator.cs
+++ b/src/Datadog.Trace/Propagation/B3SpanContextPropagator.cs
@@ -72,13 +72,13 @@ namespace SignalFx.Tracing.Propagation
                 return 0;
             }
 
-            var headerValues = enumerableHeaderValues.ToList();
-            if (headerValues.Count == 0)
+            var headerValues = enumerableHeaderValues.ToArray();
+            if (headerValues.Length == 0)
             {
                 return 0;
             }
 
-            for (var i = 0; i < headerValues.Count; ++i)
+            for (var i = 0; i < headerValues.Length; ++i)
             {
                 if (ulong.TryParse(headerValues[i], NumberStyle, InvariantCulture, out var result))
                 {
@@ -95,8 +95,8 @@ namespace SignalFx.Tracing.Propagation
             var enumerableDebugged = getter(carrier, B3HttpHeaderNames.B3Flags);
             if (enumerableDebugged != Enumerable.Empty<string>())
             {
-                var debugged = enumerableDebugged.ToList();
-                if (debugged.Count != 0 && (debugged[0] == "0" || debugged[0] == "1"))
+                var debugged = enumerableDebugged.ToArray();
+                if (debugged.Length != 0 && (debugged[0] == "0" || debugged[0] == "1"))
                 {
                     return debugged[0] == "1" ? SamplingPriority.UserKeep : (SamplingPriority?)null;
                 }
@@ -112,8 +112,8 @@ namespace SignalFx.Tracing.Propagation
             var enumerableSampled = getter(carrier, B3HttpHeaderNames.B3Sampled);
             if (enumerableSampled != Enumerable.Empty<string>())
             {
-                var sampled = enumerableSampled.ToList();
-                if (sampled.Count != 0 && (sampled[0] == "0" || sampled[0] == "1"))
+                var sampled = enumerableSampled.ToArray();
+                if (sampled.Length != 0 && (sampled[0] == "0" || sampled[0] == "1"))
                 {
                     return sampled[0] == "1" ? SamplingPriority.AutoKeep : SamplingPriority.AutoReject;
                 }

--- a/src/Datadog.Trace/Propagation/ContextPropagatorBuilder.cs
+++ b/src/Datadog.Trace/Propagation/ContextPropagatorBuilder.cs
@@ -1,29 +1,24 @@
 // Modified by SignalFx
 
 using System;
-using System.Collections.Generic;
 using SignalFx.Tracing.Configuration;
 
 namespace SignalFx.Tracing.Propagation
 {
     internal static class ContextPropagatorBuilder
     {
-        private static readonly IReadOnlyDictionary<PropagatorType, Func<IPropagator>> _propagatorSelector =
-            new Dictionary<PropagatorType, Func<IPropagator>>()
-            {
-                { PropagatorType.B3, () => new B3SpanContextPropagator() },
-                { PropagatorType.Default, () => new B3SpanContextPropagator() },
-                { PropagatorType.W3C, () => W3CSpanContextPropagator.Instance }
-            };
-
         public static IPropagator BuildPropagator(PropagatorType propagator)
         {
-            if (_propagatorSelector.TryGetValue(propagator, out var getter))
+            switch (propagator)
             {
-                return getter();
+                case PropagatorType.B3:
+                case PropagatorType.Default:
+                    return new B3SpanContextPropagator();
+                case PropagatorType.W3C:
+                    return W3CSpanContextPropagator.Instance;
+                default:
+                    throw new InvalidOperationException($"There is no propagator registered for type '{propagator}'");
             }
-
-            throw new InvalidOperationException($"There is no propagator registered for type '{propagator}'");
         }
     }
 }

--- a/src/Datadog.Trace/Propagation/PropagationExtensions.cs
+++ b/src/Datadog.Trace/Propagation/PropagationExtensions.cs
@@ -17,24 +17,6 @@ namespace SignalFx.Tracing.Propagation
             return propagator.Extract(headers, ExtractFromHeadersCollection);
         }
 
-        public static IEnumerable<KeyValuePair<string, string>> ExtractHeaderTags(this IHeadersCollection headers, IEnumerable<KeyValuePair<string, string>> headerToTagMap)
-        {
-            foreach (KeyValuePair<string, string> headerNameToTagName in headerToTagMap)
-            {
-                var headerValue = ParseString(headers, headerNameToTagName.Key);
-
-                if (headerValue != null)
-                {
-                    yield return new KeyValuePair<string, string>(headerNameToTagName.Value, headerValue);
-                }
-            }
-        }
-
-        public static string ParseString(this IHeadersCollection headers, string headerName)
-        {
-            return PropagationHelpers.ParseString(headers, (carrier, header) => carrier.GetValues(header), headerName);
-        }
-
         private static void InjectToHeadersCollection(IHeadersCollection carrier, string header, string value)
         {
             carrier.Set(header, value);

--- a/src/Datadog.Trace/Propagation/PropagationHelpers.cs
+++ b/src/Datadog.Trace/Propagation/PropagationHelpers.cs
@@ -15,13 +15,13 @@ namespace SignalFx.Tracing.Propagation
                 return TraceId.Zero;
             }
 
-            var headerValues = enumerableHeaderValues.ToList();
-            if (headerValues.Count == 0)
+            var headerValues = enumerableHeaderValues.ToArray();
+            if (headerValues.Length == 0)
             {
                 return TraceId.Zero;
             }
 
-            for (var i = 0; i < headerValues.Count; ++i)
+            for (var i = 0; i < headerValues.Length; ++i)
             {
                 var traceId = TraceId.CreateFromString(headerValues[i]);
                 if (traceId != TraceId.Zero)


### PR DESCRIPTION
Optimizing the default propagation using B3 by focusing on "common" cases:

1. Inbound request but no B3 headers: in this case bailout earlier avoiding allocations and logging on every attempt to extract - the big saving, in this case, are due to the removal of one log per "extract"
2. Inbound request with B3 headers: saving on allocations by removing "early" allocations and enumerator allocations (not a big save in speed in this case, but some memory allocation)

Original:

|   Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |----------:|----------:|----------:|-------:|------:|------:|----------:|
|     NoB3 | 18.678 us | 0.3681 us | 0.9825 us | 0.4578 |     - |     - |   1.88 KB |
| B3Header |  1.193 us | 0.0235 us | 0.0344 us | 0.2708 |     - |     - |   1.11 KB |

Optimized:

|   Method |       Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |-----------:|---------:|---------:|-------:|------:|------:|----------:|
|     NoB3 |   419.0 ns |  8.23 ns | 15.47 ns | 0.0801 |     - |     - |     336 B |
| B3Header | 1,003.6 ns | 19.72 ns | 35.55 ns | 0.1926 |     - |     - |     808 B |

