### PR TITLE
Include .NET Framework 4.6.1 tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,9 +222,6 @@ jobs:
       run: docker-compose build --build-arg dotnet_tracer_msi=.$relativeArtifacts/{{ matrix.platform }}/en-us/*.msi --build-arg ENABLE_32_BIT=${{ env.enable32bit }} IntegrationTests.IIS
     - name: docker-compose start IIS containers
       run: docker-compose up -d IntegrationTests.IIS
-    - name: GacAdd
-      run: ./tracer/build.cmd GacAdd -Framework ${{ matrix.framework }}
-      if: ${{ matrix.framework  == 'net461' }}
     - name: RunWindowsIisIntegrationTests
       run: ./tracer/build.cmd RunWindowsIisIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose stop services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       run: docker-compose up -d IntegrationTests.IIS
     - name: GacAdd
       run: ./tracer/build.cmd GacAdd -Framework ${{ matrix.framework }}
-      if: (${{ matrix.framework }} == 'net461')
+      if: ${{ matrix.framework  == 'net461' }}
     - name: RunWindowsIisIntegrationTests
       run: ./tracer/build.cmd RunWindowsIisIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose stop services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,12 @@ jobs:
       run: docker-compose build --build-arg dotnet_tracer_msi=.$relativeArtifacts/{{ matrix.platform }}/en-us/*.msi --build-arg ENABLE_32_BIT=${{ env.enable32bit }} IntegrationTests.IIS
     - name: docker-compose start IIS containers
       run: docker-compose up -d IntegrationTests.IIS
+    # Workaround around long name being hit in MultiDomainHostTests.WorksInsideTheGAC tests
     - name: RunWindowsIisIntegrationTests
-      run: ./tracer/build.cmd RunWindowsIisIntegrationTests -Framework ${{ matrix.framework }}
+      run: |
+        subst y: .
+        y:
+        ./tracer/build.cmd RunWindowsIisIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose stop services
       run: docker-compose down
       if: (${{ job.status }} != 'cancelled')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,16 +213,20 @@ jobs:
       matrix:
         platform:
         - x64
+        framework: [ netcoreapp3.1, net461 ]
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
-    - run: ./tracer/build.cmd BuildTracerHome PackageTracerHome BuildWindowsIntegrationTests -Framework netcoreapp3.1
+    - run: ./tracer/build.cmd BuildTracerHome PackageTracerHome BuildWindowsIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose build IIS containers
       run: docker-compose build --build-arg dotnet_tracer_msi=.$relativeArtifacts/{{ matrix.platform }}/en-us/*.msi --build-arg ENABLE_32_BIT=${{ env.enable32bit }} IntegrationTests.IIS
     - name: docker-compose start IIS containers
       run: docker-compose up -d IntegrationTests.IIS
+    - name: GacAdd
+      run: ./tracer/build.cmd GacAdd -Framework ${{ matrix.framework }}
+      if: (${{ matrix.framework }} == 'net461')
     - name: RunWindowsIisIntegrationTests
-      run: ./tracer/build.cmd RunWindowsIisIntegrationTests -Framework netcoreapp3.1
+      run: ./tracer/build.cmd RunWindowsIisIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose stop services
       run: docker-compose down
       if: (${{ job.status }} != 'cancelled')

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/woof,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/woof,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/get/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/get/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/get,
     LogicScope: aspnet.request,
     Resource: GET /home/get,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-async/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.woof,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse/woof,
+    Resource: GET doghouse.woof,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get/?,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-async/?,
+    Resource: GET /delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional/?,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay/?,
+    Resource: GET /delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/woof,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/woof,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/get/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/get/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/get,
     LogicScope: aspnet.request,
     Resource: GET /home/get,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-async/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.woof,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse/woof,
+    Resource: GET doghouse.woof,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get/?,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-async/?,
+    Resource: GET /delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional/?,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay/?,
+    Resource: GET /delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallSite.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/woof,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/woof,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/get/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/get/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/get,
     LogicScope: aspnet.request,
     Resource: GET /home/get,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-async/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.woof,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse/woof,
+    Resource: GET doghouse.woof,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get/?,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-async/?,
+    Resource: GET /delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional/?,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay/?,
+    Resource: GET /delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/woof,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/woof,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,7 +27,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /datadog/doghouse/index,
     LogicScope: aspnet.request,
     Resource: GET /datadog/doghouse/index,
     Service: sample,
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/get/{id},
     LogicScope: aspnet.request,
     Resource: GET /home/get/{id},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /home/get,
     LogicScope: aspnet.request,
     Resource: GET /home/get,
     Service: sample,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /home/index,
     LogicScope: aspnet.request,
     Resource: GET /home/index,
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-async/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay-optional/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /delay/{seconds},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.woof,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse/woof,
+    Resource: GET doghouse.woof,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog/doghouse,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET doghouse.index,
     LogicScope: aspnet.request,
-    Resource: GET /datadog,
+    Resource: GET doghouse.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -41,6 +41,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get/?,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -2,9 +2,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET home.get,
     LogicScope: aspnet.request,
-    Resource: GET /home/get,
+    Resource: GET home.get,
     Service: sample,
     Type: web,
     Error: 1,
@@ -25,6 +25,8 @@ Parameter name: parameters,
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home/index,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /home,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET home.index,
     LogicScope: aspnet.request,
-    Resource: GET /,
+    Resource: GET home.index,
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: GET,
+    Name: GET /badrequest,
     LogicScope: aspnet.request,
     Resource: GET /badrequest,
     Service: sample,
@@ -22,6 +22,8 @@
       sfx.error.stack: 
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-async/?,
+    Resource: GET /delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional/?,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay-optional,
+    Resource: GET /delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /delay/?,
+    Resource: GET /delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.CallTarget.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /statuscode/?,
+    Resource: GET /statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delayasync/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delayasync/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delay/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delay/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/absolute-route,
     LogicScope: aspnet.request,
     Resource: GET /api/absolute-route,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-async/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/environment,
     LogicScope: aspnet.request,
     Resource: GET /api/environment,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delayasync/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delayasync/?,
+    Resource: GET api2/delayasync/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delay/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delay/?,
+    Resource: GET api2/delay/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional/?,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/false,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/true,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/absolute-route,
     LogicScope: aspnet.request,
-    Resource: GET /api/absolute-route,
+    Resource: GET api/absolute-route,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-async/?,
+    Resource: GET api/delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional/?,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay/?,
+    Resource: GET api/delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/environment,
     LogicScope: aspnet.request,
-    Resource: GET /api/environment,
+    Resource: GET api/environment,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/false,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/true,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delayasync/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delayasync/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delay/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delay/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/absolute-route,
     LogicScope: aspnet.request,
     Resource: GET /api/absolute-route,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-async/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/environment,
     LogicScope: aspnet.request,
     Resource: GET /api/environment,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delayasync/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delayasync/?,
+    Resource: GET api2/delayasync/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delay/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delay/?,
+    Resource: GET api2/delay/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional/?,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/false,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/true,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/absolute-route,
     LogicScope: aspnet.request,
-    Resource: GET /api/absolute-route,
+    Resource: GET api/absolute-route,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-async/?,
+    Resource: GET api/delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional/?,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay/?,
+    Resource: GET api/delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/environment,
     LogicScope: aspnet.request,
-    Resource: GET /api/environment,
+    Resource: GET api/environment,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/false,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/true,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallSite.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delayasync/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delayasync/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delay/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delay/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/absolute-route,
     LogicScope: aspnet.request,
     Resource: GET /api/absolute-route,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-async/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/environment,
     LogicScope: aspnet.request,
     Resource: GET /api/environment,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delayasync/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delayasync/?,
+    Resource: GET api2/delayasync/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delay/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delay/?,
+    Resource: GET api2/delay/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional/?,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/false,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/true,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/absolute-route,
     LogicScope: aspnet.request,
-    Resource: GET /api/absolute-route,
+    Resource: GET api/absolute-route,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-async/?,
+    Resource: GET api/delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional/?,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay/?,
+    Resource: GET api/delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/environment,
     LogicScope: aspnet.request,
-    Resource: GET /api/environment,
+    Resource: GET api/environment,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/false,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/true,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delayasync/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delayasync/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/delay/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/delay/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/optional/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/optional/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,7 +28,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/statuscode/{value},
     Service: sample,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api2/transientfailure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api2/transientfailure/{value},
     Service: sample,
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/absolute-route,
     LogicScope: aspnet.request,
     Resource: GET /api/absolute-route,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-async/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-async/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay-optional/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay-optional/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/delay/{seconds},
     LogicScope: aspnet.request,
     Resource: GET /api/delay/{seconds},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/environment,
     LogicScope: aspnet.request,
     Resource: GET /api/environment,
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,7 +26,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/statuscode/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/statuscode/{value},
     Service: sample,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,7 +15,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,7 +24,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET /api/transient-failure/{value},
     LogicScope: aspnet.request,
     Resource: GET /api/transient-failure/{value},
     Service: sample,
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delayasync/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delayasync/?,
+    Resource: GET api2/delayasync/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/delay/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/delay/?,
+    Resource: GET api2/delay/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional/?,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/optional/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/optional,
+    Resource: GET api2/optional/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -28,9 +28,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/statuscode/?,
+    Resource: GET api2/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -44,6 +44,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/false,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api2/transientfailure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api2/transientfailure/true,
+    Resource: GET api2/transientfailure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -40,6 +40,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/absolute-route,
     LogicScope: aspnet.request,
-    Resource: GET /api/absolute-route,
+    Resource: GET api/absolute-route,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-async/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-async/?,
+    Resource: GET api/delay-async/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional/?,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay-optional/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay-optional,
+    Resource: GET api/delay-optional/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/delay/{seconds},
     LogicScope: aspnet.request,
-    Resource: GET /api/delay/?,
+    Resource: GET api/delay/{seconds},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/environment,
     LogicScope: aspnet.request,
-    Resource: GET /api/environment,
+    Resource: GET api/environment,
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -26,9 +26,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/statuscode/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/statuscode/?,
+    Resource: GET api/statuscode/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -42,6 +42,8 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.message: The HTTP response has status code 503.,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -15,9 +15,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/false,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Error: 1,
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -24,9 +24,9 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: GET,
+    Name: GET api/transient-failure/{value},
     LogicScope: aspnet.request,
-    Resource: GET /api/transient-failure/true,
+    Resource: GET api/transient-failure/{value},
     Service: sample,
     Type: web,
     Tags: {
@@ -38,6 +38,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -35,6 +35,8 @@
       sfx.error.stack: 
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -16,6 +16,8 @@
       language: dotnet,
       net.peer.ip: ::1,
       runtime-id: Guid_1,
+      signalfx.tracing.library: dotnet-tracing,
+      signalfx.tracing.version: 0.0.1.0,
       span.kind: server,
       version: 1.0.0
     },


### PR DESCRIPTION
## Why
In order to run aspnet tests with CI.
## What
Include net461 framework tests in windows-iis-integration-tests job.
Update verification files for aspnet tests (aspnetmvc5 and aspnetwebapi2).

## Tests
Aspnet tests are now part of ci workflow.
