### PR TITLE
SignalFx Tracing Library and Version

### DIFF
--- a/tracer/src/Datadog.Trace/Tagging/CommonTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/CommonTags.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 namespace Datadog.Trace.Tagging
 {
     internal class CommonTags : TagsList
@@ -17,12 +19,18 @@ namespace Datadog.Trace.Tagging
         protected static readonly IProperty<string>[] CommonTagsProperties =
         {
             new Property<CommonTags, string>(Trace.Tags.Env, t => t.Environment, (t, v) => t.Environment = v),
-            new Property<CommonTags, string>(Trace.Tags.Version, t => t.Version, (t, v) => t.Version = v)
+            new Property<CommonTags, string>(Trace.Tags.Version, t => t.Version, (t, v) => t.Version = v),
+            new Property<CommonTags, string>(Trace.Tags.SignalFxVersion, t => t.SignalFxVersion, (t, v) => t.SignalFxVersion = v),
+            new Property<CommonTags, string>(Trace.Tags.SignalFxLibrary, t => t.SignalFxLibrary, (t, v) => t.SignalFxLibrary = v),
         };
 
         public string Environment { get; set; }
 
         public string Version { get; set; }
+
+        public string SignalFxVersion { get; set; }
+
+        public string SignalFxLibrary { get; set; }
 
         public double? SamplingPriority { get; set; }
 

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -30,6 +30,16 @@ namespace Datadog.Trace
         public const string Version = "version";
 
         /// <summary>
+        /// SingalFx Language tag, applied to root spans.
+        /// </summary>
+        public const string SignalFxLibrary = "signalfx.tracing.library";
+
+        /// <summary>
+        /// SingalFx Version tag, applied to root spans.
+        /// </summary>
+        public const string SignalFxVersion = "signalfx.tracing.version";
+
+        /// <summary>
         /// The name of the integration that generated the span.
         /// Use OpenTracing tag "component"
         /// </summary>

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -492,6 +492,12 @@ namespace Datadog.Trace
                 spanContext.TraceContext.AddSpan(span);
             }
 
+            if (span.IsRootSpan)
+            {
+                span.SetTag(Tags.SignalFxLibrary, TracerConstants.Library);
+                span.SetTag(Tags.SignalFxVersion, TracerConstants.AssemblyVersion);
+            }
+
             return span;
         }
 

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -3,11 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 namespace Datadog.Trace
 {
     internal static class TracerConstants
     {
         public const string Language = "dotnet";
+        public const string Library = "dotnet-tracing";
 
         /// <summary>
         /// 2^63-1

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -80,6 +80,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // check the SingalFx library name
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.library", "dotnet-tracing");
+
+                        // check the SingalFx library version
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "0.0.1.0");
+
                         // checks the runtime id tag
                         AssertTargetSpanExists(targetSpan, Tags.RuntimeId);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -104,6 +104,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // check the SingalFx library name
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.library", "dotnet-tracing");
+
+                        // check the SingalFx library version
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "0.0.1.0");
+
                         // checks the runtime id tag
                         AssertTargetSpanExists(targetSpan, Tags.RuntimeId);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -90,6 +90,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // check the SingalFx library name
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.library", "dotnet-tracing");
+
+                        // check the SingalFx library version
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "0.0.1.0");
+
                         // checks the origin tag
                         CheckOriginTag(targetSpan);
 

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -19,6 +19,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -19,6 +19,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -45,6 +45,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -45,6 +45,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -41,6 +41,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -41,6 +41,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -19,6 +19,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -19,6 +19,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -45,6 +45,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -17,6 +17,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -45,6 +45,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -39,6 +39,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -41,6 +41,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -41,6 +41,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=__statusCode=200.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -25,6 +25,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -25,6 +25,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -23,6 +23,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=__statusCode=200.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -47,6 +47,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -47,6 +47,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -45,6 +45,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -45,6 +45,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=__statusCode=200.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -25,6 +25,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -25,6 +25,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -21,6 +21,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -23,6 +23,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=__statusCode=200.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -47,6 +47,8 @@
       sfx.error.stack: 
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -47,6 +47,8 @@
       sfx.error.stack: 
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -43,6 +43,8 @@
       language: dotnet,
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -45,6 +45,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 402.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -45,6 +45,8 @@
       net.peer.ip: 127.0.0.1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 500.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delayAsync/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=false,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -41,6 +43,8 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/transientfailure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -18,6 +18,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -21,6 +21,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -39,6 +41,8 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delayAsync/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=false,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -41,6 +43,8 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/transientfailure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -18,6 +18,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -21,6 +21,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -39,6 +41,8 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallSite.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delayAsync/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=false,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -41,6 +43,8 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/transientfailure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -18,6 +18,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -21,6 +21,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -39,6 +41,8 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delayAsync/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=false,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201?ps=true&ts=true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -20,6 +20,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -23,6 +23,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -41,6 +43,8 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -18,6 +18,8 @@
       http.url: http://localhost:00000/api2/transientfailure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -18,6 +18,8 @@
       language: dotnet,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -21,6 +21,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -39,6 +41,8 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.CallTarget.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -8,6 +8,8 @@
     Tags: {
       deployment.environment: integration_tests,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableCallTarget=False_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableCallTarget=False_enableNewWcfInstrumentation=False.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -42,6 +44,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -68,6 +72,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -94,6 +100,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -120,6 +128,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -146,6 +156,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=False.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -42,6 +44,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -68,6 +72,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -94,6 +100,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -120,6 +128,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -146,6 +156,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=True.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -42,6 +44,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -68,6 +72,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -94,6 +100,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -120,6 +128,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -146,6 +156,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableCallTarget=False_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableCallTarget=False_enableNewWcfInstrumentation=False.verified.txt
@@ -13,6 +13,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -36,6 +38,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -59,6 +63,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -82,6 +88,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -105,6 +113,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -128,6 +138,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableCallTarget=True_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableCallTarget=True_enableNewWcfInstrumentation=False.verified.txt
@@ -13,6 +13,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -36,6 +38,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -59,6 +63,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -82,6 +88,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -105,6 +113,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -128,6 +138,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableCallTarget=True_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableCallTarget=True_enableNewWcfInstrumentation=True.verified.txt
@@ -13,6 +13,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -36,6 +38,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -59,6 +63,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -82,6 +88,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -105,6 +113,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -128,6 +138,8 @@
       http.url: net.tcp://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableCallTarget=False_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableCallTarget=False_enableNewWcfInstrumentation=False.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -42,6 +44,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -68,6 +72,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -94,6 +100,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -120,6 +128,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -146,6 +156,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=False.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -42,6 +44,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -68,6 +72,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -94,6 +100,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -120,6 +128,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -146,6 +156,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableCallTarget=True_enableNewWcfInstrumentation=True.verified.txt
@@ -16,6 +16,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -42,6 +44,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -68,6 +72,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -94,6 +100,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -120,6 +128,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },
@@ -146,6 +156,8 @@
       http.url: http://localhost:00000/WcfSample/CalculatorService,
       language: dotnet,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },


### PR DESCRIPTION
Introduce `signalfx.tracing.library` (also interpreted as a `otel.library.name`) and `signalfx.tracing.version` (`otel.library.version`) for root spans.

Difference against main branch
`TracerConstants` defines hardcoded version instead of taking it from assembly. There is a task `VerifyChangedFilesFromVersionBump` to verify update of this version when upgrading version. I would consider that it is enough.

Based on https://github.com/signalfx/signalfx-dotnet-tracing/pull/58/files

before changes: https://app.signalfx.com/#/apm/traces/4b0ee2cbdb556b361ef25375f3efbcad
after changes: https://app.signalfx.com/#/apm/traces/2c5be67f7b981939033d4d24c032b001