### PR TITLE
Limit zipkin tag value length

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -61,6 +61,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` |  Sets whether to intercept method calls when the caller method is inside a domain-neutral assembly. This is recommended when instrumenting IIS applications. | `false` |
 | `SIGNALFX_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
+| `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | The maximum length an attribute value can have. Values longer than this are truncated. Values are completely truncated when set to 0, and ignored when set to a negative value. | `12000` |
 
 ## Ways to configure
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -393,6 +393,14 @@ namespace Datadog.Trace.Configuration
         public const string KafkaCreateConsumerScopeEnabled = "SIGNALFX_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED";
 
         /// <summary>
+        /// Configuration key to set maximum length a tag/log value can have.
+        /// Values are completely truncated when set to 0, and ignored when set to negative
+        /// or non-integer string. The default value is 1200.
+        /// </summary>
+        /// <seealso cref="TracerSettings.RecordedValueMaxLength"/>
+        public const string RecordedValueMaxLength = "SIGNALFX_RECORDED_VALUE_MAX_LENGTH";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -395,7 +395,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key to set maximum length a tag/log value can have.
         /// Values are completely truncated when set to 0, and ignored when set to negative
-        /// or non-integer string. The default value is 1200.
+        /// or non-integer string. The default value is 12000.
         /// </summary>
         /// <seealso cref="TracerSettings.RecordedValueMaxLength"/>
         public const string RecordedValueMaxLength = "SIGNALFX_RECORDED_VALUE_MAX_LENGTH";

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -33,6 +33,8 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public const int DefaultAgentPort = 8126;
 
+        private const int DefaultRecordedValueMaxLength = 1200;
+
         private int _partialFlushMinSpans;
 
         /// <summary>
@@ -199,6 +201,12 @@ namespace Datadog.Trace.Configuration
 
             TraceBatchInterval = source?.GetInt32(ConfigurationKeys.SerializationBatchInterval)
                         ?? 100;
+
+            RecordedValueMaxLength = source?.GetInt32(ConfigurationKeys.RecordedValueMaxLength) ?? DefaultRecordedValueMaxLength;
+            if (RecordedValueMaxLength < 0)
+            {
+                RecordedValueMaxLength = DefaultRecordedValueMaxLength;
+            }
 
             RouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
                                                    ?? false;
@@ -447,6 +455,14 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating whether the diagnostic log at startup is enabled
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value with the maximum length a tag/log value can have.
+        /// Values are completely truncated when set to 0, and ignored when set to negative
+        /// or non-integer string. The default value is 1200.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.RecordedValueMaxLength"/>
+        public int RecordedValueMaxLength { get; set; }
 
         /// <summary>
         /// Gets or sets the comma separated list of url patterns to skip tracing.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public const int DefaultAgentPort = 8126;
 
-        private const int DefaultRecordedValueMaxLength = 1200;
+        private const int DefaultRecordedValueMaxLength = 12000;
 
         private int _partialFlushMinSpans;
 
@@ -459,7 +459,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets or sets a value with the maximum length a tag/log value can have.
         /// Values are completely truncated when set to 0, and ignored when set to negative
-        /// or non-integer string. The default value is 1200.
+        /// or non-integer string. The default value is 12000.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.RecordedValueMaxLength"/>
         public int RecordedValueMaxLength { get; set; }

--- a/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -86,9 +86,7 @@ namespace Datadog.Trace.ExtensionMethods
         /// <returns>The truncated string or the original string if its length is less than or equal to <paramref name="maxLength"/>.</returns>
         public static string Truncate(this string value, int maxLength)
         {
-            if (value == null) { throw new ArgumentNullException(nameof(value)); }
-
-            return value.Length > maxLength ? value.Substring(0, maxLength) : value;
+            return value?.Length > maxLength ? value.Substring(0, maxLength) : value;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -78,6 +78,20 @@ namespace Datadog.Trace.ExtensionMethods
         }
 
         /// <summary>
+        /// Truncates a <see cref="string"/> to the given maximum length.
+        /// </summary>
+        /// <param name="value">The string to truncate.</param>
+        /// <param name="maxLength">The maximum length of the truncated string.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Throw if <paramref name="maxLength"/> is negative.</exception>
+        /// <returns>The truncated string or the original string if its length is less than or equal to <paramref name="maxLength"/>.</returns>
+        public static string Truncate(this string value, int maxLength)
+        {
+            if (value == null) { throw new ArgumentNullException(nameof(value)); }
+
+            return value.Length > maxLength ? value.Substring(0, maxLength) : value;
+        }
+
+        /// <summary>
         /// Datadog tag requirements:
         /// 1. Tag must start with a letter
         /// 2. Tag cannot exceed 200 characters

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -775,7 +775,7 @@ namespace Datadog.Trace
             switch (settings.Exporter)
             {
                 case ExporterType.Zipkin:
-                    return new ExporterWriter(new ZipkinExporter(settings.AgentUri), metrics);
+                    return new ExporterWriter(new ZipkinExporter(settings), metrics);
                 case ExporterType.Jaeger:
                     return new ExporterWriter(new JaegerExporter(JaegerOptions.FromTracerSettings(settings)), metrics);
                 default:

--- a/tracer/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -15,8 +15,9 @@ namespace Datadog.Trace.IntegrationTests
         public SendTracesToZipkinCollector()
         {
             int collectorPort = 9411;
-            var agentUri = new Uri($"http://localhost:{collectorPort}/api/v2/spans");
-            var exporter = new ZipkinExporter(agentUri);
+            var settings = new TracerSettings();
+            settings.AgentUri = new Uri($"http://localhost:{collectorPort}/api/v2/spans");
+            var exporter = new ZipkinExporter(settings);
             var exporterWriter = new ExporterWriter(exporter, new NullMetrics());
             _tracer = new Tracer(new TracerSettings(), plugins: null, exporterWriter, sampler: null, scopeManager: null, statsd: null);
             _zipkinCollector = new MockZipkinCollector(collectorPort);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -65,6 +65,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
             yield return new object[] { CreateFunc(s => s.TracerMetricsEnabled), false };
             yield return new object[] { CreateFunc(s => s.DogStatsdPort), 8125 };
+            yield return new object[] { CreateFunc(s => s.RecordedValueMaxLength), 1200 };
         }
 
         public static IEnumerable<object[]> GetTestData()
@@ -109,6 +110,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.Convention, "opentelemetry", CreateFunc(s => s.Convention), ConventionType.OpenTelemetry };
             yield return new object[] { ConfigurationKeys.Convention, "Datadog", CreateFunc(s => s.Convention), ConventionType.Datadog };
             yield return new object[] { ConfigurationKeys.Convention, "unknown", CreateFunc(s => s.Convention), ConventionType.Default };
+
+            yield return new object[] { ConfigurationKeys.RecordedValueMaxLength, "100", CreateFunc(s => s.RecordedValueMaxLength), 100 };
         }
 
         // JsonConfigurationSource needs to be tested with JSON data, which cannot be used with the other IConfigurationSource implementations.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
             yield return new object[] { CreateFunc(s => s.TracerMetricsEnabled), false };
             yield return new object[] { CreateFunc(s => s.DogStatsdPort), 8125 };
-            yield return new object[] { CreateFunc(s => s.RecordedValueMaxLength), 1200 };
+            yield return new object[] { CreateFunc(s => s.RecordedValueMaxLength), 12000 };
         }
 
         public static IEnumerable<object[]> GetTestData()


### PR DESCRIPTION
Implement tag truncation per current implementation: truncate tag values at export time.