### PR TITLE
Elasticsearch use db.operation tag

### DIFF
--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -125,6 +125,11 @@ namespace Datadog.Trace
         public const string DbName = "db.name";
 
         /// <summary>
+        /// The name of the operation.
+        /// </summary>
+        public const string DbOperation = "db.operation";
+
+        /// <summary>
         /// The command/query text
         /// </summary>
         public const string DbStatement = "db.statement";
@@ -483,7 +488,7 @@ namespace Datadog.Trace
 
         internal const string ElasticsearchAction = "elasticsearch.action";
 
-        internal const string ElasticsearchMethod = "elasticsearch.method";
+        internal const string ElasticsearchMethod = DbOperation;
 
         internal const string ElasticsearchUrl = "elasticsearch.url";
 


### PR DESCRIPTION
Based on #205 and https://github.com/open-telemetry/opentelemetry-specification/blob/3e380e249f60c3a5f68746f5e84d10195ba41a79/specification/trace/semantic_conventions/database.md#call-level-attributes

It is good idea to change `elasticsearch.method` tag to `db.operation`.

Before changes: https://app.signalfx.com/#/apm/traces/5c97a185812bd86135b0e6daf15e2c91
After changes: https://app.signalfx.com/#/apm/traces/45e2481573b74ed81fb21c23fc285dc2

I do not think that `elasticsearch.action` should be changed into `db.statement`. Potential values populated for `elasticsearch.action`: DeleteUser, ClusterState, CloseIndex, etc.