### PR TITLE
Fix tag used for environment

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -48,7 +48,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to activate sending partial traces to the agent. | `false` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` | The minimum number of closed spans in a trace before it's partially flushed. `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` has to be enabled for this to take effect. | `500` |
 | `SIGNALFX_SERVICE` | Application's default service name. |  |
-| `SIGNALFX_ENV` | The value for the `environment` tag added to every span. |  |
+| `SIGNALFX_ENV` | The value for the `deployment.environment` tag added to every span. |  |
 | `SIGNALFX_TRACE_ENABLED` | Enable to activate the tracer. | `true` | 
 | `SIGNALFX_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` | 
 | `SIGNALFX_TRACE_AGENT_URL`, `SIGNALFX_ENDPOINT_URL` | The URL to where trace exporters (see: `SIGNALFX_EXPORTER`) send traces. | `http://localhost:8126` | 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -40,7 +40,7 @@ namespace environment {
     // Sets the Agent's port. Default is 8126.
     const WSTRING agent_port = WStr("SIGNALFX_TRACE_AGENT_PORT");
 
-    // Sets the "env" tag for every span.
+    // Sets the "deployment.environment" tag for every span.
     const WSTRING env = WStr("SIGNALFX_ENV");
 
     // Sets the default service name for every span.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Configuration
         public const string PluginConfigurationFileName = "SIGNALFX_DOTNET_TRACER_PLUGINS_FILE";
 
         /// <summary>
-        /// Configuration key for the application's environment. Sets the "env" tag on every <see cref="Span"/>.
+        /// Configuration key for the application's environment. Sets the "deployment.environment" tag on every <see cref="Span"/>.
         /// </summary>
         /// <seealso cref="TracerSettings.Environment"/>
         public const string Environment = "SIGNALFX_ENV";

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -13,9 +13,14 @@ namespace Datadog.Trace
     public static class Tags
     {
         /// <summary>
-        /// The environment of the profiled service.
+        /// The deployment environment of the profiled service.
         /// </summary>
-        public const string Env = "env";
+        /// <remarks>
+        /// This tag matches with the OpenTelemetry specification v0.1.7, see
+        /// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/resource/semantic_conventions/deployment_environment.md.
+        /// Legacy used the name "environment" until version 0.1.13 and upstream uses "env".
+        /// </remarks>
+        public const string Env = "deployment.environment";
 
         /// <summary>
         /// The version of the profiled service.

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -476,7 +476,7 @@ namespace Datadog.Trace
                 }
             }
 
-            // automatically add the "env" tag if defined, taking precedence over an "env" tag set from a global tag
+            // automatically add the "deployment.environment" tag if defined, taking precedence over an "deployment.environment" tag set from a global tag
             var env = Settings.Environment;
             if (!string.IsNullOrWhiteSpace(env))
             {
@@ -551,7 +551,7 @@ namespace Datadog.Trace
                     writer.WritePropertyName("lang_version");
                     writer.WriteValue(FrameworkDescription.Instance.ProductVersion);
 
-                    writer.WritePropertyName("env");
+                    writer.WritePropertyName("deployment.environment");
                     writer.WriteValue(Settings.Environment);
 
                     writer.WritePropertyName("enabled");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -137,7 +137,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                     .ExcludingMissingMembers()
                     .ExcludingDefaultSpanProperties()
                     .AssertMetricsMatchExcludingKeys("_dd.tracer_kr", "_sampling_priority_v1")
-                    .AssertTagsMatchAndSpecifiedTagsPresent("env", "aws.requestId", "aws.queue.url", "runtime-id"));
+                    .AssertTagsMatchAndSpecifiedTagsPresent("deployment.environment", "aws.requestId", "aws.queue.url", "runtime-id"));
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
@@ -300,7 +300,7 @@ namespace Datadog.Trace
         public const string DbName = "db.name";
         public const string DbType = "db.type";
         public const string DbUser = "db.user";
-        public const string Env = "env";
+        public const string Env = "deployment.environment";
         public const string ErrorMsg = "error.msg";
         public const string ErrorStack = "error.stack";
         public const string ErrorType = "error.type";

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
@@ -337,7 +337,7 @@ namespace Datadog.Trace
         public const string DbName = "db.name";
         public const string DbType = "db.type";
         public const string DbUser = "db.user";
-        public const string Env = "env";
+        public const string Env = "deployment.environment";
         public const string ErrorMsg = "error.msg";
         public const string ErrorStack = "error.stack";
         public const string ErrorType = "error.type";

--- a/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
@@ -22,7 +22,7 @@ namespace Benchmarks.Trace
             {
                 StartupDiagnosticLogEnabled = false,
                 LogsInjectionEnabled = true,
-                Environment = "env",
+                Environment = "deployment.environment",
                 ServiceVersion = "version"
             };
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/Log4netBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Log4netBenchmark.cs
@@ -24,7 +24,7 @@ namespace Benchmarks.Trace
             {
                 StartupDiagnosticLogEnabled = false,
                 LogsInjectionEnabled = true,
-                Environment = "env",
+                Environment = "deployment.environment",
                 ServiceVersion = "version"
             };
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/NLogBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/NLogBenchmark.cs
@@ -23,7 +23,7 @@ namespace Benchmarks.Trace
             {
                 StartupDiagnosticLogEnabled = false,
                 LogsInjectionEnabled = true,
-                Environment = "env",
+                Environment = "deployment.environment",
                 ServiceVersion = "version"
             };
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
@@ -24,7 +24,7 @@ namespace Benchmarks.Trace
             {
                 StartupDiagnosticLogEnabled = false,
                 LogsInjectionEnabled = true,
-                Environment = "env",
+                Environment = "deployment.environment",
                 ServiceVersion = "version"
             };
 


### PR DESCRIPTION
The tag "env", used by upstream, is not recognized by the backend.
Legacy uses "environment" and while that is supported by the backend
it requires use of global tags when combining with k8s data collection.
Using the current recommendation from GDI spec.
