### PR TITLE
Change span name for AspNetCoreDiagnosticObserver

### DIFF
--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -42,8 +42,8 @@ partial class Build
 
     readonly IEnumerable<string> GacProjects = new []
     {
-        Projects.DatadogTrace,
-        Projects.DatadogTraceAspNet
+        "OpenTelemetry.AutoInstrumentation",
+        "OpenTelemetry.AutoInstrumentation.AspNet"
     };
 
     Target GacAdd => _ => _

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -596,6 +596,9 @@ namespace Datadog.Trace.DiagnosticListeners
                 }
 
                 parentSpan.ResourceName = span.ResourceName;
+
+                // Upstream updated the resource name, update the operation name too.
+                parentSpan.OperationName = span.ResourceName;
             }
 
             return span;
@@ -807,6 +810,10 @@ namespace Datadog.Trace.DiagnosticListeners
                 {
                     span.ResourceName = resourceName;
                     tags.AspNetCoreRoute = normalizedRoute;
+
+                    // Upstream only needs to update the resource name, we also need to update
+                    // the span name.
+                    span.OperationName = resourceName;
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -123,7 +123,8 @@ namespace Datadog.Trace.PlatformHelpers
                 tags = new AspNetCoreTags();
             }
 
-            var scope = tracer.StartActiveWithTags(_requestInOperationName, propagatedContext, tags: tags);
+            var scope = tracer.StartActiveWithTags($"HTTP {httpMethod}", propagatedContext, tags: tags);
+            scope.Span.LogicScope = _requestInOperationName;
 
             scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders);
 

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -376,8 +376,8 @@ namespace Datadog.Trace
                 if (IsLogLevelDebugEnabled)
                 {
                     Log.Debug(
-                        "Span closed: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
-                        new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, Tags });
+                        "Span closed: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, LogicScope: {LogicScope}, Tags: [{Tags}])",
+                        new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, LogicScope, Tags });
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -195,7 +195,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             trace.Should().HaveCount(spanCount);
 
             var parentSpan = trace.Should()
-                                  .ContainSingle(x => x.OperationName == "aspnet_core.request")
+                                  .ContainSingle(x => x.LogicScope == "aspnet_core.request")
                                   .Subject;
 
             AssertTagHasValue(parentSpan, Tags.InstrumentationName, "aspnet_core");
@@ -216,9 +216,9 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
             if (spanCount > 1)
             {
-                trace.Should().Contain(x => x.OperationName == "aspnet_core_mvc.request");
+                trace.Should().Contain(x => x.LogicScope == "aspnet_core_mvc.request");
 
-                var childSpan = trace.First(x => x.OperationName == "aspnet_core_mvc.request");
+                var childSpan = trace.First(x => x.LogicScope == "aspnet_core_mvc.request");
 
                 AssertTagHasValue(childSpan, Tags.InstrumentationName, "aspnet_core");
                 childSpan.Type.Should().Be(SpanTypes.Web);
@@ -236,7 +236,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
                 if (spanCount > 2)
                 {
-                    var childSpan2 = trace.Last(x => x.OperationName == "aspnet_core_mvc.request");
+                    var childSpan2 = trace.Last(x => x.LogicScope == "aspnet_core_mvc.request");
                     childSpan2.Should().NotBe(childSpan);
 
                     AssertTagHasValue(childSpan2, Tags.InstrumentationName, "aspnet_core");

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             using var agent = await RunOnSelfHosted(enableSecurity, enableBlocking);
             await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, 5, new Action<TestHelpers.MockTracerAgent.Span>[]
             {
-             s => Assert.Equal("aspnet_core.request", s.Name),
+             s => Assert.Equal("aspnet_core.request", s.LogicScope),
              s  => Assert.Equal("Samples.AspNetCore2", s.Service),
              s  =>  Assert.Equal("web", s.Type)
             });

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             using var agent = await RunOnSelfHosted(enableSecurity, enableBlocking);
             await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, 5, new Action<TestHelpers.MockTracerAgent.Span>[]
             {
-             s => Assert.Equal("aspnet_core.request", s.Name),
+             s => Assert.Equal("aspnet_core.request", s.LogicScope),
              s  => Assert.Equal("Samples.AspNetCore5", s.Service),
              s  =>  Assert.Equal("web", s.Type)
             });

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             // NOTE: by integrating the latest version of the WAF, blocking was disabled, as it does not support blocking yet
             return TestBlockedRequestAsync(_iisFixture.Agent, _enableSecurity, _enableSecurity && _blockingEnabled ? HttpStatusCode.OK : HttpStatusCode.OK, _enableSecurity && _blockingEnabled ? 10 : 10, new Action<TestHelpers.MockTracerAgent.Span>[]
              {
-             s => Assert.Matches("aspnet(-mvc)?.request", s.Name),
+             s => Assert.Matches("aspnet(-mvc)?.request", s.LogicScope ?? s.Name),
              s => Assert.Equal("sample", s.Service),
              s => Assert.Equal("web", s.Type)
              });

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
 
             Assert.NotNull(span);
 
-            Assert.Equal("HTTP GET", span.LogicScope);
+            Assert.Equal("HTTP GET", span.OperationName);
             Assert.Equal("aspnet_core.request", span.LogicScope);
             Assert.Equal("aspnet_core", span.GetTag(Tags.InstrumentationName));
             Assert.Equal(SpanTypes.Web, span.Type);

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -78,7 +78,8 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
 
             Assert.NotNull(span);
 
-            Assert.Equal("aspnet_core.request", span.OperationName);
+            Assert.Equal("HTTP GET", span.LogicScope);
+            Assert.Equal("aspnet_core.request", span.LogicScope);
             Assert.Equal("aspnet_core", span.GetTag(Tags.InstrumentationName));
             Assert.Equal(SpanTypes.Web, span.Type);
             Assert.Equal("GET /home/?/action", span.ResourceName);

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc21,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc30,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET Home/Index,
+    Name: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
+    LogicScope: aspnet_core.request,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET Home/Index,
     Resource: GET Home/Index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET bad-request,
+    Name: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET delay/{seconds},
     Resource: GET delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
+    LogicScope: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET status-code/{statusCode},
+    Name: aspnet_core.request,
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET status-code/{statusCode},
     Resource: GET status-code/{statusCode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /home/index,
+    Name: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /home/index,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /home/index,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /api/delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /api/delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /api/delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /bad-request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /bad-request,
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /bad-request,
+    Name: aspnet_core.request,
     Resource: GET /bad-request,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/not-found,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /branch/ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /branch/ping,
+    Name: aspnet_core.request,
     Resource: GET /branch/ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /delay/{seconds},
+    Name: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
+    LogicScope: aspnet_core.request,
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /delay/{seconds},
     Resource: GET /delay/{seconds},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /not-found,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
+    LogicScope: aspnet_core.request,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /not-found,
     Resource: GET /not-found,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: HTTP GET,
     LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET /ping,
+    Name: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
+    LogicScope: aspnet_core.request,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core.request,
+    Name: GET /ping,
     Resource: GET /ping,
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET /status-code/{statuscode},
+    Name: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: aspnet_core.request,
+    Name: GET /status-code/{statuscode},
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -2,7 +2,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: aspnet_core_mvc.request,
+    Name: GET /status-code/{statuscode},
+    LogicScope: aspnet_core_mvc.request,
     Resource: GET /status-code/{statuscode},
     Service: Samples.AspNetCoreMvc31,
     Type: web,


### PR DESCRIPTION
Changes the span name for the diagnostic observer to match OpenTelemetry pattern "HTTP &lt;METHOD&gt;" if no "friendly" path is available.

There were two previous PRs that used only "&lt;METHOD&gt;", I will revisit those to use this OTel pattern instead.