### PR TITLE
Adjust network tags

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -46,7 +46,7 @@ The following Web UI endpoints are exposed:
 Example usage:
 
 ```sh
-./dev/instrument.sh dotnet run -f netcoreapp3.1 -p ./tracer/samples/ConsoleApp/ConsoleApp.csproj
+./dev/instrument.sh dotnet run -f netcoreapp3.1 -p ./tracer/samples/ConsoleApp/ConsoleApp.csproj --no-launch-profile
 ```
 
  [`dev/envvars.sh`](../dev/envvars.sh) can be used to export profiler
@@ -59,7 +59,7 @@ Example usage:
  ./tracer/samples/ConsoleApp/bin/Debug/netcoreapp3.1/ConsoleApp
  ```
 
-Confiugration to send data directly to Splunk Observability Cloud:
+Configuration to send data directly to Splunk Observability Cloud:
 
  ```sh
 export SIGNALFX_ACCESS_TOKEN=secret

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -128,7 +128,7 @@ namespace Datadog.Trace.AspNet
                 var tags = new WebTags();
                 scope = tracer.StartActiveWithTags(httpMethod, propagatedContext, tags: tags);
                 // Leave resourceName blank for now - we'll update it in OnEndRequest
-                scope.Span.DecorateWebServerSpan(resourceName: null, httpMethod, host, url, tags, tagsFromHeaders);
+                scope.Span.DecorateWebServerSpan(resourceName: null, httpMethod, host, url, tags, tagsFromHeaders, httpRequest.UserHostAddress);
                 scope.Span.LogicScope = _requestOperationName;
 
                 tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -177,7 +177,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         host: host,
                         httpUrl: url,
                         tags,
-                        tagsFromHeaders);
+                        tagsFromHeaders,
+                        httpContext.Request.UserHostAddress);
 
                     span.LogicScope = OperationName;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -469,14 +469,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Replace("{area}", area)
                        .Replace("{controller}", controller)
                        .Replace("{action}", action);
-
                 span.DecorateWebServerSpan(
                     resourceName: resourceName,
                     method: method,
                     host: host,
                     httpUrl: rawUrl,
                     tags,
-                    headerTags);
+                    headerTags,
+                    HttpContext.Current?.Request.UserHostAddress);
 
                 span.LogicScope = OperationName;
                 span.OperationName = resourceName;

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -638,7 +638,8 @@ namespace Datadog.Trace.DiagnosticListeners
             var scope = tracer.StartActiveWithTags($"HTTP {httpMethod}", propagatedContext, tags: tags);
             scope.Span.LogicScope = HttpRequestInOperationName;
 
-            scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders);
+            var remoteIp = httpContext?.Connection?.RemoteIpAddress?.ToString();
+            scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders, remoteIp);
 
             tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);
 

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -67,7 +67,8 @@ namespace Datadog.Trace.ExtensionMethods
             string host,
             string httpUrl,
             WebTags tags,
-            IEnumerable<KeyValuePair<string, string>> tagsFromHeaders)
+            IEnumerable<KeyValuePair<string, string>> tagsFromHeaders,
+            string remoteIp = null)
         {
             span.Type = SpanTypes.Web;
             span.ResourceName = resourceName?.Trim();
@@ -75,6 +76,8 @@ namespace Datadog.Trace.ExtensionMethods
             tags.HttpMethod = method;
             tags.HttpRequestHeadersHost = host;
             tags.HttpUrl = httpUrl;
+
+            tags.PeerIp = remoteIp;
 
             foreach (KeyValuePair<string, string> kvp in tagsFromHeaders)
             {

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -126,7 +126,8 @@ namespace Datadog.Trace.PlatformHelpers
             var scope = tracer.StartActiveWithTags($"HTTP {httpMethod}", propagatedContext, tags: tags);
             scope.Span.LogicScope = _requestInOperationName;
 
-            scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders);
+            var remoteIp = httpContext?.Connection?.RemoteIpAddress?.ToString();
+            scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders, remoteIp);
 
             tags.SetAnalyticsSampleRate(_integrationId, tracer.Settings, enabledWithGlobalSetting: true);
 

--- a/tracer/src/Datadog.Trace/Tagging/WebTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/WebTags.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.Tagging
                 new Property<WebTags, string>(Trace.Tags.HttpMethod, t => t.HttpMethod, (t, v) => t.HttpMethod = v),
                 new Property<WebTags, string>(Trace.Tags.HttpRequestHeadersHost, t => t.HttpRequestHeadersHost, (t, v) => t.HttpRequestHeadersHost = v),
                 new Property<WebTags, string>(Trace.Tags.HttpUrl, t => t.HttpUrl, (t, v) => t.HttpUrl = v),
+                new Property<WebTags, string>(Trace.Tags.Net.PeerIP, t => t.PeerIp, (t, v) => t.PeerIp = v),
                 new ReadOnlyProperty<WebTags, string>(Trace.Tags.Language, t => t.Language));
 
         public override string SpanKind => SpanKinds.Server;
@@ -24,6 +25,8 @@ namespace Datadog.Trace.Tagging
         public string HttpRequestHeadersHost { get; set; }
 
         public string HttpUrl { get; set; }
+
+        public string PeerIp { get; set; }
 
         public string Language => TracerConstants.Language;
 

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -197,12 +197,20 @@ namespace Datadog.Trace
         /// <summary>
         /// The hostname of a outgoing server connection.
         /// </summary>
-        public const string OutHost = "out.host";
+        /// <remarks>
+        /// Upstream uses "out.host", however, to better align with OpenTelemetry we use
+        /// "net.peer.name" instead.
+        /// </remarks>>
+        public const string OutHost = Net.PeerName;
 
         /// <summary>
         /// The port of a outgoing server connection.
         /// </summary>
-        public const string OutPort = "out.port";
+        /// <remarks>
+        /// Upstream uses "out.port", however, to better align with OpenTelemetry we use
+        /// "net.peer.port" instead.
+        /// </remarks>>
+        public const string OutPort = Net.PeerPort;
 
         /// <summary>
         /// The raw command sent to Redis.
@@ -606,6 +614,11 @@ namespace Datadog.Trace
             /// This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
             /// </summary>
             public const string PeerName = "net.peer.name";
+
+            /// <summary>
+            /// Remote port number.
+            /// </summary>
+            public const string PeerPort = "net.peer.port";
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -59,8 +59,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal("redis.command", span.LogicScope);
                     Assert.Equal("Samples.ServiceStack.Redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
-                    Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
-                    Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.port"));
+                    Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "net.peer.name"));
+                    Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "net.peer.port"));
                     Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -278,8 +278,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal("redis.command", span.LogicScope);
                     Assert.Equal("Samples.StackExchange.Redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
-                    Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
-                    Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.port"));
+                    Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "net.peer.name"));
+                    Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "net.peer.port"));
                     Assert.Contains(Tags.Version, (IDictionary<string, string>)span.Tags);
                 }
 

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -16,6 +16,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -15,6 +15,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -37,6 +37,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -38,6 +38,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -20,6 +20,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -20,6 +20,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -40,6 +40,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -40,6 +40,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -42,6 +42,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -42,6 +42,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -19,6 +19,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -20,6 +20,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -20,6 +20,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -40,6 +40,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/bad-request,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/branch/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/branch/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/delay/0,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 404,
       http.url: http://localhost:00000/not-found,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/ping,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -40,6 +40,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code-string/%5B200%5D,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -41,6 +41,7 @@
       http.status_code: 203,
       http.url: http://localhost:00000/status-code/203,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: server,
       version: 1.0.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -42,6 +42,7 @@
       http.status_code: 402,
       http.url: http://localhost:00000/status-code/402,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
       span.kind: server,

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -42,6 +42,7 @@
       http.status_code: 500,
       http.url: http://localhost:00000/status-code/500,
       language: dotnet,
+      net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
       span.kind: server,


### PR DESCRIPTION
Changes proposed in this pull request:
- change network tag names to better align with opentelemetry: change "out.host" to "net.peer.name", "out.port" to "net.peer.port"
- set "net.peer.ip" when decorating `WebTags`

Implemented based on what's on main. Self-hosted owin scenario won't set "net.peer.ip".

Sample traces:

 `AspNetMvc`:
- before: https://app.signalfx.com/#/apm/traces/74481645fcb8696b5037a1c380793e32
- after: https://app.signalfx.com/#/apm/traces/621038ef87c4b56008d411e6a68a0473

`Npsql`:
- before: https://app.signalfx.com/#/apm/traces/1e90b0f5d30b14ec413d2b6d9d6aacf9
- after: https://app.signalfx.com/#/apm/traces/58cf38d6050ccfeb2a171c2aaa597586

`Redis`:
- before: https://app.signalfx.com/#/apm/traces/0d5c03405c61fad673147781e4ebf8ad
- after: https://app.signalfx.com/#/apm/traces/0aea58e7f961f422343520c50844a098

Verification files currently not being used in CI will be updated with the next PR.

@signalfx/instrumentation