### PR TITLE
Speed-up span Id generation

### DIFF
--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -56,7 +56,7 @@ namespace SignalFx.Tracing
 
             if (SpanId == 0)
             {
-                SpanId = GenerateId();
+                SpanId = RandomNumberGenerator.Current.Next();
             }
         }
 
@@ -70,7 +70,7 @@ namespace SignalFx.Tracing
             }
 
             TraceId = TraceId.CreateRandom();
-            SpanId = GenerateId();
+            SpanId = RandomNumberGenerator.Current.Next();
         }
 
         /// <summary>
@@ -119,13 +119,5 @@ namespace SignalFx.Tracing
         /// Gets or sets the span associated with this context.
         /// </summary>
         internal ISpan Span { get; set; }
-
-        private static ulong GenerateId()
-        {
-            var guidBytes = Guid.NewGuid().ToByteArray();
-
-            // Remove the fixed byte from the GUID in order to have all 64 bits random.
-            return (BitConverter.ToUInt64(guidBytes, 8) & 0xffffffffffffff00) | guidBytes[0];
-        }
     }
 }


### PR DESCRIPTION
Use the RandomNumberGenerator.Next instead of Guid.New to generate span Ids. Besides saving the allocation of the array Guid.New is pretty slow on Linux.

Linux:
|     Method |        Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |------------:|----------:|----------:|-------:|------:|------:|----------:|
|     NextId |    12.52 ns |  0.317 ns |  0.900 ns |      - |     - |     - |         - |
| GenerateId | 1,611.62 ns | 31.538 ns | 30.975 ns | 0.0095 |     - |     - |      40 B |

Windows:
|     Method |      Mean |     Error |    StdDev |    Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |----------:|----------:|----------:|----------:|-------:|------:|------:|----------:|
|     NextId |  9.495 ns | 0.2111 ns | 0.4498 ns |  9.481 ns |      - |     - |     - |         - |
| GenerateId | 80.733 ns | 1.6216 ns | 4.2718 ns | 79.465 ns | 0.0095 |     - |     - |      40 B |
