### PR TITLE
Exclude next-ver branch from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,11 @@ version: 2.1
 orbs:
   win: circleci/windows@2.2.0
 
+general:
+  branches:
+    ignore:
+      - next-ver
+
 jobs:
   Alpine:
     machine:


### PR DESCRIPTION
Do not run CircleCI for next-ver branch, we still want to run it on the main branch.