### PR TITLE
Add option to exclude outbound HTTP spans for selected hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS` |  | Enable to tag Redis commands as a `db.statement`. |
 | `SIGNALFX_LOGS_INJECTION` | `false` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. |
 | `SIGNALFX_MAX_LOGFILE_SIZE` | `104857600` (10MiB) | The maximum size for tracer log files, in bytes. |
-| `SIGNALFX_OUTBOUND_HTTP_EXCLUDED_HOSTS` |  | List of host for which no outbound HTTP spans should be generated, if any, separated by a semi-colon. |
+| `SIGNALFX_OUTBOUND_HTTP_EXCLUDED_HOSTS` |  | A semicolon-separated list of hosts for which HTTP outbound spans are not created. |
 | `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` |  | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |
 | `SIGNALFX_PROFILER_PROCESSES` |  | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |
 | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | The maximum length an attribute value can have. Values longer than this are truncated. |

--- a/README.md
+++ b/README.md
@@ -46,37 +46,38 @@ Use these environment variables to configure the tracing library:
 
 | Environment variable | Default value | Description |
 |-|-|-|
-| `SIGNALFX_ENV` |  | The value for the `environment` tag added to every span. This determines the environment in which the service is available in SignalFx µAPM.  |
-| `SIGNALFX_DOTNET_TRACER_CONFIG_FILE` | ```%WorkingDirectory%/signalfx.json``` | The file path of a JSON configuration file that will be loaded. |
-| `SIGNALFX_SERVICE_NAME` |  | The name of the service. |
-| `SIGNALFX_SERVICE_NAME_PER_SPAN_ENABLED` |  | Enable to allow manual instrumentation to have a different service name than the one you specify with `SIGNALFX_SERVICE_NAME`.  Add a tag `service.name` with the desired name to the manual instrumentation. |
-| `SIGNALFX_TRACING_ENABLED` | `true` | Enable to activate the tracer. |
-| `SIGNALFX_TRACE_DEBUG` | `false` | Enable to activate debugging mode for the tracer. |
-| `SIGNALFX_ENDPOINT_URL` | `http://localhost:9080/v1/trace` | The hostname and port for a SignalFx Smart Agent or OpenTelemetry Collector. |
 | `SIGNALFX_ACCESS_TOKEN` |  | The access token for your SignalFx organization. Providing a token enables you to send traces to a SignalFx ingest endpoint. |
-| `SIGNALFX_TRACE_GLOBAL_TAGS` |  | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |
-| `SIGNALFX_LOGS_INJECTION` | `false` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. |
-| `SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS` |  | Enable to tag the Mongo command `BsonDocument` as a `db.statement`. |
-| `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES` |  | Enable to tag the Elasticsearch command `PostData` as a `db.statement`. |
-| `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS` |  | Enable to tag Redis commands as a `db.statement`. |
-| `SIGNALFX_SANITIZE_SQL_STATEMENTS` |  | Enable to stop sanitizing each SQL `db.statement`. |
-| `SIGNALFX_INSTRUMENTATION_ASPNETCORE_DIAGNOSTIC_LISTENERS` |  | Comma-separated list of diagnostic listeners that you subscribe to an observer. |
-| `SIGNALFX_MAX_LOGFILE_SIZE` | `10 MB` | The maximum size for tracer log files, in bytes. |
-| `SIGNALFX_TRACE_LOG_PATH` | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\dotnet-profiler.log` | The path of the profiler log file. |
-| `SIGNALFX_APPEND_URL_PATH_TO_NAME` | `false` | Enable to append the absolute URI path to the span name. |
-| `SIGNALFX_USE_WEBSERVER_RESOURCE_AS_OPERATION_NAME` | `true` | Enable to specify the resource name as the span name. This applies only to AspNetMvc and AspNetWebApi. |
 | `SIGNALFX_ADD_CLIENT_IP_TO_SERVER_SPANS` | `false` | Enable to add the client IP as a span tag when creating a server span. |
+| `SIGNALFX_APPEND_URL_PATH_TO_NAME` | `false` | Enable to append the absolute URI path to the span name. |
+| `SIGNALFX_ASPNET_TEMPLATE_NAMES_ENABLED` | `true` |  Feature Flag: enables updated resource names on `aspnet.request`, `aspnet-mvc.request`, `aspnet-webapi.request`, and `aspnet_core.request` spans. Enables `aspnet_core_mvc.request` spans and additional features on `aspnet_core.request` spans. |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | `true` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. |
 | `SIGNALFX_DISABLED_INTEGRATIONS` |  | The integrations you want to disable, if any, separated by a semi-colon. These are the supported integrations: AspNetMvc, AspNetWebApi2, DbCommand, ElasticsearchNet5, ElasticsearchNet6, GraphQL, HttpMessageHandler, IDbCommand, MongoDb, NpgsqlCommand, OpenTracing, ServiceStackRedis, SqlCommand, StackExchangeRedis, Wcf, WebRequest |
-| `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | The maximum length an attribute value can have. Values longer than this are truncated. |
+| `SIGNALFX_DOTNET_TRACER_CONFIG_FILE` | ```%WorkingDirectory%/signalfx.json``` | The file path of a JSON configuration file that will be loaded. |
+| `SIGNALFX_ENDPOINT_URL` | `http://localhost:9080/v1/trace` | The hostname and port for a SignalFx Smart Agent or OpenTelemetry Collector. |
+| `SIGNALFX_ENV` |  | The value for the `environment` tag added to every span. This determines the environment in which the service is available in SignalFx µAPM.  |
 | `SIGNALFX_FILE_LOG_ENABLED` | `true` | Enable file logging. This is enabled by default. |
+| `SIGNALFX_INSTRUMENTATION_ASPNETCORE_DIAGNOSTIC_LISTENERS` |  | Comma-separated list of diagnostic listeners that you subscribe to an observer. |
+| `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES` |  | Enable to tag the Elasticsearch command `PostData` as a `db.statement`. |
+| `SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS` |  | Enable to tag the Mongo command `BsonDocument` as a `db.statement`. |
+| `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS` |  | Enable to tag Redis commands as a `db.statement`. |
+| `SIGNALFX_LOGS_INJECTION` | `false` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. |
+| `SIGNALFX_MAX_LOGFILE_SIZE` | `104857600` (10MiB) | The maximum size for tracer log files, in bytes. |
+| `SIGNALFX_OUTBOUND_HTTP_EXCLUDED_HOSTS` |  | List of host for which no outbound HTTP spans should be generated, if any, separated by a semi-colon. |
+| `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` |  | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |
+| `SIGNALFX_PROFILER_PROCESSES` |  | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |
+| `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | `1200` | The maximum length an attribute value can have. Values longer than this are truncated. |
+| `SIGNALFX_SANITIZE_SQL_STATEMENTS` |  | Enable to stop sanitizing each SQL `db.statement`. |
+| `SIGNALFX_SERVICE_NAME_PER_SPAN_ENABLED` |  | Enable to allow manual instrumentation to have a different service name than the one you specify with `SIGNALFX_SERVICE_NAME`.  Add a tag `service.name` with the desired name to the manual instrumentation. |
+| `SIGNALFX_SERVICE_NAME` |  | The name of the service. |
 | `SIGNALFX_STDOUT_LOG_ENABLED` | `false` | Enables `stdout` logging. This is disabled by default. |
 | `SIGNALFX_SYNC_SEND` | `false` | Enable to send spans in synchronous mode when the root span is closed. Sending spans in synchronous mode is generally recommended for only tests, but can also be useful for some special scenarios.|
+| `SIGNALFX_TRACE_DEBUG` | `false` | Enable to activate debugging mode for the tracer. |
 | `SIGNALFX_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` | `false` |  Sets whether to intercept method calls when the caller method is inside a domain-neutral assembly. This is recommended when instrumenting IIS applications. |
-| `SIGNALFX_ASPNET_TEMPLATE_NAMES_ENABLED` | `true` |  Feature Flag: enables updated resource names on `aspnet.request`, `aspnet-mvc.request`, `aspnet-webapi.request`, and `aspnet_core.request` spans. Enables `aspnet_core_mvc.request` spans and additional features on `aspnet_core.request` spans. |
-| `SIGNALFX_PROFILER_PROCESSES` |  | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |
-| `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` |  | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |
+| `SIGNALFX_TRACE_GLOBAL_TAGS` |  | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |
+| `SIGNALFX_TRACE_LOG_PATH` | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\dotnet-profiler.log` | The path of the profiler log file. |
 | `SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED` | `true` | If set to true enables adding `Server-Timing` header to the server HTTP responses. |
+| `SIGNALFX_TRACING_ENABLED` | `true` | Enable to activate the tracer. |
+| `SIGNALFX_USE_WEBSERVER_RESOURCE_AS_OPERATION_NAME` | `true` | Enable to specify the resource name as the span name. This applies only to AspNetMvc and AspNetWebApi. |
 
 ## Ways to configure
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use OpenTelemetry semantic conventions for log correlation
 - Remove spans for Confluent.Kafka Consume calls that didn't receive a message
+- Add configuration setting, `SIGNALFX_OUTBOUND_HTTP_EXCLUDED_HOSTS`, that prevents the creation of outbound HTTP spans for certain hosts
 
 [Commits](https://github.com/signalfx/signalfx-dotnet-tracing/v0.1.12...HEAD)
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Data;
 using SignalFx.Tracing;
+using SignalFx.Tracing.Configuration;
 using SignalFx.Tracing.ExtensionMethods;
 using SignalFx.Tracing.Logging;
 using SignalFx.Tracing.Util;
@@ -97,9 +98,9 @@ namespace Datadog.Trace.ClrProfiler
         /// <returns>A new pre-populated scope.</returns>
         public static Scope CreateOutboundHttpScope(Tracer tracer, string httpMethod, Uri requestUri, string integrationName, ulong? propagatedSpanId = null)
         {
-            if (!tracer.Settings.IsIntegrationEnabled(integrationName))
+            if (!tracer.Settings.IsIntegrationEnabled(integrationName) || IsOutboundHttpExcludedHost(tracer.Settings, requestUri.Host))
             {
-                // integration disabled, don't create a scope, skip this trace
+                // integration disabled or host excluded, don't create a scope, skip this trace
                 return null;
             }
 
@@ -221,6 +222,11 @@ namespace Datadog.Trace.ClrProfiler
                                ? commandTypeName.Substring(0, commandTypeName.Length - commandSuffix.Length).ToLowerInvariant()
                                : commandTypeName.ToLowerInvariant();
             }
+        }
+
+        internal static bool IsOutboundHttpExcludedHost(TracerSettings settings, string host)
+        {
+            return settings.OutboundHttpExcludedHosts.Contains(host);
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -347,6 +347,15 @@ namespace SignalFx.Tracing.Configuration
         public const string TraceResponseHeaderEnabled = "SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED";
 
         /// <summary>
+        /// Configuration key for a list of hosts for which outbound HTTP spans are not going to
+        /// be generated.
+        /// Default is empty (no host is excluded).
+        /// Supports multiple values separated with semi-colons.
+        /// </summary>
+        /// <seealso cref="TracerSettings.OutboundHttpExcludedHosts"/>
+        public const string OutboundHttpExcludedHosts = "SIGNALFX_OUTBOUND_HTTP_EXCLUDED_HOSTS";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -69,6 +69,12 @@ namespace SignalFx.Tracing.Configuration
 
             DisabledIntegrationNames = new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase);
 
+            var outboundHttpExcludedHosts = source?.GetString(ConfigurationKeys.OutboundHttpExcludedHosts)
+                                                 ?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ??
+                                           Enumerable.Empty<string>();
+
+            OutboundHttpExcludedHosts = new HashSet<string>(outboundHttpExcludedHosts, StringComparer.OrdinalIgnoreCase);
+
             var endpointUrl = source?.GetString(ConfigurationKeys.EndpointUrl) ?? DefaultEndpointUrl;
             EndpointUrl = new Uri(endpointUrl);
 
@@ -408,6 +414,12 @@ namespace SignalFx.Tracing.Configuration
         /// Gets or sets a value indicating whether context server timing header will be added.
         /// </summary>
         public bool TraceResponseHeaderEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of hosts to exclude from HTTP outbound calls.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.OutboundHttpExcludedHosts"/>
+        public HashSet<string> OutboundHttpExcludedHosts { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether the feature flag to enable the updated ASP.NET resource names is enabled

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -45,6 +45,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.Environment), null };
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
+            yield return new object[] { CreateFunc(s => s.OutboundHttpExcludedHosts.Count), 0 };
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
             yield return new object[] { CreateFunc(s => s.GlobalTags), null };
             yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
@@ -71,6 +72,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.ServiceName, "web-service", CreateFunc(s => s.ServiceName), "web-service" };
 
             yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1;integration2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
+
+            yield return new object[] { ConfigurationKeys.OutboundHttpExcludedHosts, "168.63.129.16;www.example.com", CreateFunc(s => s.OutboundHttpExcludedHosts.Count), 2 };
 
             yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags.Count), 2 };
 


### PR DESCRIPTION
In certain scenarios is desirable to not generate outbound HTTP spans for certain hosts. This change adds a config setting, `SIGNALFX_OUTBOUND_HTTP_EXCLUDED_HOSTS` that gives this capability.