### PR TITLE
Automate release for next-ver branch

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -73,7 +73,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v}
       # TODO: Extract release notes
       - name: Create Release
-        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi
+        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft --prerelease artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -48,7 +48,6 @@ jobs:
       - run: git config --system core.longpaths true
       - uses: actions/checkout@v2
       - uses: microsoft/setup-msbuild@v1.0.2
-      - name: Run 'Clean BuildTracerHome ZipTracerHome'
         run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -2,13 +2,13 @@ name: Publish Release Artifacts
 
 on:
   push:
-    branches:
-    - next-ver
     tags:
     - 'v*'
 
 jobs:
   linux_build:
+    name: Linux Build
+    if: github.event.base_ref == 'refs/heads/next-ver'
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
@@ -44,6 +44,7 @@ jobs:
 
   windows_build:
     name: Windows Build
+    if: github.event.base_ref == 'refs/heads/next-ver'
     runs-on: windows-2019
     steps:
       - run: git config --system core.longpaths true

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,7 +3,7 @@ name: Publish Release Artifacts
 on:
   push:
     branches:
-    - next-ver-automate-releases
+    - next-ver
     tags:
     - 'v*'
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   linux_build:
     name: Linux Build
-    if: github.event.base_ref == 'refs/heads/next-ver'
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
@@ -44,7 +43,6 @@ jobs:
 
   windows_build:
     name: Windows Build
-    if: github.event.base_ref == 'refs/heads/next-ver'
     runs-on: windows-2019
     steps:
       - run: git config --system core.longpaths true

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -73,7 +73,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v}
       # TODO: Extract release notes
       - name: Create Release
-        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft -F notes.md artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi
+        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,10 +1,16 @@
-name: Build artifacts
+name: Publish Release Artifacts
+
 on:
-  workflow_dispatch:
+  push:
+    branches:
+    - next-ver-automate-releases
+    tags:
+    - 'v*'
 
 jobs:
   linux_build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
     strategy:
       matrix:
         baseImage: [alpine, debian]
@@ -29,9 +35,6 @@ jobs:
           --env NugetPackageDirectory=/project/packages \
           --env tracerHome=/project/tracer/bin/tracer-home \
           --env artifacts=/project/tracer/src/bin/artifacts \
-          --env SIGNALFX_CLR_ENABLE_NGEN=${SIGNALFX_CLR_ENABLE_NGEN} \
-          --env Verify_DisableClipboard=true \
-          --env DiffEngine_Disabled=true \
           dd-trace-dotnet/${baseImage}-builder \
           dotnet /build/bin/Debug/_build.dll Clean BuildTracerHome ZipTracerHome
     - uses: actions/upload-artifact@v2
@@ -46,13 +49,8 @@ jobs:
       - run: git config --system core.longpaths true
       - uses: actions/checkout@v2
       - uses: microsoft/setup-msbuild@v1.0.2
-      - run: dotnet --list-sdks
-        shell: cmd
-      - run: choco install wixtoolset
-        shell: cmd
-      - run: tracer\build.cmd BuildTracerHome
-        shell: cmd
-      - run: tracer\build.cmd PackageTracerHome
+      - name: Run 'Clean BuildTracerHome ZipTracerHome'
+        run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - uses: actions/upload-artifact@v2
         with:
@@ -70,12 +68,12 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           path: .
-      - name: Extract tag name
+      - name: Extract Version from Tag
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v}
-      - name: Extract release notes
-        run: awk '/## \[${{ steps.get_version.outputs.VERSION }}\]/,0' docs/CHANGELOG.md >> notes.md
-      - run: gh release create v${{ steps.get_version.outputs.VERSION }} -F notes.md artifacts/otel* artifacts/x64/en-us/opentelemetry* artifacts/x86/en-us/opentelemetry*
+      # TODO: Extract release notes
+      - name: Create Release
+        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft -F notes.md artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Automate the generation of releases for the next-ver branch. It includes the Alpine package. 

It doesn't include automatic generation of release notes and version update. Upstream has some related actions for that but keeping it very simple here so we can start publish releases for earlier test of next-ver. All releases are created via this, are marked as pre-release and also as a draft so final publication requires a manual approval.

When next-ver becomes the default branch we can improve the process by triggering this type of action manually.

- Run of publish release tags: https://github.com/pjanotti/signalfx-dotnet-tracing/actions/runs/1459480288
- Example of release: https://github.com/pjanotti/signalfx-dotnet-tracing/releases/tag/untagged-c2b1812b905167a33226
