### PR TITLE
Remove alpine CI jobs

### DIFF
--- a/.azure-pipelines/mininal-pipeline.yml
+++ b/.azure-pipelines/mininal-pipeline.yml
@@ -109,8 +109,8 @@ stages:
       matrix:
         debian:
           baseImage: debian
-        alpine:
-          baseImage: alpine
+        # alpine:
+        #   baseImage: alpine
     pool:
       vmImage: ubuntu-18.04
 
@@ -215,8 +215,8 @@ stages:
       matrix:
         debian:
           baseImage: debian
-        alpine:
-          baseImage: alpine
+        # alpine:
+        #   baseImage: alpine
     pool:
       vmImage: ubuntu-18.04
 
@@ -385,12 +385,12 @@ stages:
         debian_net5_0:
           publishTargetFramework: net5.0
           baseImage: debian
-        alpine_netcoreapp3_1:
-          publishTargetFramework: netcoreapp3.1
-          baseImage: alpine
-        alpine_net5_0:
-          publishTargetFramework: net5.0
-          baseImage: alpine
+        # alpine_netcoreapp3_1:
+        #   publishTargetFramework: netcoreapp3.1
+        #   baseImage: alpine
+        # alpine_net5_0:
+        #   publishTargetFramework: net5.0
+        #   baseImage: alpine
 
     variables:
       TestAllPackageVersions: false

--- a/.azure-pipelines/mininal-pipeline.yml
+++ b/.azure-pipelines/mininal-pipeline.yml
@@ -258,18 +258,18 @@ stages:
           platform: x64
           target: BuildAndRunWindowsIntegrationTests
           requiresCosmos: true
-        x86_interation:
-          platform: x86
-          target: BuildAndRunWindowsIntegrationTests
-          requiresCosmos: true
+        # x86_interation:
+        #   platform: x86
+        #   target: BuildAndRunWindowsIntegrationTests
+        #   requiresCosmos: true
         x64_regression:
           platform: x64
           target: BuildAndRunWindowsRegressionTests
           requiresCosmos: false
-        x86_regression:
-          platform: x86
-          target: BuildAndRunWindowsRegressionTests
-          requiresCosmos: false
+        # x86_regression:
+        #   platform: x86
+        #   target: BuildAndRunWindowsRegressionTests
+        #   requiresCosmos: false
 
     steps:
     - template: steps/install-dotnet-sdks.yml
@@ -312,9 +312,9 @@ stages:
         x64:
           platform: x64
           enable32bit: false
-        x86:
-          platform: x86
-          enable32bit: true
+        # x86:
+        #   platform: x86
+        #   enable32bit: true
     pool:
       vmImage: windows-2019
     variables:


### PR DESCRIPTION
## What

Remove alpine CI jobs.

## Why

Decrease non-critical jobs to reduce the resource usage on Azure Pieplines.