### PR TITLE
Update version to v0.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 # First install the package. This example downloads the latest version
 # alternatively download a specific version or use a local copy.
-ARG TRACER_VERSION=0.1.11
+ARG TRACER_VERSION=0.1.12
 ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
 RUN dpkg -i /signalfx-package/signalfx-dotnet-tracing.deb
 RUN rm -rf /signalfx-package

--- a/customer-samples/ConsoleApp/Alpine3.10.dockerfile
+++ b/customer-samples/ConsoleApp/Alpine3.10.dockerfile
@@ -17,7 +17,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=0.1.11
+ARG TRACER_VERSION=0.1.12
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/customer-samples/ConsoleApp/Alpine3.9.dockerfile
+++ b/customer-samples/ConsoleApp/Alpine3.9.dockerfile
@@ -17,7 +17,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=0.1.11
+ARG TRACER_VERSION=0.1.12
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/customer-samples/ConsoleApp/Debian.dockerfile
+++ b/customer-samples/ConsoleApp/Debian.dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Set up Datadog APM
-ARG TRACER_VERSION=0.1.11
+ARG TRACER_VERSION=0.1.12
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb

--- a/deploy/Azure.Site.Extension/Azure.Site.Extension.nuspec
+++ b/deploy/Azure.Site.Extension/Azure.Site.Extension.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>SignalFx.NET.Tracing.Azure.Site.Extension</id>
-    <version>0.1.11.0</version>
+    <version>0.1.12.0</version>
     <title>SignalFx .NET Tracing [PreRelease]</title>
     <authors>SignalFx</authors>
     <icon>icon.png</icon>

--- a/deploy/Azure.Site.Extension/applicationHost.xdt
+++ b/deploy/Azure.Site.Extension/applicationHost.xdt
@@ -26,18 +26,18 @@
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.1.11\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.11\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.11\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.1.12\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.12\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.12\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.11\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.11\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.12\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.12\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
-        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.1.11" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.1.11\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.1.11\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.1.12" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.1.12\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.1.12\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
       </environmentVariables>

--- a/deploy/Azure.Site.Extension/install.cmd
+++ b/deploy/Azure.Site.Extension/install.cmd
@@ -8,7 +8,7 @@ echo Extension directory is %extensionBaseDir%
 echo Site root directory is %siteHome%
 
 REM Create version specific tracer directory
-SET tracerDir=%siteHome%\signalfx\tracing\v0.1.11
+SET tracerDir=%siteHome%\signalfx\tracing\v0.1.12
 if not exist %tracerDir% mkdir %tracerDir%
 
 REM Copy tracer to version specific directory

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -15,11 +15,11 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>signalfx-dotnet-tracing-0.1.11-$(Platform)</OutputName>
+    <OutputName>signalfx-dotnet-tracing-0.1.12-$(Platform)</OutputName>
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>InstallerVersion=0.1.11</DefineConstants>
+    <DefineConstants>InstallerVersion=0.1.12</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/deployments/cloudfoundry/buildpack-linux/README.md
+++ b/deployments/cloudfoundry/buildpack-linux/README.md
@@ -42,5 +42,5 @@ If you want to use a specific version of the tracing library in your application
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.11"
+$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.12"
 ```

--- a/deployments/cloudfoundry/buildpack-linux/bin/supply
+++ b/deployments/cloudfoundry/buildpack-linux/bin/supply
@@ -7,7 +7,7 @@ from urllib.request import build_opener, HTTPRedirectHandler
 from tarfile import TarFile
 
 # Please don't change the formatting of this line - it's automatically updated by SetAllVersions.cs
-LATEST_VERSION = "0.1.11"
+LATEST_VERSION = "0.1.12"
 DOTNET_AGENT_VERSION = ENV.get("SIGNALFX_DOTNET_TRACING_VERSION", default=LATEST_VERSION)
 DOTNET_AGENT_ARCHIVE_NAME=f"signalfx-dotnet-tracing-{DOTNET_AGENT_VERSION}.tar.gz"
 DOTNET_AGENT_URL=f"https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v{DOTNET_AGENT_VERSION}/{DOTNET_AGENT_ARCHIVE_NAME}"

--- a/deployments/cloudfoundry/buildpack-windows/README.md
+++ b/deployments/cloudfoundry/buildpack-windows/README.md
@@ -50,7 +50,7 @@ If you want to use a specific version of the tracing library in your application
 environment variable before application deployment, either using `cf set-env` or the `manifest.yml` file:
 
 ```sh
-$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.11"
+$ cf set-env SIGNALFX_DOTNET_TRACING_VERSION "0.1.12"
 ```
 
 If you want to use this buildpack in a .NET Framework application deployment you have to enable HWC support by setting the `SIGNALFX_USE_HWC` environment variable to `true` either using `cf set-env` or the `manifest.yml` file:

--- a/deployments/cloudfoundry/buildpack-windows/src/supply/supply.go
+++ b/deployments/cloudfoundry/buildpack-windows/src/supply/supply.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Please don't change the formatting of this line - it's automatically updated by SetAllVersions.cs
-const LatestVersion = "0.1.11"
+const LatestVersion = "0.1.12"
 
 func getAgentVersion() string {
 	version, ok := os.LookupEnv("SIGNALFX_DOTNET_TRACING_VERSION")

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-VERSION=0.1.11
+VERSION=0.1.12
 
 mkdir -p $DIR/../deploy/linux
 for target in integrations.json defaults.env LICENSE NOTICE createLogPath.sh ; do

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ## [Unreleased]
 
+[Commits](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.12...HEAD)
+
+[Full diff](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.12..HEAD)
+
+## [Release 0.1.12](https://github.com/signalfx/signalfx-dotnet-tracing/releases/tag/v0.1.12)
+
 - Support for .NET 5.0
+- Added Confluent.Kafka instrumentation for IConsumer.Consume, IProducer.Produce, and IProducer.ProduceAsync
 - New instrumentations for SqlCommand: ExecuteXmlReader and ExecuteXmlReaderAsync methods
 
-[Commits](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.11...HEAD)
+[Commits](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.11...v0.1.12)
 
-[Full diff](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.11..HEAD)
+[Full diff](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.11..v0.1.12)
 
 ## [Release 0.1.11](https://github.com/signalfx/signalfx-dotnet-tracing/releases/tag/v0.1.11)
 

--- a/integrations.json
+++ b/integrations.json
@@ -25,7 +25,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "BeginInvokeAction",
           "signature": "00 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -52,7 +52,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "EndInvokeAction",
           "signature": "00 05 02 1C 1C 08 08 0A",
@@ -83,7 +83,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
           "method": "ExecuteAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -113,7 +113,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Kafka.ConsumeKafkaIntegration",
           "method": "ConsumeInt32",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -138,7 +138,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Kafka.ConsumeKafkaIntegration",
           "method": "ConsumeCancellationToken",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -163,7 +163,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Kafka.ConsumeKafkaIntegration",
           "method": "ConsumeTimeSpan",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -192,7 +192,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -216,7 +216,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -241,7 +241,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -266,7 +266,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -292,7 +292,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -318,7 +318,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -342,7 +342,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -366,7 +366,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -391,7 +391,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -416,7 +416,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -440,7 +440,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -464,7 +464,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -489,7 +489,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -514,7 +514,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.DbCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -546,7 +546,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearch",
           "signature": "10 01 05 1C 1C 1C 08 08 0A",
@@ -574,7 +574,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearchAsync",
           "signature": "10 01 06 1C 1C 1C 1C 08 08 0A",
@@ -606,7 +606,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearch",
           "signature": "10 01 05 1C 1C 1C 08 08 0A",
@@ -634,7 +634,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearchAsync",
           "signature": "10 01 06 1C 1C 1C 1C 08 08 0A",
@@ -669,7 +669,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "Validate",
           "signature": "00 0A 1C 1C 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -694,7 +694,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "ExecuteAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -725,7 +725,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpMessageHandler_SendAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -751,7 +751,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpClientHandler_SendAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -780,7 +780,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -804,7 +804,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -828,7 +828,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -853,7 +853,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -878,7 +878,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -903,7 +903,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -927,7 +927,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -951,7 +951,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -975,7 +975,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -999,7 +999,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1023,7 +1023,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1047,7 +1047,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1078,7 +1078,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1104,7 +1104,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteGeneric",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1130,7 +1130,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1156,7 +1156,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsyncGeneric",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
@@ -1185,7 +1185,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1210,7 +1210,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1235,7 +1235,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1261,7 +1261,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderAsyncTwoParams",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1285,7 +1285,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1310,7 +1310,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1334,7 +1334,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1359,7 +1359,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1384,7 +1384,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1411,7 +1411,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.OpenTracingIntegration",
           "method": "NoopWithoutMatchingMethod",
           "signature": "00 03 1C 08 08 0A",
@@ -1443,7 +1443,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Kafka.ProduceKafkaIntegration",
           "method": "ProduceWithTopicPartitionTopic",
           "signature": "00 07 01 1C 1C 1C 1C 08 08 0A",
@@ -1470,7 +1470,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Kafka.ProduceKafkaIntegration",
           "method": "ProduceWithStringTopic",
           "signature": "00 07 01 1C 1C 1C 1C 08 08 0A",
@@ -1497,7 +1497,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Kafka.ProduceKafkaIntegration",
           "method": "ProduceAsyncTopicPartitionTopic",
           "signature": "00 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -1524,7 +1524,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Kafka.ProduceKafkaIntegration",
           "method": "ProduceAsyncWithStringTopic",
           "signature": "00 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -1559,7 +1559,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ServiceStackRedisIntegration",
           "method": "SendReceive",
           "signature": "10 01 08 1E 00 1C 1D 1D 05 1C 1C 02 08 08 0A",
@@ -1588,7 +1588,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteXmlReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1612,7 +1612,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteXmlReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1637,7 +1637,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteXmlReaderAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1662,7 +1662,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteXmlReaderAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1686,7 +1686,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1710,7 +1710,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReader",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1735,7 +1735,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1760,7 +1760,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A",
@@ -1786,7 +1786,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1812,7 +1812,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteReaderAsync",
           "signature": "00 06 1C 1C 08 1C 08 08 0A",
@@ -1836,7 +1836,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1860,7 +1860,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A",
@@ -1885,7 +1885,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1910,7 +1910,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteNonQueryAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -1934,7 +1934,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1958,7 +1958,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -1983,7 +1983,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -2008,7 +2008,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.SqlCommandIntegration",
           "method": "ExecuteScalarAsync",
           "signature": "00 05 1C 1C 1C 08 08 0A",
@@ -2042,7 +2042,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A",
@@ -2071,7 +2071,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A",
@@ -2101,7 +2101,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -2131,7 +2131,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A",
@@ -2160,7 +2160,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
           "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -2189,7 +2189,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
           "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A",
@@ -2220,7 +2220,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WcfIntegration",
           "method": "HandleRequest",
           "signature": "00 06 02 1C 1C 1C 08 08 0A",
@@ -2249,7 +2249,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetRequestStream",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2273,7 +2273,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetRequestStream",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2297,7 +2297,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2321,7 +2321,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2345,7 +2345,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -2369,7 +2369,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
           "signature": "00 04 1C 1C 08 08 0A",

--- a/reproductions/AutomapperTest/Dockerfile
+++ b/reproductions/AutomapperTest/Dockerfile
@@ -1,6 +1,6 @@
 # Modified by SignalFx
 FROM mcr.microsoft.com/dotnet/core/runtime:2.1-stretch-slim AS base
-ARG TRACER_VERSION=0.1.11
+ARG TRACER_VERSION=0.1.12
 RUN mkdir -p /opt/datadog
 RUN mkdir -p /var/log/signalfx/dotnet
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v$TRACER_VERSION/datadog-dotnet-apm-$TRACER_VERSION.tar.gz | tar xzf - -C /opt/datadog

--- a/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net45</TargetFrameworks>
 
     <!-- NuGet -->
-    <Version>0.1.11</Version>
+    <Version>0.1.12</Version>
     <Title>SignalFx Tracing for ASP.NET</Title>
     <AssemblyName>SignalFx.Tracing.AspNet</AssemblyName>
     <PackageDescription>

--- a/src/Datadog.Trace.ClrProfiler.Managed.Core/Datadog.Trace.ClrProfiler.Managed.Core.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Core/Datadog.Trace.ClrProfiler.Managed.Core.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>SignalFx.Tracing.ClrProfiler.Managed.Core</AssemblyName>
 
     <!-- NuGet -->
-    <Version>0.1.11</Version>
+    <Version>0.1.12</Version>
     <IsPackable>false</IsPackable>
 
     <!-- Allow the GenerateAssemblyInfo task in the .NET SDK to generate all

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -8,7 +8,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>0.1.11</Version>
+    <Version>0.1.12</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         {
             try
             {
-                var assembly = Assembly.Load("SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+                var assembly = Assembly.Load("SignalFx.Tracing.ClrProfiler.Managed, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
                 if (assembly != null)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>SignalFx.Tracing.ClrProfiler.Managed</AssemblyName>
 
     <!-- NuGet -->
-    <Version>0.1.11</Version>
+    <Version>0.1.12</Version>
     <Title>Datadog APM - ClrProfiler</Title>
     <PackageDescription>
 DEPRECATED. This package exists only for backwards compatibility. If your project references this package ("Datadog.Trace.ClrProfiler.Managed") or "Datadog.Trace.AspNet", you can remove them both.

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required (VERSION 3.8)
 cmake_policy(SET CMP0015 NEW)
 
-project("Datadog.Trace.ClrProfiler.Native" VERSION 0.1.11)
+project("Datadog.Trace.ClrProfiler.Native" VERSION 0.1.12)
 
 add_compile_options(-std=c++11 -fPIC -fms-extensions)
 add_compile_options(-DBIT64 -DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)

--- a/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,1,11,0
- PRODUCTVERSION 0,1,11,0
+ FILEVERSION 0,1,12,0
+ PRODUCTVERSION 0,1,12,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "SignalFx"
             VALUE "FileDescription", "SignalFx CLR Profiler"
-            VALUE "FileVersion", "0.1.11.0"
+            VALUE "FileVersion", "0.1.12.0"
             VALUE "InternalName", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "LegalCopyright", "Copyright (C) 2020-2022"
             VALUE "OriginalFilename", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "ProductName", "SignalFx .NET Tracing"
-            VALUE "ProductVersion", "0.1.11"
+            VALUE "ProductVersion", "0.1.12"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/Datadog.Trace.ClrProfiler.Native/version.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/version.h
@@ -1,4 +1,4 @@
 // Modified by SignalFx
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.1.11";
+constexpr auto PROFILER_VERSION = "0.1.12";

--- a/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>0.1.11</Version>
+    <Version>0.1.12</Version>
     <Title>SignalFx Tracing OpenTracing</Title>
     <Description>Provides OpenTracing support for SignalFx Tracing</Description>
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>0.1.11</Version>
+    <Version>0.1.12</Version>
     <Title>SignalFx Tracing</Title>
     <Description>Manual instrumentation library for SignalFx Tracing</Description>
     <AssemblyName>SignalFx.Tracing</AssemblyName>

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -505,7 +505,7 @@ namespace SignalFx.Tracing
         {
             try
             {
-                Assembly asm = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=0.1.11.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"));
+                Assembly asm = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=0.1.12.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"));
                 Type openTracingTracerFactory = asm.GetType("SignalFx.Tracing.OpenTracing.OpenTracingTracerFactory");
                 var methodInfo = openTracingTracerFactory.GetMethod("RegisterGlobalTracer");
                 object[] args = new object[] { instance };

--- a/tools/Datadog.Core.Tools/TracerVersion.cs
+++ b/tools/Datadog.Core.Tools/TracerVersion.cs
@@ -19,7 +19,7 @@ namespace Datadog.Core.Tools
         /// <summary>
         /// The patch portion of the current version.
         /// </summary>
-        public const int Patch = 11;
+        public const int Patch = 12;
 
         /// <summary>
         /// Whether the current release is a pre-release


### PR DESCRIPTION
Preparing next release, version v0.1.12, change log:

## [Release 0.1.12](https://github.com/signalfx/signalfx-dotnet-tracing/releases/tag/v0.1.12)

- Support for .NET 5.0
- Added Confluent.Kafka instrumentation for IConsumer.Consume, IProducer.Produce, and IProducer.ProduceAsync
- New instrumentations for SqlCommand: ExecuteXmlReader and ExecuteXmlReaderAsync methods