### PR TITLE
Fix b3 propagation exception

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Net;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.ExtensionMethods;
@@ -48,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                 // We may have already set headers
                 var propagator = tracer.Propagator;
-                var requestContext = propagator.Extract(request.Headers, (headers, key) => headers.GetValues(key) ?? Enumerable.Empty<string>());
+                var requestContext = propagator.Extract(request.Headers, (headers, key) => headers.GetValues(key));
                 if (requestContext is null || requestContext.TraceId == TraceId.Zero)
                 {
                     var spanContext = ScopeFactory.CreateHttpSpanContext(tracer, WebRequestCommon.IntegrationId);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Net;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.ExtensionMethods;
@@ -47,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                 // We may have already set headers
                 var propagator = tracer.Propagator;
-                var requestContext = propagator.Extract(request.Headers, (headers, key) => headers.GetValues(key));
+                var requestContext = propagator.Extract(request.Headers, (headers, key) => headers.GetValues(key) ?? Enumerable.Empty<string>());
                 if (requestContext is null || requestContext.TraceId == TraceId.Zero)
                 {
                     var spanContext = ScopeFactory.CreateHttpSpanContext(tracer, WebRequestCommon.IntegrationId);

--- a/tracer/src/Datadog.Trace/Propagation/B3SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagation/B3SpanContextPropagator.cs
@@ -99,14 +99,14 @@ namespace Datadog.Trace.Propagation
 
         private static SamplingPriority? ParseB3Sampling<T>(T carrier, Func<T, string, IEnumerable<string>> getter)
         {
-            var debugged = getter(carrier, B3HttpHeaderNames.B3Flags).ToList();
-            var sampled = getter(carrier, B3HttpHeaderNames.B3Sampled).ToList();
+            var debugged = getter(carrier, B3HttpHeaderNames.B3Flags)?.ToList();
+            var sampled = getter(carrier, B3HttpHeaderNames.B3Sampled)?.ToList();
 
-            if (debugged.Count != 0 && (debugged[0] == "0" || debugged[0] == "1"))
+            if (debugged != null && debugged.Count != 0 && (debugged[0] == "0" || debugged[0] == "1"))
             {
                 return debugged[0] == "1" ? SamplingPriority.UserKeep : null;
             }
-            else if (sampled.Count != 0 && (sampled[0] == "0" || sampled[0] == "1"))
+            else if (sampled != null && sampled.Count != 0 && (sampled[0] == "0" || sampled[0] == "1"))
             {
                 return sampled[0] == "1" ? SamplingPriority.AutoKeep : SamplingPriority.AutoReject;
             }


### PR DESCRIPTION
Fix bug in B3 propagation

```
System.ArgumentNullException: Value cannot be null.
Parameter name: source
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Datadog.Trace.Propagation.B3SpanContextPropagator.ParseB3Sampling[T](T carrier, Func`3 getter)
   at Datadog.Trace.Propagation.B3SpanContextPropagator.Extract[T](T carrier, Func`3 getter)
   at Datadog.Trace.Propagation.CompositeTextMapPropagator.Extract[T](T carrier, Func`3 getter)
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_BeginGetResponse_Integration.OnMethodBegin[TTarget](TTarget instance, AsyncCallback callback, Object state)
   at HttpWebRequest_BeginGetResponse_Integration.OnMethodBegin(HttpWebRequest , AsyncCallback , Object )
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.BeginMethodHandler`4.Invoke(TTarget instance, TArg1 arg1, TArg2 arg2)
   at System.Net.HttpWebRequest.BeginGetResponse(AsyncCallback callback, Object state)
```