### PR TITLE
Restore logging configurations

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -53,7 +53,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |  |
 | `SIGNALFX_LOGS_INJECTION` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. | `false` |
 | `SIGNALFX_STDOUT_LOG_ENABLED` | `false` | Enables `stdout` logging. This is disabled by default. |
-| `SIGNALFX_STDOUT_LOG_TEMPLATE` | `"[{Level:u3}] {Message:lj} {NewLine}{Exception}{NewLine}"` | Configures `stdout` log template. |
+| `SIGNALFX_STDOUT_LOG_TEMPLATE` | `"[{Level:u3}] {Message:lj} {NewLine}{Exception}{NewLine}"` | Configures `stdout` log template. See more about Serilog formatting options [here](https://github.com/serilog/serilog/wiki/Configuration-Basics#output-templates). |
 | `SIGNALFX_FILE_LOG_ENABLED` | `true` | Enable file logging. This is enabled by default. |
 | `SIGNALFX_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |
 | `SIGNALFX_TRACE_LOG_PATH` | The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\dotnet-profiler.log` |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -52,6 +52,9 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TRACE_AGENT_URL`, `SIGNALFX_ENDPOINT_URL` | The URL to where trace exporters send traces. | `http://localhost:8126` |
 | `SIGNALFX_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |  |
 | `SIGNALFX_LOGS_INJECTION` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. | `false` |
+| `SIGNALFX_STDOUT_LOG_ENABLED` | `false` | Enables `stdout` logging. This is disabled by default. |
+| `SIGNALFX_STDOUT_LOG_TEMPLATE` | `"[{Level:u3}] {Message:lj} {NewLine}{Exception}{NewLine}"` | Configures `stdout` log template. |
+| `SIGNALFX_FILE_LOG_ENABLED` | `true` | Enable file logging. This is enabled by default. |
 | `SIGNALFX_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |
 | `SIGNALFX_TRACE_LOG_PATH` | The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. | `true` |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -52,9 +52,9 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TRACE_AGENT_URL`, `SIGNALFX_ENDPOINT_URL` | The URL to where trace exporters send traces. | `http://localhost:8126` |
 | `SIGNALFX_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |  |
 | `SIGNALFX_LOGS_INJECTION` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. | `false` |
-| `SIGNALFX_STDOUT_LOG_ENABLED` | `false` | Enables `stdout` logging. This is disabled by default. |
-| `SIGNALFX_STDOUT_LOG_TEMPLATE` | `"[{Level:u3}] {Message:lj} {NewLine}{Exception}{NewLine}"` | Configures `stdout` log template. See more about Serilog formatting options [here](https://github.com/serilog/serilog/wiki/Configuration-Basics#output-templates). |
-| `SIGNALFX_FILE_LOG_ENABLED` | `true` | Enable file logging. This is enabled by default. |
+| `SIGNALFX_STDOUT_LOG_ENABLED` | Enables `stdout` logging. This is disabled by default. | `false` |
+| `SIGNALFX_STDOUT_LOG_TEMPLATE` | Configures `stdout` log template. See more about Serilog formatting options [here](https://github.com/serilog/serilog/wiki/Configuration-Basics#output-templates). | `"[{Level:u3}] {Message:lj} {NewLine}{Exception}{NewLine}"` |
+| `SIGNALFX_FILE_LOG_ENABLED` | Enable file logging. This is enabled by default. | `true` |
 | `SIGNALFX_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |
 | `SIGNALFX_TRACE_LOG_PATH` | The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. | `true` |

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -96,6 +96,17 @@ namespace Datadog.Trace.Configuration
         public const string DebugEnabled = "SIGNALFX_TRACE_DEBUG";
 
         /// <summary>
+        /// Gets a value indicating whether file log is enabled.
+        /// Default is <c>true</c>.
+        /// </summary>
+        /// <remarks>
+        /// Not exposed via <see cref="TracerSettings"/> since the logger
+        /// is created before it is set.
+        /// </remarks>
+        /// <seealso cref="GlobalSettings.FileLogEnabled"/>
+        public const string FileLogEnabled = "SIGNALFX_FILE_LOG_ENABLED";
+
+        /// <summary>
         /// Configuration key for a list of integrations to disable. All other integrations remain enabled.
         /// Default is empty (all integrations are enabled).
         /// Supports multiple values separated with comma.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -107,6 +107,23 @@ namespace Datadog.Trace.Configuration
         public const string FileLogEnabled = "SIGNALFX_FILE_LOG_ENABLED";
 
         /// <summary>
+        /// Gets a value indicating whether stdout log is enabled.
+        /// Default is <c>false</c>.
+        /// </summary>
+        /// <remarks>
+        /// Not exposed via <see cref="TracerSettings"/> since the logger
+        /// is created before it is set.
+        /// </remarks>
+        /// <seealso cref="GlobalSettings.StdoutLogEnabled"/>
+        public const string StdoutLogEnabled = "SIGNALFX_STDOUT_LOG_ENABLED";
+
+        /// <summary>
+        /// Allows to override the default output template used with stdout logging.
+        /// It is ignored if stdout log is disabled.
+        /// </summary>
+        public const string StdoutLogTemplate = "SIGNALFX_STDOUT_LOG_TEMPLATE";
+
+        /// <summary>
         /// Configuration key for a list of integrations to disable. All other integrations remain enabled.
         /// Default is empty (all integrations are enabled).
         /// Supports multiple values separated with comma.

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -40,6 +40,8 @@ namespace Datadog.Trace.Configuration
                                       // default value
                                       true;
 
+            FileLogEnabled = source?.GetBool(ConfigurationKeys.FileLogEnabled) ?? true;
+
             if (TryLoadPluginJsonConfigurationFile(source, out JsonConfigurationSource jsonConfigurationSource))
             {
                 PluginsConfiguration = jsonConfigurationSource;
@@ -53,6 +55,13 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DebugEnabled"/>
         public bool DebugEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether file log is enabled.
+        /// Default is <c>true</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.FileLogEnabled"/>
+        public bool FileLogEnabled { get; private set; }
 
         /// <summary>
         /// Gets or sets the global settings instance.

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -42,6 +42,8 @@ namespace Datadog.Trace.Configuration
 
             FileLogEnabled = source?.GetBool(ConfigurationKeys.FileLogEnabled) ?? true;
 
+            StdoutLogEnabled = source?.GetBool(ConfigurationKeys.StdoutLogEnabled) ?? false;
+
             if (TryLoadPluginJsonConfigurationFile(source, out JsonConfigurationSource jsonConfigurationSource))
             {
                 PluginsConfiguration = jsonConfigurationSource;
@@ -62,6 +64,13 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.FileLogEnabled"/>
         public bool FileLogEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether stdout log is enabled.
+        /// Default is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.StdoutLogEnabled"/>
+        public bool StdoutLogEnabled { get; private set; }
 
         /// <summary>
         /// Gets or sets the global settings instance.

--- a/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
 using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Events;
+using Datadog.Trace.Vendors.Serilog.Formatting.Display;
 using Datadog.Trace.Vendors.Serilog.Sinks.File;
 
 namespace Datadog.Trace.Logging
@@ -89,7 +90,17 @@ namespace Datadog.Trace.Logging
                             fileSizeLimitBytes: MaxLogFileSize,
                             shared: true);
                 }
-                else
+
+                if (GlobalSettings.Source.StdoutLogEnabled)
+                {
+                    var outputTemplate = Environment.GetEnvironmentVariable(ConfigurationKeys.StdoutLogTemplate) ??
+                        "[{Level:u3}] {Message:lj} {NewLine}{Exception}{NewLine}";
+
+                    loggerConfiguration.WriteTo.Sink(new ConsoleSink(outputTemplate), LogEventLevel.Verbose);
+                }
+
+                if (!GlobalSettings.Source.FileLogEnabled &&
+                    !GlobalSettings.Source.StdoutLogEnabled)
                 {
                     loggerConfiguration = loggerConfiguration
                         .WriteTo.Sink<NullSink>();
@@ -233,6 +244,23 @@ namespace Datadog.Trace.Logging
             }
 
             return logDirectory;
+        }
+
+        private class ConsoleSink : ILogEventSink
+        {
+            private readonly MessageTemplateTextFormatter _formatter;
+
+            public ConsoleSink(string outputTemplate)
+            {
+                outputTemplate = outputTemplate ?? throw new ArgumentNullException(nameof(outputTemplate));
+
+                _formatter = new MessageTemplateTextFormatter(outputTemplate, null);
+            }
+
+            public void Emit(LogEvent logEvent)
+            {
+                _formatter.Format(logEvent, Console.Out);
+            }
         }
     }
 }


### PR DESCRIPTION
Restoring `FileLogEnabled`, `StdoutLogEnabled`, `StdoutLogTemplate` to be sync with main.
