### PR TITLE
Fix size calculation of Loader PDB and DLL for Linux

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2984,11 +2984,11 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
 }
 
 #ifdef LINUX
-extern uint8_t dll_start[] asm("_binary_Datadog_Trace_ClrProfiler_Managed_Loader_dll_start");
-extern uint8_t dll_end[] asm("_binary_Datadog_Trace_ClrProfiler_Managed_Loader_dll_end");
+extern uint8_t dll_start[] asm("_binary_OpenTelemetry_AutoInstrumentation_ClrProfiler_Managed_Loader_dll_start");
+extern uint8_t dll_end[] asm("_binary_OpenTelemetry_AutoInstrumentation_ClrProfiler_Managed_Loader_dll_end");
 
-extern uint8_t pdb_start[] asm("_binary_Datadog_Trace_ClrProfiler_Managed_Loader_pdb_start");
-extern uint8_t pdb_end[] asm("_binary_Datadog_Trace_ClrProfiler_Managed_Loader_pdb_end");
+extern uint8_t pdb_start[] asm("_binary_OpenTelemetry_AutoInstrumentation_ClrProfiler_Managed_Loader_pdb_start");
+extern uint8_t pdb_end[] asm("_binary_OpenTelemetry_AutoInstrumentation_ClrProfiler_Managed_Loader_pdb_end");
 #endif
 
 void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assemblySize, BYTE** pSymbolsArray,


### PR DESCRIPTION
The bug was discovered by debugging the .NET runtime code:

```
Process 20148 stopped
* thread #1, name = 'corerun', stop reason = instruction step over
    frame #0: 0x00007ffff76166f8 libcoreclr.so`LOADLoadLibraryDirect(libraryNameOrPath="/home/rpajak/repos/signalfx-dotnet-tracing/tracer/bin/tracer-home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so") at module.cpp:1477:9
   1474     if (dl_handle == nullptr)
   1475     {
   1476         LPCSTR err_msg = dlerror();
-> 1477         TRACE("dlopen() failed %s\n", err_msg);
   1478         SetLastError(ERROR_MOD_NOT_FOUND);
   1479     }
   1480     else
(lldb) var
(LPCSTR) libraryNameOrPath = 0x00005555555f84c0 "/home/rpajak/repos/signalfx-dotnet-tracing/tracer/bin/tracer-home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so"
(NATIVE_LIBRARY_HANDLE) dl_handle = 0x0000000000000000
(LPCSTR) err_msg = 0x00005555555f8740 "/home/rpajak/repos/signalfx-dotnet-tracing/tracer/bin/tracer-home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so: undefined symbol: _binary_Datadog_Trace_ClrProfiler_Managed_Loader_pdb_end"
```

These lines were manually added to .NET profiler codebase to know why `dlopen()` failed:

```c
LPCSTR err_msg = dlerror();
TRACE("dlopen() failed %s\n", err_msg);
```

Kudos for @pjanotti for pair-debugging

Before

![image](https://user-images.githubusercontent.com/5067549/135577688-602dcdb9-ed10-487b-a1e2-10ffa486ab8d.png)


After

![image](https://user-images.githubusercontent.com/5067549/135577732-db24b58b-b036-466b-a2cc-92755f1e6163.png)

Now, I see only one test is failing (most probably some configuration error)

```
Datadog.Trace.ClrProfiler.IntegrationTests.CI.MsTestV2Tests.SubmitTraces(packageVersion: "") [FAIL]

Error message
System.ArgumentException : Version string portion was too short or too long. (Parameter 'input')


Stack trace
   at System.Version.ParseVersion(ReadOnlySpan`1 input, Boolean throwOnFailure)
   at System.Version.Parse(String input)
   at System.Version..ctor(String version)
   at Datadog.Trace.ClrProfiler.IntegrationTests.CI.MsTestV2Tests.SubmitTraces(String packageVersion) in /project/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs:line 36
```