### PR TITLE
[WIP] Switch to Splunk OTel Connector

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -16,9 +16,7 @@ services:
       - SPLUNK_ACCESS_TOKEN
       - SPLUNK_REALM=us0
     ports:
-      - "1777:1777"  # pprof extension
       - "8888:8888"  # Prometheus metrics exposed by the collector
-      - "8889:8889"  # Prometheus exporter metrics
       - "13133:13133" # health_check extension
       - "4317:4317"  # OTLP gRPC receiver
       - "55679:55679" # zpages extension

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -9,11 +9,12 @@ services:
       - "14250:14250"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.37.1
+    image: quay.io/signalfx/splunk-otel-collector:0.37.1
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
     environment:
-      - SPLUNK_AUTH_TOKEN
+      - SPLUNK_ACCESS_TOKEN
+      - SPLUNK_REALM=us0
     ports:
       - "1777:1777"  # pprof extension
       - "8888:8888"  # Prometheus metrics exposed by the collector

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
     environment:
       - SPLUNK_ACCESS_TOKEN
       - SPLUNK_REALM=us0
+      - JAEGER_ENDPOINT=jaeger:14250
     ports:
       - "8888:8888"  # Prometheus metrics exposed by the collector
       - "13133:13133" # health_check extension

--- a/dev/otel-config.yaml
+++ b/dev/otel-config.yaml
@@ -145,7 +145,7 @@ exporters:
     loglevel: debug
   # Jaeger
   jaeger:
-    endpoint: jaeger:14250
+    endpoint: "${JAEGER_ENDPOINT}" 
     tls:
       insecure: true
 

--- a/dev/otel-config.yaml
+++ b/dev/otel-config.yaml
@@ -1,56 +1,192 @@
+# based on:
+# - https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/agent_config.yaml
+# - https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/full_config_linux.yaml
+
 extensions:
   health_check:
-  pprof:
-    endpoint: :1777
+    endpoint: 0.0.0.0:13133
+  http_forwarder:
+    ingress:
+      endpoint: 0.0.0.0:6060
+    egress:
+      endpoint: "${SPLUNK_API_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}"
+  smartagent:
+    bundleDir: "${SPLUNK_BUNDLE_DIR}"
+    collectd:
+      configDir: "${SPLUNK_COLLECTD_DIR}"
   zpages:
-    endpoint: :55679
+    #endpoint: 0.0.0.0:55679
+  memory_ballast:
+    # In general, the ballast should be set to 1/3 of the collector's memory, the limit
+    # should be 90% of the collector's memory.
+    # The simplest way to specify the ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable.
+    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
 receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
-  opencensus:
+  fluentforward:
+    endpoint: 127.0.0.1:8006
+  hostmetrics:
+    collection_interval: 10s
+    scrapers:
+      cpu:
+      disk:
+      filesystem:
+      memory:
+      network:
+      # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
+      load:
+      # Paging/Swap space utilization and I/O metrics
+      paging:
+      # Aggregated system process count metrics
+      processes:
+      # System processes metrics, disabled by default
+      # process:
   jaeger:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:14250
       thrift_binary:
+        endpoint: 0.0.0.0:6832
       thrift_compact:
+        endpoint: 0.0.0.0:6831
       thrift_http:
+        endpoint: 0.0.0.0:14268
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:55681
+  # This section is used to collect the OpenTelemetry Collector metrics
+  # Even if just a Splunk APM customer, these metrics are included
+  prometheus/internal:
+    config:
+      scrape_configs:
+      - job_name: 'otel-collector'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: '.*grpc_io.*'
+            action: drop
+  smartagent/signalfx-forwarder:
+    type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080
+  signalfx:
+    endpoint: 0.0.0.0:9943
+    # Whether to preserve incoming access token and use instead of exporter token
+    # default = false
+    #access_token_passthrough: true
   zipkin:
+    endpoint: 0.0.0.0:9411
 
 processors:
   batch:
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # For more information about memory limiter, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
+  memory_limiter:
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+
+  # Detect if the collector is running on a cloud system, which is important for creating unique cloud provider dimensions.
+  # Detector order is important: the `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
+  resourcedetection:
+    detectors: [gce, ecs, ec2, azure, system]
+    override: false
+
+  # Same as above but overrides resource attributes set by receivers
+  resourcedetection/internal:
+    detectors: [gce, ecs, ec2, azure, system]
+    override: true
+
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 
+  # traces when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #value: staging/production/...
+        #key: deployment.environment
 
 exporters:
+  # Traces
+  sapm:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    endpoint: "${SPLUNK_TRACE_URL}"
+  # Metrics + Events
+  signalfx:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    api_url: "${SPLUNK_API_URL}"
+    ingest_url: "${SPLUNK_INGEST_URL}"
+    # Use instead when sending to gateway
+    #api_url: http://${SPLUNK_GATEWAY_URL}:6060
+    #ingest_url: http://${SPLUNK_GATEWAY_URL}:9943
+    sync_host_metadata: true
+    correlation:
+  # Logs
+  splunk_hec:
+    token: "${SPLUNK_HEC_TOKEN}"
+    endpoint: "${SPLUNK_HEC_URL}"
+    source: "otel"
+    sourcetype: "otel"
+  # Send to gateway
+  otlp:
+    endpoint: "${SPLUNK_GATEWAY_URL}:4317"
+    tls:
+      insecure: true
+  # Debug
   logging:
-    logLevel: debug
-
-  zipkin:
-    endpoint: https://ingest.us0.signalfx.com/v2/trace
-    headers:
-      # Splunk Observability Cloud accepts Basic auth where user=auth and password=access-token
-      Authorization: Basic ${SPLUNK_AUTH_TOKEN}
+    loglevel: debug
+  # Jaeger
   jaeger:
     endpoint: jaeger:14250
     tls:
       insecure: true
-  prometheus:
-    endpoint: "0.0.0.0:8889"
-    namespace: promexample
-    const_labels:
-      label1: value1
 
 service:
+  extensions: [health_check, http_forwarder, zpages, memory_ballast]
   pipelines:
     traces:
-      receivers: [otlp, opencensus, jaeger, zipkin]
-      processors: [batch]
-      exporters: [logging, jaeger, zipkin]
+      receivers: [jaeger, otlp, smartagent/signalfx-forwarder, zipkin]
+      processors:
+      - memory_limiter
+      - batch
+      - resourcedetection
+      #- resource/add_environment
+      exporters: [logging, sapm, signalfx, jaeger]
+      # Use instead when sending to gateway
+      #exporters: [otlp, signalfx]
     metrics:
-      receivers: [otlp, opencensus]
-      processors: [batch]
-      exporters: [prometheus]
-      #exporters: [logging]
-
-  extensions: [health_check, pprof, zpages]
+      receivers: [hostmetrics, otlp, signalfx, smartagent/signalfx-forwarder]
+      processors: [memory_limiter, batch, resourcedetection]
+      exporters: [signalfx]
+      # Use instead when sending to gateway
+      #exporters: [otlp]
+    metrics/internal:
+      receivers: [prometheus/internal]
+      processors: [memory_limiter, batch, resourcedetection/internal]
+      exporters: [signalfx]
+      # Use instead when sending to gateway
+      #exporters: [otlp]
+    logs/signalfx:
+      receivers: [signalfx]
+      processors: [memory_limiter, batch]
+      exporters: [signalfx]
+      # Use instead when sending to gateway
+      #exporters: [otlp]
+    logs:
+      receivers: [fluentforward, otlp]
+      processors:
+      - memory_limiter
+      - batch
+      - resourcedetection
+      #- resource/add_environment
+      exporters: [splunk_hec]
+      # Use instead when sending to gateway
+      #exporters: [otlp]

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -27,7 +27,7 @@ You can run the services using:
 SPLUNK_ACCESS_TOKEN=secret docker-compose -f dev/docker-compose.yaml up
 ```
 
-The value for `SPLUNK_ACCESS_TOKEN` env var can be found
+The value for `SPLUNK_ACCESS_TOKEN` can be found
 [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
 
 The following Web UI endpoints are exposed:

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -21,19 +21,14 @@ If for whatever reason you need to use `Datadog.Trace.sln` you can run `./tracer
 The [`dev/docker-compose.yaml`](../dev/docker-compose.yaml) contains configuration for running OTel Collector and Jaeger.
 It also configured to send the traces to Splunk Observability Cloud.
 
-Before running `docker-compose` make sure to set `SPLUNK_AUTH_TOKEN` env var.
-You can do this by executing following command in Bash,
-where a value for `$SPLUNK_ACCESS_TOKEN` can be found [here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
-
-```sh
-export SPLUNK_AUTH_TOKEN=$(echo -n "auth:$SPLUNK_ACCESS_TOKEN" | base64)
-```
-
 You can run the services using:
 
 ```sh
-docker-compose -f dev/docker-compose.yaml up
+SPLUNK_ACCESS_TOKEN=secret docker-compose -f dev/docker-compose.yaml up
 ```
+
+The value for `SPLUNK_ACCESS_TOKEN` env var can be found
+[here](https://app.signalfx.com/o11y/#/organization/current?selectedKeyValue=sf_section:accesstokens).
 
 The following Web UI endpoints are exposed:
 


### PR DESCRIPTION
Not sure why it is not working. I decided to do https://github.com/signalfx/signalfx-dotnet-tracing/pull/195 first and look at it later

I guess it might be related to the env vars. 

Abandoning as I tested that everything works correctly when I used:

```
docker run --rm -e SPLUNK_ACCESS_TOKEN -e SPLUNK_REALM=us0 \
    -p 13133:13133 -p 14250:14250 -p 14268:14268 -p 4317:4317 -p 6060:6060 \
    -p 8888:8888 -p 9080:9080 -p 9411:9411 -p 9943:9943 \
    --name otelcol quay.io/signalfx/splunk-otel-collector:latest
```