### PR TITLE
Fix handling TestAllPackageVersions build parameter

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1111,8 +1111,7 @@ partial class Build
                 .SetProperty("ExcludeManagedProfiler", "true")
                 .SetProperty("ExcludeNativeProfiler", "true")
                 .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
-                .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
-                .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
+                .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                 .CombineWith(targets, (c, target) => c.SetTargets(target))
             );
         });
@@ -1139,9 +1138,8 @@ partial class Build
                     // .SetTargetPlatform(Platform)
                     .SetNoWarnDotNetCore3()
                     .When(TestAllPackageVersions, o => o
-                        .SetProperty("TestAllPackageVersions", "true"))
-                    .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
-                    .AddProcessEnvironmentVariable("ManagedProfilerOutputDirectory", TracerHomeDirectory)
+                        .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
+                    .SetProcessEnvironmentVariable("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
                         o.SetPackageDirectory(NugetPackageDirectory))
                     .CombineWith(integrationTestProjects, (c, project) => c


### PR DESCRIPTION
`TestAllPackageVersions` was always set in the integration tests.

This makes local builds and Azure Pipelines faster in our repository.

## Local execution

After changing:

```
$./tracer/build.sh Clean BuildTracerHome BuildLinuxIntegrationTests --framework netcoreapp3.1
...
════════════════════════════════════════════════════════════
Target                                  Status      Duration
────────────────────────────────────────────────────────────
Clean                                   Executed        0:18
Restore                                 Executed        0:32
CreateRequiredDirectories               Executed      < 1sec
CompileManagedSrc                       Executed        1:02
PublishManagedProfiler                  Executed        0:09
CompileNativeSrcMacOs                   Skipped                // EnvironmentInfo.IsOsx
CompileNativeSrcLinux                   Executed        4:22
CompileNativeSrcWindows                 Skipped                // EnvironmentInfo.IsWin
PublishNativeProfilerMacOs              Skipped                // EnvironmentInfo.IsOsx
PublishNativeProfilerLinux              Executed      < 1sec
PublishNativeProfilerWindows            Skipped                // EnvironmentInfo.IsWin
DownloadLibDdwaf                        Executed        0:02
CopyLibDdwaf                            Executed      < 1sec
CopyIntegrationsJson                    Executed      < 1sec
CreateDdTracerHome                      Executed        0:01
CompileRegressionDependencyLibs         Executed        0:09
CompileDependencyLibs                   Executed        0:20
CompileManagedTestHelpers               Executed        0:13
CompileSamplesLinux                     Executed        7:31
CompileMultiApiPackageVersionSamples    Executed        0:22
CompileLinuxIntegrationTests            Executed        1:28
────────────────────────────────────────────────────────────
Total                                                  16:35
════════════════════════════════════════════════════════════

$./tracer/build.sh BuildLinuxIntegrationTests --framework netcoreapp3.1
...
════════════════════════════════════════════════════════════
Target                                  Status      Duration
────────────────────────────────────────────────────────────
CompileRegressionDependencyLibs         Executed        0:14
CompileDependencyLibs                   Executed        0:24
CompileManagedTestHelpers               Executed        0:17
CompileSamplesLinux                     Executed        6:42
CompileMultiApiPackageVersionSamples    Executed        0:23
CompileLinuxIntegrationTests            Executed        1:23
────────────────────────────────────────────────────────────
Total                                                   9:25
════════════════════════════════════════════════════════════
```


Before changing: 

```
$./tracer/build.sh BuildLinuxIntegrationTests --framework netcoreapp3.1
...
════════════════════════════════════════════════════════════
Target                                  Status      Duration
────────────────────────────────────────────────────────────
CompileRegressionDependencyLibs         Executed        0:11
CompileDependencyLibs                   Executed        0:23
CompileManagedTestHelpers               Executed        0:15
CompileSamplesLinux                     Executed        6:45
CompileMultiApiPackageVersionSamples    Executed       13:44
CompileLinuxIntegrationTests            Executed        1:28
────────────────────────────────────────────────────────────
Total                                                  22:50
════════════════════════════════════════════════════════════
```

## Azure Pipelines

After changing: https://dev.azure.com/signalfx/signalfx-dotnet-tracing/_build/results?buildId=6140&view=results

![image](https://user-images.githubusercontent.com/5067549/134490906-fcc98482-fb54-457f-b873-a1d26af01153.png)


Before changing: https://dev.azure.com/signalfx/signalfx-dotnet-tracing/_build/results?buildId=6139&view=results

![image](https://user-images.githubusercontent.com/5067549/134489787-e26b1e9a-33d6-48df-b2f7-f9a21e36caf8.png)
