### PR TITLE
Adjust ado.net based integrations to Otel spec

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -225,8 +225,8 @@ namespace Datadog.Trace.ClrProfiler
             var result =
                 commandTypeName switch
                 {
-                    "SqlCommand" => "sql-server",
-                    "NpgsqlCommand" => "postgres",
+                    "SqlCommand" => "mssql",
+                    "NpgsqlCommand" => "postgresql",
                     "MySqlCommand" => "mysql",
                     "SqliteCommand" => "sqlite",
                     "SQLiteCommand" => "sqlite",

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -88,7 +88,11 @@ namespace Datadog.Trace
         /// <summary>
         /// The type of database (e.g. mssql, mysql)
         /// </summary>
-        public const string DbType = "db.type";
+        /// /// <remarks>
+        /// Upstream uses "db.type", however, to better align with OpenTelemetry we use
+        /// "db.system" instead.
+        /// </remarks>
+        public const string DbType = "db.system";
 
         /// <summary>
         /// The user used to sign into a database

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -88,7 +88,7 @@ namespace Datadog.Trace
         /// <summary>
         /// The type of database (e.g. mssql, mysql)
         /// </summary>
-        /// /// <remarks>
+        /// <remarks>
         /// Upstream uses "db.type", however, to better align with OpenTelemetry we use
         /// "db.system" instead.
         /// </remarks>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         public void SubmitsTraces()
         {
             const int expectedSpanCount = 17;
-            const string dbType = "postgres";
+            const string dbType = "postgresql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Dapper-" + dbType;
 
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         public void SubmitsTracesWithNetStandard()
         {
             const int expectedSpanCount = 17;
-            const string dbType = "postgres";
+            const string dbType = "postgresql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Dapper-" + dbType;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 expectedSpanCount = 147;
             }
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Microsoft.Data.SqlClient-" + dbType;
 
@@ -108,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var totalSpanCount = 21;
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
 
             SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var totalSpanCount = 21;
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
 
             SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SQLite.SQLiteCommand,Microsoft.Data.Sqlite.SqliteCommand");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 #endif
             }
 
-            const string dbType = "postgres";
+            const string dbType = "postgresql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Npgsql-" + dbType;
 
@@ -115,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var totalSpanCount = 21;
 
-            const string dbType = "postgres";
+            const string dbType = "postgresql";
             const string expectedOperationName = dbType + ".query";
 
             SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 expectedSpanCount = 28; // CallTarget support instrumenting a constrained generic caller.
             }
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.SqlServer.NetFramework20-" + dbType;
 
@@ -75,7 +75,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var totalSpanCount = 21;
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
 
             SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 #endif
             }
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.SqlServer-" + dbType;
 
@@ -113,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var totalSpanCount = 21;
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
 
             SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var totalSpanCount = 21;
 
-            const string dbType = "sql-server";
+            const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
 
             SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SQLite.SQLiteCommand,Microsoft.Data.Sqlite.SqliteCommand");

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
@@ -95,9 +95,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         }
 
         [Theory]
-        [InlineData("System.Data.SqlClient", "SqlCommand", "sql-server")]
+        [InlineData("System.Data.SqlClient", "SqlCommand", "mssql")]
         [InlineData("MySql.Data.MySqlClient", "MySqlCommand", "mysql")]
-        [InlineData("Npgsql", "NpgsqlCommand", "postgres")]
+        [InlineData("Npgsql", "NpgsqlCommand", "postgresql")]
         [InlineData("", "ProfiledDbCommand", null)]
         [InlineData("", "ExampleCommand", "example")]
         [InlineData("", "Example", "example")]


### PR DESCRIPTION
Changes proposed in this pull request:
Adjusts ADO.NET based integrations to Otel spec




@signalfx/instrumentation