### PR TITLE
Instrument SqlCommand ExecuteXmlReader and ExecuteXmlReaderAsync

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- 
+- Support for .NET 5.0
+- New instrumentations for SqlCommand: ExecuteXmlReader and ExecuteXmlReaderAsync methods
 
 [Commits](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.11...HEAD)
 

--- a/integrations.json
+++ b/integrations.json
@@ -1383,6 +1383,104 @@
         "target": {
           "assembly": "System.Data",
           "type": "System.Data.SqlClient.SqlCommand",
+          "method": "ExecuteXmlReader",
+          "signature_types": [
+            "System.Xml.XmlReader"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
+          "method": "ExecuteXmlReader",
+          "signature": "00 04 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.SqlClient",
+          "type": "System.Data.SqlClient.SqlCommand",
+          "method": "ExecuteXmlReader",
+          "signature_types": [
+            "System.Xml.XmlReader"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
+          "method": "ExecuteXmlReader",
+          "signature": "00 04 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.SqlClient.SqlCommand",
+          "method": "ExecuteXmlReaderAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Xml.XmlReader>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
+          "method": "ExecuteXmlReaderAsync",
+          "signature": "00 05 1C 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.SqlClient",
+          "type": "System.Data.SqlClient.SqlCommand",
+          "method": "ExecuteXmlReaderAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Xml.XmlReader>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
+          "method": "ExecuteXmlReaderAsync",
+          "signature": "00 05 1C 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.SqlClient.SqlCommand",
           "method": "ExecuteReader",
           "signature_types": [
             "System.Data.SqlClient.SqlDataReader"

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -17,6 +17,12 @@ namespace Samples.SqlServer
             {
                 using (var connection = CreateConnection())
                 {
+                    var xmlQueries = new SqlClientXmlQueries(connection);
+                    await xmlQueries.RunAsync().ConfigureAwait(false);
+                }
+
+                using (var connection = CreateConnection())
+                {
                     var testQueries = new RelationalDatabaseTestHarness<SqlConnection, SqlCommand, SqlDataReader>(
                         connection,
                         command => command.ExecuteNonQuery(),

--- a/samples/Samples.SqlServer/SqlClientXmlQueries.cs
+++ b/samples/Samples.SqlServer/SqlClientXmlQueries.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using SignalFx.Tracing;
+
+namespace Samples.SqlServer
+{
+    public class SqlClientXmlQueries
+    {
+        private const string DropAndCreateCommandText =
+            "DROP TABLE IF EXISTS Cities; CREATE TABLE Cities (Id int PRIMARY KEY, Name varchar(100));";
+        private const string InsertCommandText =
+            "INSERT INTO Cities (Id, Name) VALUES (0, 'Seattle');INSERT INTO Cities (Id, Name) VALUES (1, 'Renton');";
+        private const string SelectXmlCommandText =
+            "SELECT * FROM Cities FOR XML AUTO, XMLDATA;";
+
+        private readonly IDbConnection _connection;
+
+        public SqlClientXmlQueries(IDbConnection connection)
+        {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        }
+
+        public async Task RunAsync()
+        {
+            using (var scopeAll = Tracer.Instance.StartActive("sql.client.xml"))
+            {
+                scopeAll.Span.SetTag("command-type", typeof(SqlCommand).FullName);
+
+                _connection.Open();
+                SetupTableForXmlQueries(_connection);
+                SelectXml(_connection);
+                await SelectXmlAsync(_connection).ConfigureAwait(false);
+                _connection.Close();
+            }
+        }
+
+        private static void SetupTableForXmlQueries(IDbConnection connection)
+        {
+            using (var command = (SqlCommand)connection.CreateCommand())
+            {
+                command.CommandText = DropAndCreateCommandText;
+
+                int records = command.ExecuteNonQuery();
+                Console.WriteLine($"Dropped and recreated table for XML queries. {records} record(s) affected.");
+
+                command.CommandText = InsertCommandText;
+                records = command.ExecuteNonQuery();
+                Console.WriteLine($"Inserted {records} record(s).");
+            }
+        }
+
+        private static void SelectXml(IDbConnection connection)
+        {
+            using (var command = (SqlCommand)connection.CreateCommand())
+            {
+                command.CommandText = SelectXmlCommandText;
+                var xmlReader = command.ExecuteXmlReader();
+                Console.WriteLine("Selected XML data synchronously: " + XmlReaderToString(xmlReader));
+            }
+        }
+
+        private static async Task SelectXmlAsync(IDbConnection connection)
+        {
+            using (var command = (SqlCommand)connection.CreateCommand())
+            {
+                command.CommandText = SelectXmlCommandText;
+                var xmlReader = await command.ExecuteXmlReaderAsync().ConfigureAwait(false);
+                Console.WriteLine("Selected XML data asynchronously: " + XmlReaderToString(xmlReader));
+            }
+        }
+
+        private static string XmlReaderToString(XmlReader xmlReader)
+        {
+            var sb = new StringBuilder();
+            while (xmlReader.Read())
+            {
+                sb.Append(xmlReader.ReadOuterXml());
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("RunOnWindows", "True")]
         public void SubmitsTraces(string packageVersion)
         {
-            const int expectedSpanCount = 35;
+            const int expectedSpanCount = 39;
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.SqlServer";


### PR DESCRIPTION
Add instrumentation to two SqlCommand methods: ExecuteXmlReader and ExecuteXmlReaderAsync. This was a gap for SqlCommand in which all other command execution paths were covered except for these 2.