### PR TITLE
Avoid race on mock zipkin and increase test port range

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -186,30 +186,38 @@ namespace Datadog.Trace.TestHelpers
                     var getCtxTask = Task.Run(() => _listener.GetContext());
                     getCtxTask.Wait(_listenerCts.Token);
 
-                    var ctx = getCtxTask.Result;
-                    OnRequestReceived(ctx);
-
-                    if (ShouldDeserializeTraces)
+                    lock (_listener)
                     {
-                        using (var reader = new StreamReader(ctx.Request.InputStream))
+                        if (!_listener.IsListening)
                         {
-                            var zspans = JsonConvert.DeserializeObject<List<Span>>(reader.ReadToEnd());
-                            if (zspans != null)
-                            {
-                                IList<IMockSpan> spans = (IList<IMockSpan>)zspans.ConvertAll(x => (IMockSpan)x);
-                                OnRequestDeserialized(spans);
-
-                                Spans = Spans.AddRange(spans);
-                            }
-
-                            RequestHeaders = RequestHeaders.Add(new NameValueCollection(ctx.Request.Headers));
+                            return;
                         }
-                    }
 
-                    ctx.Response.ContentType = "application/json";
-                    var buffer = Encoding.UTF8.GetBytes("{}");
-                    ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
-                    ctx.Response.Close();
+                        var ctx = getCtxTask.Result;
+                        OnRequestReceived(ctx);
+
+                        if (ShouldDeserializeTraces)
+                        {
+                            using (var reader = new StreamReader(ctx.Request.InputStream))
+                            {
+                                var zspans = JsonConvert.DeserializeObject<List<Span>>(reader.ReadToEnd());
+                                if (zspans != null)
+                                {
+                                    IList<IMockSpan> spans = (IList<IMockSpan>)zspans.ConvertAll(x => (IMockSpan)x);
+                                    OnRequestDeserialized(spans);
+
+                                    Spans = Spans.AddRange(spans);
+                                }
+
+                                RequestHeaders = RequestHeaders.Add(new NameValueCollection(ctx.Request.Headers));
+                            }
+                        }
+
+                        ctx.Response.ContentType = "application/json";
+                        var buffer = Encoding.UTF8.GetBytes("{}");
+                        ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                        ctx.Response.Close();
+                    }
                 }
                 catch (Exception ex) when (ex is HttpListenerException || ex is OperationCanceledException || ex is AggregateException)
                 {

--- a/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
+++ b/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
@@ -55,10 +55,11 @@ namespace Datadog.Trace.TestHelpers
 
         private static int GetStartingPort()
         {
-            // pick a starting port from the ephemeral port range (49152 – 65535),
+            // pick a low starting port from the port range since the use of process id and thread id can make
+            // the range very limited.
             // use process and threads ids to try to get different ports for each thread.
             // https://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode
-            const int startPort = 49152;
+            const int startPort = 4000;
             const int endPort = 65535;
             const int poolSize = endPort - startPort;
             int hash = 17;


### PR DESCRIPTION
There is a race on MockZipkinCollector that cause frequent CI crashes. Also the port range gets very limited depending on the process and thread ID, trying to avoid that by starting with low port value, thus increasing the port range used by the tests.