### PR TITLE
2 tiny optimizations: most spans have tags and avoid allocating Stopwatch

### DIFF
--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -155,7 +155,7 @@ namespace SignalFx.Tracing.Agent
             {
                 get
                 {
-                    if (_span.Logs.Count == 0)
+                    if (!_span.HasLogs || _span.Logs.Count == 0)
                     {
                         return emptyAnnotations;
                     }

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -21,7 +21,7 @@ namespace SignalFx.Tracing.Agent
 
         public static IDictionary<string, string> BuildTags(Span span, TracerSettings settings)
         {
-            var tags = new Dictionary<string, string>();
+            var tags = new Dictionary<string, string>(span.Tags.Count);
             var recordedValueMaxLength = settings.RecordedValueMaxLength;
             foreach (var entry in span.Tags)
             {
@@ -96,7 +96,7 @@ namespace SignalFx.Tracing.Agent
             {
                 _span = span;
                 _settings = settings;
-                _tags = span.Tags != null ? BuildTags(span, settings) : emptyTags;
+                _tags = span.Tags.Count > 0 ? BuildTags(span, settings) : emptyTags;
             }
 
             public string Id
@@ -202,7 +202,7 @@ namespace SignalFx.Tracing.Agent
 
             public bool ShouldSerializeKind()
             {
-                return _span.Tags != null && _span.Tags.ContainsKey(Tracing.Tags.SpanKind);
+                return _span.Tags.ContainsKey(Tracing.Tags.SpanKind);
             }
         }
     }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -25,6 +25,8 @@ namespace SignalFx.Tracing
 
         private readonly object _lock = new object();
         private readonly object _tagsLock = new object();
+        private readonly Lazy<ConcurrentDictionary<DateTimeOffset, Dictionary<string, string>>> _lazyLogs =
+            new Lazy<ConcurrentDictionary<DateTimeOffset, Dictionary<string, string>>>();
 
         internal Span(SpanContext context, DateTimeOffset? start)
         {
@@ -33,11 +35,14 @@ namespace SignalFx.Tracing
             ServiceName = context.ServiceName;
             StartTime = start ?? Context.TraceContext.UtcNow;
 
-            Logger.Debug(
-                "Span started: [s_id: {0}, p_id: {1}, t_id: {2}]",
-                SpanId,
-                Context.ParentId,
-                TraceId);
+            if (IsLogLevelDebugEnabled)
+            {
+                Logger.Debug(
+                    "Span started: [s_id: {0}, p_id: {1}, t_id: {2}]",
+                    SpanId,
+                    Context.ParentId,
+                    TraceId);
+            }
         }
 
         /// <summary>
@@ -87,11 +92,11 @@ namespace SignalFx.Tracing
 
         internal TimeSpan Duration { get; private set; }
 
-        internal Dictionary<string, string> Tags { get; private set; }
+        internal IDictionary<string, string> Tags { get; } = new Dictionary<string, string>(16);
 
         internal Dictionary<string, double> Metrics { get; private set; }
 
-        internal ConcurrentDictionary<DateTimeOffset, Dictionary<string, string>> Logs { get; } = new ConcurrentDictionary<DateTimeOffset, Dictionary<string, string>>();
+        internal ConcurrentDictionary<DateTimeOffset, Dictionary<string, string>> Logs => _lazyLogs.Value;
 
         internal bool IsFinished { get; private set; }
 
@@ -118,7 +123,7 @@ namespace SignalFx.Tracing
             sb.AppendLine($"Error: {Error}");
             sb.AppendLine("Meta:");
 
-            if (Tags?.Count > 0)
+            if (Tags.Count > 0)
             {
                 // lock because we're iterating the collection, not reading a single value
                 lock (_tagsLock)
@@ -192,15 +197,12 @@ namespace SignalFx.Tracing
                 default:
                     if (value == null)
                     {
-                        if (Tags != null)
+                        // lock when modifying the collection
+                        lock (_tagsLock)
                         {
-                            // lock when modifying the collection
-                            lock (_tagsLock)
-                            {
-                                // Agent doesn't accept null tag values,
-                                // remove them instead
-                                Tags.Remove(key);
-                            }
+                            // Agent doesn't accept null tag values,
+                            // remove them instead
+                            Tags.Remove(key);
                         }
                     }
                     else
@@ -208,13 +210,6 @@ namespace SignalFx.Tracing
                         // lock when modifying the collection
                         lock (_tagsLock)
                         {
-                            if (Tags == null)
-                            {
-                                // defer instantiation until needed to
-                                // avoid unnecessary allocations per span
-                                Tags = new Dictionary<string, string>();
-                            }
-
                             // if not a special tag, just add it to the tag bag
                             Tags[key] = value;
                         }
@@ -347,7 +342,7 @@ namespace SignalFx.Tracing
                         ServiceName,
                         ResourceName,
                         OperationName,
-                        Tags == null ? string.Empty : string.Join(",", Tags.Keys));
+                        Tags.Count == 0 ? string.Empty : string.Join(",", Tags.Keys));
                 }
             }
         }
@@ -393,7 +388,7 @@ namespace SignalFx.Tracing
         public string GetTag(string key)
         {
             // no need to lock on single reads
-            return Tags != null && Tags.TryGetValue(key, out var value) ? value : null;
+            return Tags.TryGetValue(key, out var value) ? value : null;
         }
 
         internal bool SetExceptionForFilter(Exception exception)

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -98,6 +98,8 @@ namespace SignalFx.Tracing
 
         internal ConcurrentDictionary<DateTimeOffset, Dictionary<string, string>> Logs => _lazyLogs.Value;
 
+        internal bool HasLogs => _lazyLogs.IsValueCreated;
+
         internal bool IsFinished { get; private set; }
 
         internal bool IsRootSpan => Context?.TraceContext?.RootSpan == this;
@@ -135,13 +137,16 @@ namespace SignalFx.Tracing
                 }
             }
 
-            sb.AppendLine("Logs:");
-            foreach (var e in Logs)
+            if (_lazyLogs.IsValueCreated)
             {
-                sb.Append($"\t{e.Key}:\n");
-                foreach (var kv in e.Value)
+                sb.AppendLine("Logs:");
+                foreach (var e in Logs)
                 {
-                    sb.Append($"\t\t{kv.Key}:{kv.Value}\n");
+                    sb.Append($"\t{e.Key}:\n");
+                    foreach (var kv in e.Value)
+                    {
+                        sb.Append($"\t\t{kv.Key}:{kv.Value}\n");
+                    }
                 }
             }
 

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -92,7 +92,7 @@ namespace SignalFx.Tracing
 
         internal TimeSpan Duration { get; private set; }
 
-        internal IDictionary<string, string> Tags { get; } = new Dictionary<string, string>(16);
+        internal Dictionary<string, string> Tags { get; } = new Dictionary<string, string>(16);
 
         internal Dictionary<string, double> Metrics { get; private set; }
 

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -13,7 +13,7 @@ namespace SignalFx.Tracing
         private static readonly Tracing.SamplingPriority? DefaultSamplingPriority = new Tracing.SamplingPriority?(Tracing.SamplingPriority.AutoKeep);
 
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
-        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private readonly long _startTimestamp = Stopwatch.GetTimestamp();
         private readonly List<Span> _spans = new List<Span>();
 
         private int _openSpans;
@@ -27,7 +27,7 @@ namespace SignalFx.Tracing
 
         public Span RootSpan { get; private set; }
 
-        public DateTimeOffset UtcNow => _utcStart.Add(_stopwatch.Elapsed);
+        public DateTimeOffset UtcNow => _utcStart.AddTicks(Stopwatch.GetTimestamp() - _startTimestamp);
 
         public ISignalFxTracer Tracer { get; }
 

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -11,6 +11,7 @@ namespace SignalFx.Tracing
     {
         private static readonly SignalFx.Tracing.Vendors.Serilog.ILogger Log = SignalFxLogging.For<TraceContext>();
         private static readonly Tracing.SamplingPriority? DefaultSamplingPriority = new Tracing.SamplingPriority?(Tracing.SamplingPriority.AutoKeep);
+        private static readonly double TickFrequency = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
 
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
         private readonly long _startTimestamp = Stopwatch.GetTimestamp();
@@ -27,7 +28,7 @@ namespace SignalFx.Tracing
 
         public Span RootSpan { get; private set; }
 
-        public DateTimeOffset UtcNow => _utcStart.AddTicks(Stopwatch.GetTimestamp() - _startTimestamp);
+        public DateTimeOffset UtcNow => _utcStart.AddTicks((long)((Stopwatch.GetTimestamp() - _startTimestamp) * TickFrequency));
 
         public ISignalFxTracer Tracer { get; }
 

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -131,7 +131,7 @@ namespace Datadog.Trace.IntegrationTests
                 Assert.Contains(scope1.Span.Tags, kvp => kvp.Key == Tags.Version && kvp.Value == TracerConstants.AssemblyVersion);
 
                 // Child spans should not have root spans tags.
-                Assert.Null(scope2.Span.Tags);
+                Assert.Empty(scope2.Span.Tags);
             }
         }
 

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -51,18 +51,18 @@ namespace Datadog.Trace.OpenTracing.Tests
             ISpan span = GetScope("Op1").Span;
 
             span.Log("Some Event");
-            Thread.Sleep(TimeSpan.FromMilliseconds(15));
+            WaitForTimestampChange(span);
 
             var doubleDict = new Dictionary<string, object>() { { "event name", 123.45 } };
             span.Log(doubleDict);
-            Thread.Sleep(TimeSpan.FromMilliseconds(15));
+            WaitForTimestampChange(span);
 
             var ex = new Exception("Some Exception");
             var exDict = new Dictionary<string, object>() { { "another event name", ex } };
             span.Log(exDict);
-            Thread.Sleep(TimeSpan.FromMilliseconds(15));
+            WaitForTimestampChange(span);
 
-            var now = DateTime.UtcNow.AddMilliseconds(1); // Add 1 msec to ensure different time than calls above.
+            var now = ((OpenTracingSpan)span).Span.Context.TraceContext.UtcNow.AddMilliseconds(1); // Add 1 msec to ensure different time than calls above.
             var then = now.AddMilliseconds(2); // TODO: currently if Log receives same timestamp previous are overwritten.
             span.Log(now, "Another Event");
             span.Log(then, exDict);
@@ -179,6 +179,19 @@ namespace Datadog.Trace.OpenTracing.Tests
             }
 
             return spanBuilder.StartActive(finishSpanOnDispose: true);
+        }
+
+        private void WaitForTimestampChange(ISpan otSpan)
+        {
+            ITraceContext traceContext = ((OpenTracingSpan)otSpan).Span.Context.TraceContext;
+            DateTimeOffset prevTimestamp = traceContext.UtcNow;
+            DateTimeOffset currTimestamp = DateTimeOffset.MinValue;
+            do
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(1));
+                currTimestamp = traceContext.UtcNow;
+            }
+            while (currTimestamp.Subtract(prevTimestamp) < TimeSpan.FromMilliseconds(1));
         }
     }
 }

--- a/win-integration-tests.cmd
+++ b/win-integration-tests.cmd
@@ -24,10 +24,10 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 msbuild Datadog.Trace.proj /t:BuildFrameworkReproductions /p:Configuration=%buildConfiguration%;Platform=%buildPlatform%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-for /f %%i in ('dir /s/b %publishOutput%\net45\*.dll') do  (
-    gacutil /i %%i /f
-    if !errorlevel! neq 0 exit /b !errorlevel!
-)
+@REM for /f %%i in ('dir /s/b %publishOutput%\net45\*.dll') do  (
+@REM     gacutil /i %%i /f
+@REM     if !errorlevel! neq 0 exit /b !errorlevel!
+@REM )
 
 for /f %%i in ('dir /s/b .\samples\*.csproj') do  (
     dotnet build --configuration %buildConfiguration% -p:Platform=%buildPlatform% -p:ManagedProfilerOutputDirectory=%publishOutput% %%i

--- a/win-integration-tests.cmd
+++ b/win-integration-tests.cmd
@@ -24,10 +24,10 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 msbuild Datadog.Trace.proj /t:BuildFrameworkReproductions /p:Configuration=%buildConfiguration%;Platform=%buildPlatform%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-@REM for /f %%i in ('dir /s/b %publishOutput%\net45\*.dll') do  (
-@REM     gacutil /i %%i /f
-@REM     if !errorlevel! neq 0 exit /b !errorlevel!
-@REM )
+for /f %%i in ('dir /s/b %publishOutput%\net45\*.dll') do  (
+    gacutil /i %%i /f
+    if !errorlevel! neq 0 exit /b !errorlevel!
+)
 
 for /f %%i in ('dir /s/b .\samples\*.csproj') do  (
     dotnet build --configuration %buildConfiguration% -p:Platform=%buildPlatform% -p:ManagedProfilerOutputDirectory=%publishOutput% %%i


### PR DESCRIPTION
1. Most spans have Tags but not Logs: optimize for this case allocate a Dictionary with capacity that avoids re-sizing for most of the cases and only allocate Logs if it is actually used.
2. Use the timestamp directly instead of the the Stopwatch since the later is a reference type.