### PR TITLE
Add new INTERNAL_CONFIGURATION.md

### DIFF
--- a/docs/INTERNAL_CONFIGURATION.md
+++ b/docs/INTERNAL_CONFIGURATION.md
@@ -1,0 +1,9 @@
+# Internal Configuration
+
+This section contains list of internal configuration settings (these should not be changed by the users).
+
+## Configuration values
+
+| Environment variable | Description | Default |
+|-|-|-|
+| `SIGNALFX_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `DatadogAgent`, `Zipkin`. | `Zipkin` |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -49,10 +49,9 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_ENV` | The value for the `deployment.environment` tag added to every span. |  |
 | `SIGNALFX_TRACE_ENABLED` | Enable to activate the tracer. | `true` |
 | `SIGNALFX_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` |
-| `SIGNALFX_TRACE_AGENT_URL`, `SIGNALFX_ENDPOINT_URL` | The URL to where trace exporters (see: `SIGNALFX_EXPORTER`) send traces. | `http://localhost:8126` |
+| `SIGNALFX_TRACE_AGENT_URL`, `SIGNALFX_ENDPOINT_URL` | The URL to where trace exporters send traces. | `http://localhost:8126` |
 | `SIGNALFX_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |  |
 | `SIGNALFX_LOGS_INJECTION` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. | `false` |
-| `SIGNALFX_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `DatadogAgent`, `Zipkin`. | `Zipkin` |
 | `SIGNALFX_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |
 | `SIGNALFX_TRACE_LOG_PATH` | The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. | `true` |


### PR DESCRIPTION
## Why

https://github.com/signalfx/signalfx-dotnet-tracing/pull/219#discussion_r755094660

## What

Introducing INTERNAL_CONFIGURATION.md. For now that only has one env variable, but I would like to merge it ASAP so everyone can add there (since some of you are working on including new env vars from main, that we missed).

## Tests

N/A
 
