### PR TITLE
Fixing Startup code

### DIFF
--- a/.azure-pipelines/mininal-pipeline.yml
+++ b/.azure-pipelines/mininal-pipeline.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - main
+      - next-ver
       - release/*
       - hotfix/*
       - refs/tags/*
@@ -45,7 +45,7 @@ schedules:
     displayName: Daily 3am (UTC) build
     branches:
       include:
-        - main
+        - next-ver
     always: true
 
 # Global variables
@@ -58,7 +58,6 @@ variables:
   tracerHome: $(System.DefaultWorkingDirectory)/tracer/src/bin/windows-tracer-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts
   ddApiKey: $(DD_API_KEY)
-  isMainBranch: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,11 +1,11 @@
 name: Build artifacts
 on: 
   push: 
-    branches: [ main ]
+    branches: [ next-ver ]
     tags:
       - 'v*.*.*'
   pull_request:
-    branches: [ main ]
+    branches: [ next-ver ]
   workflow_dispatch:
 
 jobs:

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -327,7 +327,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
         return S_OK;
     }
 
-    const auto is_instrumentation_assembly = assembly_info.name == WStr("Datadog.Trace");
+    const auto is_instrumentation_assembly = assembly_info.name == WStr("OpenTelemetry.AutoInstrumentation");
 
     if (is_instrumentation_assembly || Logger::IsDebugEnabled())
     {
@@ -593,7 +593,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
     // In this case, do not insert another startup hook into that non-shared AppDomain
     if (module_info.assembly.name == datadog_trace_clrprofiler_managed_loader_assemblyName)
     {
-        Logger::Info("ModuleLoadFinished: Datadog.Trace.ClrProfiler.Managed.Loader loaded into AppDomain ", app_domain_id, " ",
+        Logger::Info("ModuleLoadFinished: OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.Loader loaded into AppDomain ", app_domain_id, " ",
                      module_info.assembly.app_domain_name);
         first_jit_compilation_app_domains.insert(app_domain_id);
         return S_OK;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -80,7 +80,7 @@ const WSTRING skip_assemblies[]{WStr("mscorlib"),
 
 const WSTRING mscorlib_assemblyName = WStr("mscorlib");
 const WSTRING system_private_corelib_assemblyName = WStr("System.Private.CoreLib");
-const WSTRING datadog_trace_clrprofiler_managed_loader_assemblyName = WStr("Datadog.Trace.ClrProfiler.Managed.Loader");
+const WSTRING datadog_trace_clrprofiler_managed_loader_assemblyName = WStr("OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.Loader");
 
 const WSTRING microsoft_aspnetcore_hosting_assemblyName = WStr("Microsoft.AspNetCore.Hosting");
 const WSTRING dapper_assemblyName = WStr("Dapper");


### PR DESCRIPTION
Some of the rename done missed some parts on the native profiler that was causing error to many integration tests.