### PR TITLE
Add basic CircleCI config until we remove CircleCI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - run: echo "hello world"


### PR DESCRIPTION
## Why

To make the builds green.

## What

Add "hello world" CircleCI job.