### PR TITLE
Removes server timing in case of IIS classic app pool

### DIFF
--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -139,17 +139,17 @@ namespace Datadog.Trace.AspNet
                 span.DecorateWebServerSpan(resourceName, httpMethod, host, url, remoteIp);
                 span.SetTag(Tags.InstrumentationName, IntegrationName);
 
-                ServerTimingHeader.SetHeaders(span.Context, httpContext.Response.Headers, (headers, name, value) => headers.Add(name, value));
-
-                httpContext.Items[_httpContextScopeKey] = scope;
-
                 // Decorate the incoming HTTP Request with distributed tracing headers
                 // in case the next processor cannot access the stored Scope
                 // (e.g. WCF being hosted in IIS)
                 if (HttpRuntime.UsingIntegratedPipeline)
                 {
+                    ServerTimingHeader.SetHeaders(span.Context, httpContext.Response.Headers, (headers, name, value) => headers.Add(name, value));
+
                     Tracer.Instance.Propagator.Inject(scope.Span.Context, httpRequest.Headers.Wrap());
                 }
+
+                httpContext.Items[_httpContextScopeKey] = scope;
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -287,7 +287,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 // call the original method, inspecting (but not catching) any unhandled exceptions
                 var response = instrumentedMethod(asyncControllerActionInvoker, controllerContext, actionName, callback, state);
 
-                if (scope != null)
+                if (HttpRuntime.UsingIntegratedPipeline && scope != null)
                 {
                     // TracingHttpModule is expected to already have added it in the typical IIS setup
                     // In principle we could remove adding the headers from this instrumentation, keeping

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -154,7 +154,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 }
                 finally
                 {
-                    if (scope != null)
+                    if (HttpRuntime.UsingIntegratedPipeline && scope != null)
                     {
                         // TracingHttpModule is expected to already have added it in the typical IIS setup
                         // In principle we could remove adding the headers from this instrumentation, keeping


### PR DESCRIPTION
Since accessing response headers is not supported in case of IIS classic app pool, ported fix from next-ver branch.