### PR TITLE
Support SIGNALFX_ACCESS_TOKEN env var

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,6 +10,7 @@ Use these environment variables to configure the tracing library:
 
 | Environment variable | Description | Default |
 |-|-|-|
+| `SIGNALFX_ACCESS_TOKEN` | The access token for your SignalFx organization. Providing a token enables you to send traces to a SignalFx ingest endpoint. |  |
 | `SIGNALFX_TRACE_CONFIG_FILE` | The file path of a JSON configuration file that will be loaded. |  |
 | `SIGNALFX_VERSION` | The application's version that will populate `version` tag on spans. |  |
 | `SIGNALFX_TRACE_ADONET_EXCLUDED_TYPES` | Comma-separated list of AdoNet types that will be excluded from automatic instrumentation. |  |

--- a/tracer/src/Datadog.Trace/Agent/Zipkin/ZipkinExporter.cs
+++ b/tracer/src/Datadog.Trace/Agent/Zipkin/ZipkinExporter.cs
@@ -1,3 +1,5 @@
+// Modified by Splunk Inc.
+
 using System;
 using System.Net;
 using System.Threading.Tasks;
@@ -44,6 +46,12 @@ namespace Datadog.Trace.Agent.Zipkin
 
                 // Disable automatic instrumentation for Zipkin exporter
                 request.Headers.Add(CommonHttpHeaderNames.TracingEnabled, "false");
+
+                // Add SignalFx Access Token if configured
+                if (!string.IsNullOrWhiteSpace(_settings.SignalFxAccessToken))
+                {
+                    request.Headers.Add("X-Sf-Token", _settings.SignalFxAccessToken);
+                }
 
                 using (var requestStream = await request.GetRequestStreamAsync().ConfigureAwait(false))
                 {

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -45,6 +45,13 @@ namespace Datadog.Trace.Configuration
         public const string ServiceVersion = "SIGNALFX_VERSION";
 
         /// <summary>
+        /// Configuration key to set the SignalFx access token. This is to be used when sending data
+        /// directly to ingestion URL, ie.: no agent or collector is being used.
+        /// </summary>
+        /// <seealso cref="TracerSettings.SignalFxAccessToken"/>
+        public const string SignalFxAccessToken = "SIGNALFX_ACCESS_TOKEN";
+
+        /// <summary>
         /// Configuration key for enabling or disabling the Tracer.
         /// Default is value is true (enabled).
         /// </summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -62,6 +62,8 @@ namespace Datadog.Trace.Configuration
 
             ServiceVersion = source?.GetString(ConfigurationKeys.ServiceVersion);
 
+            SignalFxAccessToken = source?.GetString(ConfigurationKeys.SignalFxAccessToken);
+
             TraceEnabled = source?.GetBool(ConfigurationKeys.TraceEnabled) ??
                            // default value
                            true;
@@ -248,6 +250,13 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.ServiceVersion"/>
         public string ServiceVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value with the SignalFx access token. This is to be used when sending data
+        /// directly to ingestion URL, ie.: no agent or collector is being used.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.SignalFxAccessToken"/>
+        public string SignalFxAccessToken { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether tracing is enabled.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -57,6 +57,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.AgentUri), new Uri("http://127.0.0.1:8126/") };
             yield return new object[] { CreateFunc(s => s.Environment), null };
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
+            yield return new object[] { CreateFunc(s => s.SignalFxAccessToken), null };
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
             yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 0 };
@@ -82,6 +83,8 @@ namespace Datadog.Trace.Tests.Configuration
 
             yield return new object[] { ConfigurationKeys.ServiceName, "web-service", CreateFunc(s => s.ServiceName), "web-service" };
             yield return new object[] { "SIGNALFX_SERVICE_NAME", "web-service", CreateFunc(s => s.ServiceName), "web-service" };
+
+            yield return new object[] { ConfigurationKeys.SignalFxAccessToken, "secret-token", CreateFunc(s => s.SignalFxAccessToken), "secret-token" };
 
             yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1,integration2,,INTEGRATION2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
 


### PR DESCRIPTION
Add `SIGNALFX_ACCESS_TOKEN`  which enables sending traces to a Splunk Observability Cloud ingest endpoint.