### PR TITLE
Confluent.Kafka: do not set consumer start time if msg was received

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -386,6 +386,7 @@ services:
     - POSTGRES_HOST=postgres
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
+    - KAFKA_HOST=kafka:9092
     - buildConfiguration=${buildConfiguration}
     - publishTargetFramework=net5.0
     depends_on:
@@ -398,6 +399,7 @@ services:
     - mongo
     - postgres
     - mysql
+    - kafka
 
   IntegrationTests:
     build:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Use OpenTelemetry semantic conventions for log correlation
+- Remove spans for Confluent.Kafka Consume calls that didn't receive a message
 
 [Commits](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.12...HEAD)
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Kafka/ConsumeKafkaIntegrationHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Kafka/ConsumeKafkaIntegrationHelper.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Kafka
             {
                 result = consume(consumer, input);
                 scope = result != null
-                    ? CreateConsumeScopeFromConsumerResult(result, consumer, startTimeOffset)
+                    ? CreateConsumeScopeFromConsumerResult(result, consumer)
                     : CreateConsumeScopeFromConsumer(consumer, startTimeOffset);
             }
             catch (Exception ex)
@@ -96,7 +96,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Kafka
             return result;
         }
 
-        internal static Scope CreateConsumeScopeFromConsumerResult(object consumeResult, object consumer, DateTimeOffset startTime)
+        internal static Scope CreateConsumeScopeFromConsumerResult(object consumeResult, object consumer)
         {
             var tracer = Tracer.Instance;
             if (!tracer.Settings.IsIntegrationEnabled(ConfluentKafka.IntegrationName) || KafkaHelper.AlreadyInstrumented())
@@ -140,7 +140,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Kafka
                     partitionValue = KafkaHelper.GetPropertyValue<int>(partition, "Value").ToString(CultureInfo.InvariantCulture);
                 }
 
-                scope = tracer.StartActive(OpenTelemetryConsumeSpanName(topicName), propagatedContext, startTime: startTime);
+                scope = tracer.StartActive(OpenTelemetryConsumeSpanName(topicName), propagatedContext);
 
                 var span = scope.Span;
                 span.SetTag(Tags.InstrumentationName, ConfluentKafka.IntegrationName);

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -285,30 +285,6 @@ namespace SignalFx.Tracing
             /// This tag is NOT part of OpenTelemetry experimental specification at commit 5a19b53d71e967659517c02a69b801381d29bf1e.
             /// </remarks>
             public const string QueueTimeMs = "messaging.kafka.queue_time_ms";
-
-            /// <summary>
-            /// Topics subscribed by a consumer.
-            /// </summary>
-            /// <remarks>
-            /// This tag is NOT part of OpenTelemetry experimental specification at commit 5a19b53d71e967659517c02a69b801381d29bf1e.
-            /// </remarks>
-            public const string SubscribedTopics = "messaging.kafka.subscribed_topics";
-
-            /// <summary>
-            /// The partitions assigned to a consumer.
-            /// </summary>
-            /// <remarks>
-            /// This tag is NOT part of OpenTelemetry experimental specification at commit 5a19b53d71e967659517c02a69b801381d29bf1e.
-            /// </remarks>
-            public const string AssignedPartitions = "messaging.kafka.assigned_partitions";
-
-            /// <summary>
-            /// A boolean to indicate if a message was actually received. Required if no message was received, optional otherwise.
-            /// </summary>
-            /// <remarks>
-            /// This tag is NOT part of OpenTelemetry experimental specification at commit 5a19b53d71e967659517c02a69b801381d29bf1e.
-            /// </remarks>
-            public const string MessagedReceived = "messaging.kafka.message_received";
         }
     }
 }


### PR DESCRIPTION
When a msg is received on the consumer call has its actual start time it distorts the whole trace time by having the consumer span starting before the server receiving the request. This change doesn't use the consumer start time if an actual message is retrieved from the topic.