### PR TITLE
Default RouteTemplateResourceNamesEnabled to true

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -64,6 +64,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | The maximum length an attribute value can have. Values longer than this are truncated. Values are completely truncated when set to 0, and ignored when set to a negative value. | `12000` |
+| `SIGNALFX_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` | `true` |  ASP.NET span and resource names are based on routing configuration if applicable. |
 
 ## Ways to configure
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -212,7 +212,7 @@ namespace Datadog.Trace.Configuration
             }
 
             RouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
-                                                   ?? false;
+                                                   ?? true;
 
             TraceResponseHeaderEnabled = source?.GetBool(ConfigurationKeys.TraceResponseHeaderEnabled) ?? true;
 


### PR DESCRIPTION
## What

`RouteTemplateResourceNamesEnabled` is `true` by default.

## Why

https://github.com/signalfx/signalfx-dotnet-tracing/pull/191#discussion_r742102774

Why we are considering changing it

1. It is what is currently done on `main`: https://github.com/signalfx/signalfx-dotnet-tracing/blob/af2d083175b6433d8ddce700c70a22c1817b7af7/src/Datadog.Trace/Configuration/TracerSettings.cs#L183 . In this PR: https://github.com/signalfx/signalfx-dotnet-tracing/pull/118

Why it may be good to leave as it is:

1. Upstream still defaults to `false`.
2. Personally I am not sure what is the advantage when comparing the `.NoFF.*.verified.txt` files with `.WithFF.*.verified.txt` files. @RassK can you find some examples there?