### PR TITLE
Fix RabbitMq delivery mode tags

### DIFF
--- a/samples/Samples.RabbitMQ/Program.cs
+++ b/samples/Samples.RabbitMQ/Program.cs
@@ -74,7 +74,7 @@ namespace Samples.RabbitMQ
 
                     channel.BasicPublish(exchange: exchangeName,
                                             routingKey: routingKey,
-                                            basicProperties: null,
+                                            basicProperties: CreateBasicProperties(channel),
                                             body: body);
                     Console.WriteLine($"[Program.PublishAndGet] BasicPublish - Sent message: {string.Empty}");
                 }
@@ -114,9 +114,10 @@ namespace Samples.RabbitMQ
                     // Send message to the default exchange and use new queue as the routingKey
                     string message = "PublishAndGetDefault - Message";
                     var body = Encoding.UTF8.GetBytes(message);
+
                     channel.BasicPublish(exchange: "",
                                             routingKey: defaultQueueName,
-                                            basicProperties: null,
+                                            basicProperties: CreateBasicProperties(channel),
                                             body: body);
                     Console.WriteLine($"[Program.PublishAndGetDefault] BasicPublish - Sent message: {message}");
                 }
@@ -158,7 +159,7 @@ namespace Samples.RabbitMQ
 
                         channel.BasicPublish(exchange: "",
                                                 routingKey: "hello",
-                                                basicProperties: null,
+                                                basicProperties: CreateBasicProperties(channel),
                                                 body: body);
                         Console.WriteLine("[Send] - [x] Sent \"{0}\"", message);
 
@@ -216,6 +217,14 @@ namespace Samples.RabbitMQ
 
                 Console.WriteLine("[Receive] Exiting Thread.");
             }
+        }
+
+        private static IBasicProperties CreateBasicProperties(IModel channel)
+        {
+            var props = channel.CreateBasicProperties();
+            props.DeliveryMode = 1;
+
+            return props;
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -444,7 +444,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     {
                         if (basicPropertiesValue.IsDeliveryModePresent())
                         {
-                            tags.Add(Tags.RabbitMQ.RoutingKey, DeliveryModeStrings[0x3 & basicPropertiesValue.DeliveryMode]);
+                            tags.Add(Tags.RabbitMQ.DeliveryMode, DeliveryModeStrings[0x3 & basicPropertiesValue.DeliveryMode]);
                         }
 
                         // add distributed tracing headers to the message
@@ -542,7 +542,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     {
                         if (basicPropertiesValue.IsDeliveryModePresent())
                         {
-                            tags.Add(Tags.RabbitMQ.RoutingKey, DeliveryModeStrings[0x3 & basicPropertiesValue.DeliveryMode]);
+                            tags.Add(Tags.RabbitMQ.DeliveryMode, DeliveryModeStrings[0x3 & basicPropertiesValue.DeliveryMode]);
                         }
 
                         // add distributed tracing headers to the message

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -63,6 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         {
                             basicPublishCount++;
                             Assert.Equal(SpanKinds.Producer, span.Tags[Tags.SpanKind]);
+                            Assert.True(span.Tags.TryGetValue(Tags.RabbitMQ.DeliveryMode, out string mode));
                         }
                         else if (string.Equals(command, "basic.get", StringComparison.OrdinalIgnoreCase))
                         {


### PR DESCRIPTION
(bug) RabbitMq delivery mode tags got swapped with RouteKey, which caused duplicate tags and crashed client application.