### PR TITLE
Redis semantic convention

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -64,6 +64,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | The maximum length an attribute value can have. Values longer than this are truncated. Values are completely truncated when set to 0, and ignored when set to a negative value. | `12000` |
 | `SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS` | Enable the tagging of a Mongo command BsonDocument as db.statement. | `true` |
+| `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS` | Enable the tagging of a Redis commands as db.statement. | `true` |
 
 ## Ways to configure
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/RedisHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/RedisHelper.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis;
 using Datadog.Trace.Configuration;
@@ -40,7 +42,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 var tags = new RedisTags();
 
-                scope = tracer.StartActiveWithTags(OperationName, serviceName: serviceName, tags: tags);
                 int separatorIndex = rawCommand.IndexOf(' ');
                 string command;
 
@@ -53,10 +54,18 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     command = rawCommand;
                 }
 
+                scope = tracer.StartActiveWithTags(command ?? OperationName, serviceName: tracer.DefaultServiceName, tags: tags);
+
                 var span = scope.Span;
                 span.Type = SpanTypes.Redis;
                 span.ResourceName = command;
-                tags.RawCommand = rawCommand;
+                span.LogicScope = OperationName;
+
+                if (tracer.Settings.TagRedisCommands)
+                {
+                    tags.RawCommand = rawCommand;
+                }
+
                 tags.Host = host;
                 tags.Port = port;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/StackExchange.Redis/RedisTags.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/StackExchange.Redis/RedisTags.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Tagging;
 
@@ -13,6 +15,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         protected static readonly IProperty<string>[] RedisTagsProperties =
             InstrumentationTagsProperties.Concat(
                 new ReadOnlyProperty<RedisTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName),
+                new ReadOnlyProperty<RedisTags, string>(Trace.Tags.DbType, t => t.DbType),
                 new Property<RedisTags, string>(Trace.Tags.RedisRawCommand, t => t.RawCommand, (t, v) => t.RawCommand = v),
                 new Property<RedisTags, string>(Trace.Tags.OutPort, t => t.Port, (t, v) => t.Port = v),
                 new Property<RedisTags, string>(Trace.Tags.OutHost, t => t.Host, (t, v) => t.Host = v));
@@ -20,6 +23,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         public override string SpanKind => SpanKinds.Client;
 
         public string InstrumentationName => RedisBatch.IntegrationName;
+
+        public string DbType => SpanTypes.Redis;
 
         public string RawCommand { get; set; }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -279,6 +279,13 @@ namespace Datadog.Trace.Configuration
         public const string RuntimeMetricsEnabled = "SIGNALFX_RUNTIME_METRICS_ENABLED";
 
         /// <summary>
+        /// Configuration key for enabling or disabling tagging Redis
+        /// commands as db.statement.
+        /// </summary>
+        /// <seealso cref="TracerSettings.TagRedisCommands"/>
+        public const string TagRedisCommands = "SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS";
+
+        /// <summary>
         /// Configuration key for setting the approximate maximum size,
         /// in bytes, for Tracer log files.
         /// Default value is 10 MB.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -162,6 +162,10 @@ namespace Datadog.Trace.Configuration
                                    // default value
                                    false;
 
+            TagRedisCommands = source?.GetBool(ConfigurationKeys.TagRedisCommands) ??
+                            // default value
+                            true;
+
             RuntimeMetricsEnabled = source?.GetBool(ConfigurationKeys.RuntimeMetricsEnabled) ??
                                     false;
 
@@ -390,6 +394,14 @@ namespace Datadog.Trace.Configuration
         /// are enabled and sent to DogStatsd.
         /// </summary>
         public bool TracerMetricsEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Redis integrations
+        /// should tag commands as db.statement.
+        /// Default is <c>true</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.TagRedisCommands"/>
+        public bool TagRedisCommands { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the exporter to be used. The Tracer uses it to encode and

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -202,7 +202,7 @@ namespace Datadog.Trace
         /// <summary>
         /// The raw command sent to Redis.
         /// </summary>
-        public const string RedisRawCommand = "redis.raw_command";
+        public const string RedisRawCommand = DbStatement;
 
         /// <summary>
         /// A MongoDB query.

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    Assert.Equal("redis.command", span.Name);
+                    Assert.Equal("redis.command", span.LogicScope);
                     Assert.Equal("Samples.ServiceStack.Redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  ? spans[i].Resource
                                  : string.Empty;
                     var a2 = i < spans.Count
-                                 ? DictionaryExtensions.GetValueOrDefault(spans[i].Tags, "redis.raw_command")
+                                 ? DictionaryExtensions.GetValueOrDefault(spans[i].Tags, "db.statement")
                                  : string.Empty;
 
                     Assert.True(e1 == a1, $@"invalid resource name for span #{i}, expected ""{e1}"", actual ""{a1}""");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -275,7 +275,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    Assert.Equal("redis.command", span.Name);
+                    Assert.Equal("redis.command", span.LogicScope);
                     Assert.Equal("Samples.StackExchange.Redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
@@ -286,7 +286,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spanLookup = new Dictionary<Tuple<string, string>, int>();
                 foreach (var span in spans)
                 {
-                    var key = new Tuple<string, string>(span.Resource, DictionaryExtensions.GetValueOrDefault(span.Tags, "redis.raw_command"));
+                    var key = new Tuple<string, string>(span.Resource, DictionaryExtensions.GetValueOrDefault(span.Tags, "db.statement"));
                     if (spanLookup.ContainsKey(key))
                     {
                         spanLookup[key]++;


### PR DESCRIPTION
main: conditionaly sends db.statement if SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS default value - true

upstream/next-ver:
no codition
sends the same value as redis.raw_command

potential values for db.statement/redis.raw_command:
SPOP setkey1
RESTORE StackExchange.Redis.Database.Key
SMOVE StackExchange.Redis.Database.Set
BITPOS StackExchange.Redis.Database.Key
TIME
HVALS StackExchange.Redis.Batch.HashValuesAsync
ECHO Hello World
SMOVE setkey1
ZREMRANGEBYSCORE ssetkey

Based on OTel documentation we should condifer to use db.operation for part of the commands. Potentailly, it requires either parsing of command or refactoring passing parameters (do not investigated how deeply).

Applied main behaviour to next-ver.

upstream/before changes: https://app.signalfx.com/#/apm/traces/23a3580222993e024a48c8382ff15e24

db.statement enabled: https://app.signalfx.com/#/apm/traces/4101997c23a1bbc270ad625bdf6860be
db.statement disable: https://app.signalfx.com/#/apm/traces/3c70a61f62c000045e462a412ce280a0