### PR TITLE
Enable integration tests for any branch

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -1,8 +1,9 @@
-trigger: none
-pr:
+trigger:
   branches:
     include:
-      - main
+      - '*'
+    exclude:
+      - refs/pull/*/head
   paths:
     exclude:
       - docs/*


### PR DESCRIPTION
## Why

The current build pipeline was running integration tests only on PRs that were targeting the `main` branch. It may be handy to run it on any branch.

## What

Trigger integration tests on each "non-PR" branch.