### PR TITLE
Fix NLog integration when using ILogger

### DIFF
--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -15,6 +15,7 @@ namespace SignalFx.Tracing.Logging
     {
         private readonly IScopeManager _scopeManager;
         private readonly ILogProvider _logProvider;
+        private readonly TracerSettings _settings;
 
         // Each mapped context sets a key-value pair into the logging context
         // Disposing the returned context unsets the key-value pair
@@ -44,6 +45,7 @@ namespace SignalFx.Tracing.Logging
         public LibLogScopeEventSubscriber(IScopeManager scopeManager, TracerSettings settings)
         {
             _scopeManager = scopeManager;
+            _settings = settings;
 
             _logProvider = LogProvider.CurrentLogProvider ?? LogProvider.ResolveLogProvider();
             if (_logProvider is SerilogLogProvider)
@@ -53,41 +55,17 @@ namespace SignalFx.Tracing.Logging
                     _scopeManager.SpanOpened += StackOnSpanOpened;
                     _scopeManager.SpanClosed += StackOnSpanClosed;
             }
-            else if (_logProvider is NLogLogProvider && UseNLogOptimized())
+            else if (_logProvider is NLogLogProvider)
             {
                 // This NLog version can use the value readers optimization.
-                UseValueReaders(settings);
+                _scopeManager.SpanActivated += ActivateMappedContext;
+                _scopeManager.TraceEnded += DeactivateMappedContext;
             }
             else
             {
                 _scopeManager.SpanActivated += MapOnSpanActivated;
                 _scopeManager.TraceEnded += MapOnTraceEnded;
             }
-        }
-
-        public static bool UseNLogOptimized()
-        {
-            // This code checks the same requisits from LibLog\5.0.6\LogProviders\NLogLogProvider.cs to see
-            // if the code can use an optimized path for NLog.
-            var ndlcContextType = Type.GetType("NLog.NestedDiagnosticsLogicalContext, NLog");
-            if (ndlcContextType != null)
-            {
-                var pushObjectMethod = ndlcContextType.GetMethod("PushObject", typeof(object));
-                if (pushObjectMethod != null)
-                {
-                    var mdlcContextType = Type.GetType("NLog.MappedDiagnosticsLogicalContext, NLog");
-                    if (mdlcContextType != null)
-                    {
-                        var setScopedMethod = mdlcContextType.GetMethod("SetScoped", typeof(string), typeof(object));
-                        if (setScopedMethod != null)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
         }
 
         public void StackOnSpanOpened(object sender, SpanEventArgs spanEventArgs)
@@ -119,6 +97,11 @@ namespace SignalFx.Tracing.Logging
                 _scopeManager.SpanOpened -= StackOnSpanOpened;
                 _scopeManager.SpanClosed -= StackOnSpanClosed;
             }
+            else if (_logProvider is NLogLogProvider)
+            {
+                _scopeManager.SpanActivated -= ActivateMappedContext;
+                _scopeManager.TraceEnded -= DeactivateMappedContext;
+            }
             else
             {
                 _scopeManager.SpanActivated -= MapOnSpanActivated;
@@ -128,37 +111,34 @@ namespace SignalFx.Tracing.Logging
             RemoveAllCorrelationIdentifierContexts();
         }
 
-        private void UseValueReaders(TracerSettings settings)
+        private void ActivateMappedContext(object sender, SpanEventArgs spanEventArgs)
         {
-            var traceIdReader = new ValueReader(() =>
-            {
-                return _scopeManager.Active?.Span?.TraceId.ToString() ?? TraceId.Zero.ToString();
-            });
-            LogProvider.OpenMappedContext(
-                CorrelationIdentifier.TraceIdKey, traceIdReader, destructure: false);
+            var span = spanEventArgs.Span;
+            OpenMappedContext(
+                span.TraceId.ToString(),
+                span.SpanId.ToString("x16"),
+                span.ServiceName ?? _settings.ServiceName,
+                _settings.Environment);
+        }
 
-            var spanIdReader = new ValueReader(() =>
-            {
-                return _scopeManager.Active?.Span?.SpanId.ToString("x16") ?? "0000000000000000";
-            });
-            LogProvider.OpenMappedContext(
-                CorrelationIdentifier.SpanIdKey, spanIdReader, destructure: false);
+        private void DeactivateMappedContext(object sender, SpanEventArgs spanEventArgs)
+        {
+            OpenMappedContext(null, null, null, null);
+        }
 
-            var serviceReader = new ValueReader(() =>
-            {
-                // It is possible to have service name per span so try that first, anyway it should not
-                // fail but use settings as a fallback just in case.
-                return _scopeManager.Active?.Span?.ServiceName ?? settings.ServiceName;
-            });
+        private void OpenMappedContext(string traceIdStr, string spanIdStr, string service, string environment)
+        {
             LogProvider.OpenMappedContext(
-                CorrelationIdentifier.ServiceNameKey, serviceReader, destructure: false);
+                CorrelationIdentifier.TraceIdKey, traceIdStr, destructure: false);
 
-            var environmentReader = new ValueReader(() =>
-            {
-                return settings.Environment ?? string.Empty;
-            });
             LogProvider.OpenMappedContext(
-                CorrelationIdentifier.ServiceEnvironmentKey, environmentReader, destructure: false);
+                CorrelationIdentifier.SpanIdKey, spanIdStr, destructure: false);
+
+            LogProvider.OpenMappedContext(
+                CorrelationIdentifier.ServiceNameKey, service, destructure: false);
+
+            LogProvider.OpenMappedContext(
+                CorrelationIdentifier.ServiceEnvironmentKey, environment, destructure: false);
         }
 
         private void RemoveLastCorrelationIdentifierContext()
@@ -216,21 +196,6 @@ namespace SignalFx.Tracing.Logging
             {
                 _safeToAddToMdc = false;
                 RemoveAllCorrelationIdentifierContexts();
-            }
-        }
-
-        private class ValueReader
-        {
-            private readonly Func<string> readerFunc;
-
-            public ValueReader(Func<string> reader)
-            {
-                readerFunc = reader;
-            }
-
-            public override string ToString()
-            {
-                return readerFunc();
             }
         }
 

--- a/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -30,6 +30,14 @@ namespace Datadog.Trace.Tests.Logging
             layout.Attributes.Add(new JsonAttribute("time", Layout.FromString("${longdate}")));
             layout.Attributes.Add(new JsonAttribute("level", Layout.FromString("${level:uppercase=true}")));
             layout.Attributes.Add(new JsonAttribute("message", Layout.FromString("${message}")));
+            layout.Attributes.Add(new JsonAttribute(LoggingProviderTestHelpers.CustomPropertyName, Layout.FromString($"${{mdlc:item={LoggingProviderTestHelpers.CustomPropertyName}}}")));
+
+            // MapDiagnosticLogicalContext attributes required by NLog v 4.6+
+            layout.Attributes.Add(new JsonAttribute("trace_id", Layout.FromString("${mdlc:item=trace_id}")));
+            layout.Attributes.Add(new JsonAttribute("span_id", Layout.FromString("${mdlc:item=span_id}")));
+            layout.Attributes.Add(new JsonAttribute("service.name", Layout.FromString("${mdlc:item=service.name}")));
+            layout.Attributes.Add(new JsonAttribute("deployment.environment", Layout.FromString("${mdlc:item=deployment.environment}")));
+
             _target = new MemoryTarget
             {
                 Layout = layout
@@ -105,10 +113,10 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: Default values of TraceId=0,SpanId=0
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.SpanIdKey, 0), logString);
-            Assert.Contains(string.Format(ExpectedIdStringFormat, CorrelationIdentifier.TraceIdKey, TraceId.Zero), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.ServiceNameKey, string.Empty), logString);
-            Assert.Contains(string.Format(ExpectedStringFormat, CorrelationIdentifier.ServiceEnvironmentKey, string.Empty), logString);
+            Assert.DoesNotContain($"\"{CorrelationIdentifier.SpanIdKey}\"", logString);
+            Assert.DoesNotContain($"\"{CorrelationIdentifier.TraceIdKey}\"", logString);
+            Assert.DoesNotContain($"\"{CorrelationIdentifier.ServiceNameKey}\"", logString);
+            Assert.DoesNotContain($"\"{CorrelationIdentifier.ServiceEnvironmentKey}\"", logString);
             Assert.DoesNotContain($"\"{LoggingProviderTestHelpers.CustomPropertyName}\"", logString);
         }
 


### PR DESCRIPTION
## Why

When NLog is used as the provider for ILogger the current optimization is broken: the values are reset after the first execution context is gone and become empty.

## What

Instead of leveraging the async local from the scope the code now subscribe to the typical events used for log correlation. However, instead of using the "context dictionary" used in the typical implementation it simply adds the values to the mapped logical context. It is likely that the same could be done for the log providers but I didn't have the time to validate if the same optimization can be applied to other log providers.

## Tests

before changes:

* Validated that the log correlation was broken in a ASP.NET Core app that used ILogger.

after changes:

* Validated that the log correlation was fixed in a ASP.NET Core app that used ILogger.
* Promoted the NLog version used in tests from 4.5.11 to 4.6.8: the test can't pass for both versions without an explicit version check so opting for upgrading the test for the latest 4.6.* version. However, I manually validated that log correlation also works for 4.5.11

## Performance Impact
As expected the code is not as fast as the previous optimization but it is better than the code using the "context dictionary".  *OldTagging* in the table below is the code using the "context dictionary".

|                     Method |         Categories |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|--------------------------- |------------------- |----------:|----------:|----------:|----------:|------:|--------:|-------:|-------:|-------:|----------:|
|                  NoTagging | NoActiveSpanSwitch |  2.734 us | 0.0436 us | 0.0340 us |  2.724 us |  1.00 |    0.00 | 0.5798 | 0.2899 | 0.0381 |    2.4 KB |
|                 OldTagging | NoActiveSpanSwitch |  9.532 us | 0.1831 us | 0.1712 us |  9.568 us |  3.48 |    0.08 | 1.4648 | 0.3510 | 0.0763 |   8.34 KB |
|           NewNLog46Tagging | NoActiveSpanSwitch |  7.186 us | 0.1437 us | 0.1345 us |  7.142 us |  2.63 |    0.07 | 1.0834 | 0.3510 | 0.0763 |   6.45 KB |
|                            |                    |           |           |           |           |       |         |        |        |        |           |
|        NoTaggingSpanSwitch |   ActiveSpanSwitch |  4.785 us | 0.0949 us | 0.2123 us |  4.816 us |  1.00 |    0.00 | 0.5951 | 0.3052 | 0.0458 |   3.53 KB |
|       OldTaggingSpanSwitch |   ActiveSpanSwitch | 18.199 us | 0.6247 us | 1.8222 us | 17.614 us |  3.73 |    0.41 | 3.7231 | 0.8240 | 0.3357 |  15.07 KB |
| NewNLog46TaggingSpanSwitch |   ActiveSpanSwitch | 13.734 us | 0.2622 us | 0.5051 us | 13.769 us |  2.88 |    0.20 | 2.1210 | 0.4883 | 0.1526 |  11.38 KB |




