### PR TITLE
Update span name in tracing module

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 - Remove `SIGNALFX_APPEND_URL_PATH_TO_NAME` configuration as it was against the
   [OpenTelemetry Semantic conventions for HTTP spans](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name).
   Take notice that the URL is available via `http.url` tag.
+- Remove `SIGNALFX_USE_WEBSERVER_RESOURCE_AS_OPERATION_NAME` configuration. New, fixed behavior is equivalent to flag enabled,
+  in order to better align with  [OpenTelemetry Semantic conventions for HTTP spans](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name).
 
 ### Enhancements
 

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -182,6 +182,8 @@ namespace Datadog.Trace.AspNet
                             && !string.IsNullOrEmpty(resourceName))
                         {
                             scope.Span.ResourceName = resourceName;
+                            // Resource name with low cardinality, update the operation name.
+                            scope.Span.OperationName = resourceName;
                         }
                         else
                         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -189,11 +189,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);
 
-                    if (newResourceNamesEnabled)
-                    {
-                        // set the resource name in the HttpContext so TracingHttpModule can update root span
-                        httpContext.Items[SharedConstants.HttpContextPropagatedResourceNameKey] = resourceName;
-                    }
+                    // set the resource name in the HttpContext so TracingHttpModule can update root span
+                    httpContext.Items[SharedConstants.HttpContextPropagatedResourceNameKey] = resourceName;
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -486,14 +486,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 tags.AspNetArea = area;
                 tags.AspNetRoute = route;
 
-                if (newResourceNamesEnabled)
+                // set the resource name in the HttpContext so TracingHttpModule can update root span
+                var httpContext = HttpContext.Current;
+
+                if (httpContext is not null)
                 {
-                    // set the resource name in the HttpContext so TracingHttpModule can update root span
-                    var httpContext = System.Web.HttpContext.Current;
-                    if (httpContext is not null)
-                    {
-                        httpContext.Items[SharedConstants.HttpContextPropagatedResourceNameKey] = resourceName;
-                    }
+                    httpContext.Items[SharedConstants.HttpContextPropagatedResourceNameKey] = resourceName;
                 }
             }
             catch (Exception ex)

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/badrequest,
     LogicScope: aspnet.request,
     Resource: GET /home/badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier,
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier,
     LogicScope: aspnet.request,
     Resource: GET /home/identifier,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.badrequest,
     LogicScope: aspnet.request,
-    Resource: GET /home/badrequest,
+    Resource: GET home.badrequest,
     Service: sample,
     Type: web,
     Error: 1,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/?,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/badvalue,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/?,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/badvalue,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/badrequest,
     LogicScope: aspnet.request,
     Resource: GET /home/badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier,
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier,
     LogicScope: aspnet.request,
     Resource: GET /home/identifier,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.badrequest,
     LogicScope: aspnet.request,
-    Resource: GET /home/badrequest,
+    Resource: GET home.badrequest,
     Service: sample,
     Type: web,
     Error: 1,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/?,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/badvalue,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/?,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/badvalue,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallSite.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/badrequest,
     LogicScope: aspnet.request,
     Resource: GET /home/badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier,
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier,
     LogicScope: aspnet.request,
     Resource: GET /home/identifier,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.badrequest,
     LogicScope: aspnet.request,
-    Resource: GET /home/badrequest,
+    Resource: GET home.badrequest,
     Service: sample,
     Type: web,
     Error: 1,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/?,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/badvalue,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/?,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/badvalue,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /admin/home/index,
     LogicScope: aspnet.request,
     Resource: GET /admin/home/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/badrequest,
     LogicScope: aspnet.request,
     Resource: GET /home/badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/optionalidentifier,
     LogicScope: aspnet.request,
     Resource: GET /home/optionalidentifier,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/statuscode,
     LogicScope: aspnet.request,
     Resource: GET /home/statuscode,
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/identifier/{id},
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/identifier,
     LogicScope: aspnet.request,
     Resource: GET /home/identifier,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin/home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /admin,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.badrequest,
     LogicScope: aspnet.request,
-    Resource: GET /home/badrequest,
+    Resource: GET home.badrequest,
     Service: sample,
     Type: web,
     Error: 1,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/?,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier/badvalue,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.optionalidentifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/optionalidentifier,
+    Resource: GET home.optionalidentifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.statuscode,
     LogicScope: aspnet.request,
-    Resource: GET /home/statuscode,
+    Resource: GET home.statuscode,
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/?,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier/badvalue,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.identifier,
     LogicScope: aspnet.request,
-    Resource: GET /home/identifier,
+    Resource: GET home.identifier,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.CallTarget.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },


### PR DESCRIPTION
## Why
In order to have good, low-cardinality names for spans created in `TracingHttpModule`.

## What
Update name for spans created in `TracingHttpModule` with resource names created based on routes.

On _main_ there is flag (i.e `UseWebServerResourceAsOperationName`) that controls whether span name should be overriden.
However, we already changed names for spans created in several integrations without checking flag's value. 
On _main_, resourceName created based on routing information is passed inside `HttpContext` to `TracingHttpModule` only if `RouteTemplateResourceNamesEnabled` flag is set(which is by default). There is useful information (i.e resourceName) to be passed even if it's disabled, that's why I dropped that check in `AspNetMvcIntegration` and `AspNetWebApi2Integration`.

## Tests
Tests with verification files (aspnetmvc4 for now)
 
