### PR TITLE
Adjust service name naming convention

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/GraphQLIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/GraphQLIntegration.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     {
         internal const string IntegrationName = nameof(IntegrationIds.GraphQL);
         internal static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
+        private const string ServiceName = "graphql";
 
         private const string Major2 = "2";
         private const string Major2Minor3 = "2.3";
@@ -243,13 +244,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             Tracer tracer = Tracer.Instance;
             string source = document.GetProperty<string>("OriginalQuery")
                                     .GetValueOrDefault();
+            string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
 
             Scope scope = null;
 
             try
             {
                 var tags = new GraphQLTags();
-                scope = tracer.StartActiveWithTags(ValidateOperationName, tags: tags);
+                scope = tracer.StartActiveWithTags(ValidateOperationName, serviceName: serviceName, tags: tags);
                 var span = scope.Span;
                 span.LogicScope = ValidateOperationName;
                 DecorateSpan(span, tags);
@@ -284,6 +286,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                                                        .GetProperty<Enum>("OperationType")
                                                        .GetValueOrDefault()
                                                        .ToString();
+            string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
+
             Scope scope = null;
 
             try
@@ -293,7 +297,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     ? operationType
                     : $"{operationType} {operationName}";
 
-                scope = tracer.StartActiveWithTags(operation, tags: tags);
+                scope = tracer.StartActiveWithTags(operation, serviceName: serviceName, tags: tags);
                 var span = scope.Span;
                 DecorateSpan(span, tags);
                 span.ResourceName = $"{operationType} {operationName ?? "operation"}";

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/MongoDbIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/MongoDbIntegration.cs
@@ -422,12 +422,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 Log.Warning(ex, "Unable to access IWireProtocol.Command properties.");
             }
 
+            string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
+
             Scope scope = null;
 
             try
             {
                 var tags = new MongoDbTags();
-                scope = tracer.StartActiveWithTags(operationName ?? DefaultOperationName, tags: tags);
+                scope = tracer.StartActiveWithTags(operationName ?? DefaultOperationName, serviceName: serviceName, tags: tags);
                 var span = scope.Span;
                 span.LogicScope = DefaultOperationName;
                 span.Type = SpanTypes.MongoDb;

--- a/tracer/src/Datadog.Trace/Configuration/ServiceNames.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ServiceNames.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System.Collections.Generic;
 using System.Linq;
 
@@ -29,7 +31,7 @@ namespace Datadog.Trace.Configuration
             }
             else
             {
-                return $"{applicationName}-{key}";
+                return applicationName;
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -139,7 +139,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                     .ExcludingMissingMembers()
                     .ExcludingDefaultSpanProperties()
                     .AssertMetricsMatchExcludingKeys("_dd.tracer_kr", "_sampling_priority_v1")
-                    .AssertTagsMatchAndSpecifiedTagsPresent("deployment.environment", "aws.requestId", "aws.queue.url", "runtime-id"));
+                    .AssertTagsMatchAndSpecifiedTagsPresent("deployment.environment", "aws.requestId", "aws.queue.url"));
             }
         }
 
@@ -151,7 +151,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 {
                     Name = "sqs.request",
                     Resource = $"SQS.{operationName}",
-                    Service = "Samples.AWS.SQS-aws-sqs",
+                    Service = "Samples.AWS.SQS",
                     Tags = new()
                     {
                         { "component", "aws-sdk" },
@@ -162,10 +162,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                         { "http.method", "POST" },
                         { "http.status_code", "200" },
                     },
-                    Metrics = new()
-                    {
-                        { "_dd.top_level", 1 }
-                    },
+                    Metrics = new(),
                     Type = SpanTypes.Http,
                 };
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const int expectedSpanCount = 17;
             const string dbType = "postgresql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.Dapper-" + dbType;
+            const string expectedServiceName = "Samples.Dapper";
 
             int agentPort = TcpPortProvider.GetOpenPort();
 
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const int expectedSpanCount = 17;
             const string dbType = "postgresql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.Dapper-" + dbType;
+            const string expectedServiceName = "Samples.Dapper";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags?[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags?[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "fake";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.FakeDbCommand-" + dbType;
+            const string expectedServiceName = "Samples.FakeDbCommand";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.Microsoft.Data.SqlClient-" + dbType;
+            const string expectedServiceName = "Samples.Microsoft.Data.SqlClient";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "sqlite";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.Microsoft.Data.Sqlite-" + dbType;
+            const string expectedServiceName = "Samples.Microsoft.Data.Sqlite";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "mysql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.MySql-" + dbType;
+            const string expectedServiceName = "Samples.MySql";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -156,7 +156,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
@@ -69,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "mysql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.MySqlConnector-" + dbType;
+            const string expectedServiceName = "Samples.MySqlConnector";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "postgresql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.Npgsql-" + dbType;
+            const string expectedServiceName = "Samples.Npgsql";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             // see https://github.com/DataDog/dd-trace-dotnet/pull/753

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if NET452
 using System;
 using System.Collections.Generic;
@@ -43,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.SqlServer.NetFramework20-" + dbType;
+            const string expectedServiceName = "Samples.SqlServer.NetFramework20";
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "mssql";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.SqlServer-" + dbType;
+            const string expectedServiceName = "Samples.SqlServer";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Sql, span.Type);
                     Assert.Equal(dbType, span.Tags[Tags.DbType]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                     Assert.Contains(Tags.DbStatement, (IDictionary<string, string>)span.Tags);
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             const string dbType = "sqlite";
             const string expectedOperationName = dbType + ".query";
-            const string expectedServiceName = "Samples.SQLite.Core-" + dbType;
+            const string expectedServiceName = "Samples.SQLite.Core";
 
             // NOTE: opt into the additional instrumentation of calls into netstandard.dll
             SetEnvironmentVariable("SIGNALFX_TRACE_NETSTANDARD_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 spans.Should()
                      .OnlyContain(span => span.Name == "aerospike.command")
-                     .And.OnlyContain(span => span.Service == "Samples.Aerospike-aerospike")
+                     .And.OnlyContain(span => span.Service == "Samples.Aerospike")
                      .And.OnlyContain(span => span.Tags[Tags.SpanKind] == SpanKinds.Client)
                      .And.OnlyContain(span => ValidateSpanKey(span));
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if !NET452
 using System;
 using System.Collections.Generic;
@@ -19,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class CosmosTests : TestHelper
     {
         private const string ExpectedOperationName = "cosmosdb.query";
-        private const string ExpectedServiceName = "Samples.CosmosDb-cosmosdb";
+        private const string ExpectedServiceName = "Samples.CosmosDb";
 
         public CosmosTests(ITestOutputHelper output)
             : base("CosmosDb", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     span.Service.Should().Be(ExpectedServiceName);
                     span.Type.Should().Be(SpanTypes.Sql);
                     span.Resource.Should().StartWith("SELECT * FROM");
-                    span.Tags.Should().NotContain(Tags.Version, "External service span should not have service version tag.");
+                    span.Tags.Should().Contain(new KeyValuePair<string, string>(Tags.Version, "1.0.0"));
                     span.Tags.Should().Contain(new KeyValuePair<string, string>(Tags.DbType, "cosmosdb"));
                     span.Tags.Should().Contain(new KeyValuePair<string, string>(Tags.OutHost, "https://localhost:8081/"));
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.ExtensionMethods;
@@ -146,7 +148,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 foreach (var span in spans)
                 {
                     Assert.Equal("elasticsearch.query", span.Name);
-                    Assert.Equal("Samples.Elasticsearch.V5-elasticsearch", span.Service);
+                    Assert.Equal("Samples.Elasticsearch.V5", span.Service);
                     Assert.Equal("elasticsearch", span.Type);
                     Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -150,7 +150,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal("elasticsearch.query", span.Name);
                     Assert.Equal("Samples.Elasticsearch.V5", span.Service);
                     Assert.Equal("elasticsearch", span.Type);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 
                 ValidateSpans(spans, (span) => span.Resource, expected);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -158,7 +158,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal("elasticsearch.query", span.Name);
                     Assert.Equal("Samples.Elasticsearch", span.Service);
                     Assert.Equal("elasticsearch", span.Type);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 
                 ValidateSpans(spans, (span) => span.Resource, expected);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -154,7 +156,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 foreach (var span in spans)
                 {
                     Assert.Equal("elasticsearch.query", span.Name);
-                    Assert.Equal("Samples.Elasticsearch-elasticsearch", span.Service);
+                    Assert.Equal("Samples.Elasticsearch", span.Service);
                     Assert.Equal("elasticsearch", span.Type);
                     Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -145,7 +147,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 foreach (var span in spans)
                 {
                     Assert.Equal("elasticsearch.query", span.Name);
-                    Assert.Equal("Samples.Elasticsearch.V7-elasticsearch", span.Service);
+                    Assert.Equal("Samples.Elasticsearch.V7", span.Service);
                     Assert.Equal("elasticsearch", span.Type);
                     Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -149,7 +149,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal("elasticsearch.query", span.Name);
                     Assert.Equal("Samples.Elasticsearch.V7", span.Service);
                     Assert.Equal("elasticsearch", span.Type);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 
                 ValidateSpans(spans, (span) => span.Resource, expected);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Http, span.Type);
                     Assert.Equal("HttpMessageHandler", span.Tags[Tags.InstrumentationName]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
 
                     if (span.Tags[Tags.HttpStatusCode] == "502")
                     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedSpanCount = expectedAsyncCount + expectedSyncCount;
 
             const string expectedOperationName = "http.request";
-            const string expectedServiceName = "Samples.HttpMessageHandler-http-client";
+            const string expectedServiceName = "Samples.HttpMessageHandler";
 
             int agentPort = TcpPortProvider.GetOpenPort();
             int httpPort = TcpPortProvider.GetOpenPort();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -138,7 +140,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             producerSpans.Should()
                          .HaveCount(expectedCount)
-                         .And.OnlyContain(x => x.Service == "Samples.Kafka-kafka")
+                         .And.OnlyContain(x => x.Service == "Samples.Kafka")
                          .And.OnlyContain(x => x.Resource == resourceName)
                          .And.OnlyContain(x => x.Metrics.ContainsKey(Tags.Measured) && x.Metrics[Tags.Measured] == 1.0);
         }
@@ -148,7 +150,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // HaveCountGreaterOrEqualTo because same message may be consumed by both
             consumerSpans.Should()
                          .HaveCountGreaterOrEqualTo(expectedCount)
-                         .And.OnlyContain(x => x.Service == "Samples.Kafka-kafka")
+                         .And.OnlyContain(x => x.Service == "Samples.Kafka")
                          .And.OnlyContain(x => x.Resource == resourceName)
                          .And.OnlyContain(x => x.Metrics.ContainsKey(Tags.Measured) && x.Metrics[Tags.Measured] == 1.0)
                          .And.OnlyContain(x => x.Metrics.ContainsKey(Metrics.MessageQueueTimeMs))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 span.Name.Should().Be("msmq.command");
-                span.Tags?.ContainsKey(Tags.Version).Should().BeFalse("External service span should not have service version tag.");
+                span.Tags.Should().ContainKey(Tags.Version);
 
                 var command = span.Tags[Tags.MsmqCommand];
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if NETFRAMEWORK
 using System;
 using System.Linq;
@@ -15,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class MsmqTests : TestHelper
     {
-        private const string ExpectedServiceName = "Samples.Msmq-msmq";
+        private const string ExpectedServiceName = "Samples.Msmq";
 
         public MsmqTests(ITestOutputHelper output)
             : base("Msmq", output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
@@ -143,7 +143,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 {
                     Assert.Equal(expectedOperationName, span.LogicScope);
                     Assert.Equal(SpanTypes.Http, span.Type);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
 
                     // Register the service to our service<->span map
                     if (!actualMap.TryGetValue(span.Service, out int newCount))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
@@ -60,13 +60,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var expectedMap = new Dictionary<string, int>()
             {
-                { "Samples.MultiDomainHost.App.FrameworkHttpNoRedirects-http-client", 2 },
-                { "Samples.MultiDomainHost.App.NuGetHttpNoRedirects-http-client", 2 },
-                { "Samples.MultiDomainHost.App.NuGetJsonWithRedirects-http-client", 2 },
+                { "Samples.MultiDomainHost.App.FrameworkHttpNoRedirects", 2 },
+                { "Samples.MultiDomainHost.App.NuGetHttpNoRedirects", 2 },
+                { "Samples.MultiDomainHost.App.NuGetJsonWithRedirects", 2 },
             };
             if (!targetFramework.StartsWith("net45"))
             {
-                expectedMap.Add("Samples.MultiDomainHost.App.NuGetHttpWithRedirects-http-client", 2);
+                expectedMap.Add("Samples.MultiDomainHost.App.NuGetHttpWithRedirects", 2);
             }
 
             RunSampleAndAssertAgainstExpectations(targetFramework, expectedMap);
@@ -85,13 +85,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var expectedMap = new Dictionary<string, int>()
                 {
-                    { "Samples.MultiDomainHost.App.FrameworkHttpNoRedirects-http-client", 2 },
-                    { "Samples.MultiDomainHost.App.NuGetHttpNoRedirects-http-client", 2 },
-                    { "Samples.MultiDomainHost.App.NuGetJsonWithRedirects-http-client", 2 },
+                    { "Samples.MultiDomainHost.App.FrameworkHttpNoRedirects", 2 },
+                    { "Samples.MultiDomainHost.App.NuGetHttpNoRedirects", 2 },
+                    { "Samples.MultiDomainHost.App.NuGetJsonWithRedirects", 2 },
                 };
                 if (!targetFramework.StartsWith("net45"))
                 {
-                    expectedMap.Add("Samples.MultiDomainHost.App.NuGetHttpWithRedirects-http-client", 2);
+                    expectedMap.Add("Samples.MultiDomainHost.App.NuGetHttpWithRedirects", 2);
                 }
 
                 RunSampleAndAssertAgainstExpectations(targetFramework, expectedMap);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
                     Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.port"));
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 
                 var expectedFromOneRun = new TupleList<string, string>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 foreach (var span in spans)
                 {
                     Assert.Equal("redis.command", span.Name);
-                    Assert.Equal("Samples.ServiceStack.Redis-redis", span.Service);
+                    Assert.Equal("Samples.ServiceStack.Redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
                     Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.port"));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -280,7 +280,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
                     Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.port"));
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 
                 var spanLookup = new Dictionary<Tuple<string, string>, int>();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -274,7 +276,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 foreach (var span in spans)
                 {
                     Assert.Equal("redis.command", span.Name);
-                    Assert.Equal("Samples.StackExchange.Redis-redis", span.Service);
+                    Assert.Equal("Samples.StackExchange.Redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
                     Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.port"));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -6,6 +6,7 @@
 // Modified by Splunk Inc.
 
 #if NET452
+using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
@@ -54,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Http, span.Type);
                     Assert.Equal("WebRequest", span.Tags[Tags.InstrumentationName]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 
                 PropagationTestHelpers.AssertPropagationEnabled(spans.First(), processResult);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int expectedSpanCount = enableCallTarget ? 45 : 25; // CallSite insturmentation doesn't instrument async requests
             const string expectedOperationName = "http.request";
-            const string expectedServiceName = "Samples.WebRequest.NetFramework20-http-client";
+            const string expectedServiceName = "Samples.WebRequest.NetFramework20";
 
             int agentPort = TcpPortProvider.GetOpenPort();
             int httpPort = TcpPortProvider.GetOpenPort();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             };
 
             const string expectedOperationName = "http.request";
-            const string expectedServiceName = "Samples.WebRequest-http-client";
+            const string expectedServiceName = "Samples.WebRequest";
 
             int agentPort = TcpPortProvider.GetOpenPort();
             int httpPort = TcpPortProvider.GetOpenPort();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -5,6 +5,7 @@
 
 // Modified by Splunk Inc.
 
+using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
@@ -64,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal(expectedServiceName, span.Service);
                     Assert.Equal(SpanTypes.Http, span.Type);
                     Assert.True(string.Equals(span.Tags[Tags.InstrumentationName], "WebRequest") || string.Equals(span.Tags[Tags.InstrumentationName], "HttpMessageHandler"));
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                    Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 
                 PropagationTestHelpers.AssertPropagationEnabled(spans.First(), processResult);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
@@ -42,7 +44,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("custom-service")]
         public void RetrievesUnmappedServiceNames(string serviceName)
         {
-            var expected = $"{ApplicationName}-{serviceName}";
+            var expected = ApplicationName;
 
             var actual = _serviceNames.GetServiceName(ApplicationName, serviceName);
 
@@ -56,7 +58,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void DoesNotRequireAnyMappings(string serviceName)
         {
             var serviceNames = new ServiceNames(new Dictionary<string, string>());
-            var expected = $"{ApplicationName}-{serviceName}";
+            var expected = ApplicationName;
 
             var actual = serviceNames.GetServiceName(ApplicationName, serviceName);
 
@@ -67,7 +69,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void CanPassNullToConstructor()
         {
             var serviceName = "elasticsearch";
-            var expected = $"{ApplicationName}-{serviceName}";
+            var expected = ApplicationName;
             var serviceNames = new ServiceNames(null);
 
             var actual = serviceNames.GetServiceName(ApplicationName, serviceName);
@@ -102,9 +104,9 @@ namespace Datadog.Trace.Tests.Configuration
             var elasticActual = serviceNames.GetServiceName(ApplicationName, "elasticsearch");
             var sqlActual = serviceNames.GetServiceName(ApplicationName, "sql-server");
 
-            Assert.Equal($"{ApplicationName}-mongodb", mongodbActual);
+            Assert.Equal(ApplicationName, mongodbActual);
             Assert.Equal("custom-name", elasticActual);
-            Assert.Equal($"{ApplicationName}-sql-server", sqlActual);
+            Assert.Equal(ApplicationName, sqlActual);
         }
     }
 }


### PR DESCRIPTION
Adjust service name naming convention for all cases
to avoid same changes in all instrumentations

