### PR TITLE
Add option to disable CancelKeyPress event subscription

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -390,6 +390,13 @@ namespace SignalFx.Tracing.Configuration
             /// Configuration key for forcing the automatic instrumentation to only use the fallback method lookup mechanism.
             /// </summary>
             public const string ForceFallbackLookup = "SIGNALFX_TRACE_DEBUG_LOOKUP_FALLBACK";
+
+            /// <summary>
+            /// Configuration key for forcing disabling subscription to the Console.CancelKeyPress event (Win32 SetConsoleCtrlHandler).
+            /// By default the handler is enabled.
+            /// </summary>
+            /// <seealso cref="TracerSettings.DisableCancelKeyPressEvent"/>
+            public const string DisableCancelKeyPressEvent = "SIGNALFX_DISABLE_CONSOLE_CTRL_HANDLE";
         }
 
         internal static class FeatureFlags

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -180,6 +180,8 @@ namespace SignalFx.Tracing.Configuration
 
             TraceResponseHeaderEnabled = source?.GetBool(ConfigurationKeys.TraceResponseHeaderEnabled) ?? true;
 
+            DisableCancelKeyPressEvent = source?.GetBool(ConfigurationKeys.Debug.DisableCancelKeyPressEvent) ?? false;
+
             RouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled) ?? true;
         }
 
@@ -420,6 +422,13 @@ namespace SignalFx.Tracing.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.OutboundHttpExcludedHosts"/>
         public HashSet<string> OutboundHttpExcludedHosts { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the feature flag to enable subscription to the Console.CancelKeyPress event (Win32 SetConsoleCtrlHandler).
+        /// By default the handler is enabled.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.Debug.DisableCancelKeyPressEvent"/>
+        internal bool DisableCancelKeyPressEvent { get; }
 
         /// <summary>
         /// Gets a value indicating whether the feature flag to enable the updated ASP.NET resource names is enabled

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -138,7 +138,11 @@ namespace SignalFx.Tracing
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
             AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            Console.CancelKeyPress += Console_CancelKeyPress;
+
+            if (!Settings.DisableCancelKeyPressEvent)
+            {
+                Console.CancelKeyPress += Console_CancelKeyPress;
+            }
 
             // start the heartbeat loop
             _heartbeatTimer = new Timer(HeartbeatCallback, state: null, dueTime: TimeSpan.Zero, period: TimeSpan.FromMinutes(1));

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -143,6 +143,7 @@ namespace SignalFx.Tracing
             {
                 try
                 {
+                    // Registering for the cancel key press event requires the System.Security.Permissions.UIPermission
                     Console.CancelKeyPress += Console_CancelKeyPress;
                 }
                 catch (Exception ex)

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -141,7 +141,14 @@ namespace SignalFx.Tracing
 
             if (!Settings.DisableCancelKeyPressEvent)
             {
-                Console.CancelKeyPress += Console_CancelKeyPress;
+                try
+                {
+                    Console.CancelKeyPress += Console_CancelKeyPress;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Unable to register a callback to the Console.CancelKeyPress event.");
+                }
             }
 
             // start the heartbeat loop


### PR DESCRIPTION
The main purpose of this change is to test a case in which there is an exception when the finalizer of the handler is called. It seems that this is not actually the cause of the crash but a side effect. Building a version in which we can disable the subscription to CancelKeyPress so we can investigate further.

At this point it is not clear if this should be merged or not.