### PR TITLE
aerospike semantic convention

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/AerospikeCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/AerospikeCommon.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Text;
 using Datadog.Trace.Configuration;
@@ -38,6 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Aerospike
                 var serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
                 scope = tracer.StartActiveWithTags(OperationName, tags: tags, serviceName: serviceName);
                 var span = scope.Span;
+                span.LogicScope = OperationName;
 
                 if (target.TryDuckCast<HasKey>(out var hasKey))
                 {

--- a/tracer/src/Datadog.Trace/Tagging/AerospikeTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AerospikeTags.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Tagging
@@ -12,6 +14,7 @@ namespace Datadog.Trace.Tagging
         protected static readonly IProperty<string>[] AerospikeTagsProperties =
             InstrumentationTagsProperties.Concat(
                 new ReadOnlyProperty<AerospikeTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName),
+                new ReadOnlyProperty<AerospikeTags, string>(Trace.Tags.DbType, t => t.DbType),
                 new Property<AerospikeTags, string>(Trace.Tags.AerospikeKey, t => t.Key, (t, v) => t.Key = v),
                 new Property<AerospikeTags, string>(Trace.Tags.AerospikeNamespace, t => t.Namespace, (t, v) => t.Namespace = v),
                 new Property<AerospikeTags, string>(Trace.Tags.AerospikeSetName, t => t.SetName, (t, v) => t.SetName = v),
@@ -19,7 +22,9 @@ namespace Datadog.Trace.Tagging
 
         public override string SpanKind => SpanKinds.Client;
 
-        public string InstrumentationName => "aerospike";
+        public string InstrumentationName => "Aerospike";
+
+        public string DbType => "aerospike";
 
         public string Key { get; set; }
 

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -494,13 +494,13 @@ namespace Datadog.Trace
 
         internal const string RuntimeId = "runtime-id";
 
-        internal const string AerospikeKey = "aerospike.key";
+        internal const string AerospikeKey = "db.aerospike.key";
 
-        internal const string AerospikeNamespace = "aerospike.namespace";
+        internal const string AerospikeNamespace = "db.aerospike.namespace";
 
-        internal const string AerospikeSetName = "aerospike.setname";
+        internal const string AerospikeSetName = "db.aerospike.setname";
 
-        internal const string AerospikeUserKey = "aerospike.userkey";
+        internal const string AerospikeUserKey = "db.aerospike.userkey";
 
         /// <summary>
         /// Messaging tags

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.TestHelpers;
@@ -65,8 +67,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 spans.Should()
                      .OnlyContain(span => span.Name == "aerospike.command")
+                     .And.OnlyContain(span => span.LogicScope == "aerospike.command")
                      .And.OnlyContain(span => span.Service == "Samples.Aerospike")
                      .And.OnlyContain(span => span.Tags[Tags.SpanKind] == SpanKinds.Client)
+                     .And.OnlyContain(span => span.Tags[Tags.DbType] == "aerospike")
                      .And.OnlyContain(span => ValidateSpanKey(span));
 
                 spans.Select(span => span.Resource).Should().ContainInOrder(expectedSpans);


### PR DESCRIPTION
Aerospike semantic adjustment.
There is no aerospike instrumentation on main.
https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/database.yaml does not have exact specification for aerospike. Only `db.system` is defined.

Proposed changes from upstream
Change following tags
 * `aerospike.key` -> `db.aerospike.key`
 * `aerospike.namespace` -> `db.aerospike.namespace`
 * `aerospike.setname` -> `db.aerospike.setname`
 * `aerospike.userkey` -> `db.aerospike.userkey`
 * added `db.system` as `aerospike`

Operation name is always `aerospike.command`. Following tags are not added to spans `db.statement` and `db.command`. Aerospike internally contains data which could be used to populate this values but it is not available yet for current instrumentation implementation.

before changes: https://app.signalfx.com/#/apm/traces/44d62583834aa8290a4de2b7871189a8
after changes:  https://app.signalfx.com/#/apm/traces/743362a493e14dfd448d454259a156de