### PR TITLE
Fix MsTestV2Tests.SubmitTraces for default value

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             if (string.IsNullOrEmpty(packageVersion))
             {
-                packageVersion = "2.0.0"
+                packageVersion = "2.0.0";
             }
 
             List<MockTracerAgent.Span> spans = null;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -32,13 +32,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [Trait("Category", "TestIntegrations")]
         public void SubmitTraces(string packageVersion)
         {
-            if (string.IsNullOrEmpty(packageVersion))
-            {
-                packageVersion = "2.0.0";
-            }
-
             List<MockTracerAgent.Span> spans = null;
-            var expectedSpanCount = new Version(packageVersion).CompareTo(new Version("2.2.5")) < 0 ? 13 : 15;
+            var actualPackageVersion = string.IsNullOrEmpty(packageVersion) ? "2.0.0" : packageVersion;
+            var expectedSpanCount = new Version(actualPackageVersion).CompareTo(new Version("2.2.5")) < 0 ? 13 : 15;
 
             try
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.MSTest), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion)
+        public void SubmitTraces(string packageVersion = "2.0.0")
         {
             List<MockTracerAgent.Span> spans = null;
             var expectedSpanCount = new Version(packageVersion).CompareTo(new Version("2.2.5")) < 0 ? 13 : 15;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -30,8 +30,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.MSTest), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion = "2.0.0")
+        public void SubmitTraces(string packageVersion)
         {
+            if (string.IsNullOrEmpty(packageVersion))
+            {
+                packageVersion = "2.0.0"
+            }
+
             List<MockTracerAgent.Span> spans = null;
             var expectedSpanCount = new Version(packageVersion).CompareTo(new Version("2.2.5")) < 0 ? 13 : 15;
 


### PR DESCRIPTION
Fixes

```
Datadog.Trace.ClrProfiler.IntegrationTests.CI.MsTestV2Tests.SubmitTraces(packageVersion: "") [FAIL]

Error message
System.ArgumentException : Version string portion was too short or too long. (Parameter 'input')


Stack trace
   at System.Version.ParseVersion(ReadOnlySpan`1 input, Boolean throwOnFailure)
   at System.Version.Parse(String input)
   at System.Version..ctor(String version)
   at Datadog.Trace.ClrProfiler.IntegrationTests.CI.MsTestV2Tests.SubmitTraces(String packageVersion) in /project/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs:line 36
```