### PR TITLE
Remove informational log from hot path (OnNext)

### DIFF
--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -57,7 +57,6 @@ namespace SignalFx.Tracing.DiagnosticListeners
 
         protected override void OnNext(string eventName, object arg)
         {
-            Log.Information($"OnNext: [{eventName}]");
             switch (eventName)
             {
                 case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start":


### PR DESCRIPTION
A log statement, at info level, was left in a hotpath for AspNetCoreDiagnosticObserver. Removing that statement.