### PR TITLE
Change SIGNALFX_SERVICE to SIGNALFX_SERVICE_NAME

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1241,7 +1241,7 @@ stages:
         ./run.sh "linux"
       displayName: Crank
       env:
-        SIGNALFX_SERVICE: dd-trace-dotnet
+        SIGNALFX_SERVICE_NAME: dd-trace-dotnet
 
   - job: Windows64
     timeoutInMinutes: 60
@@ -1261,7 +1261,7 @@ stages:
         ./run.sh "windows"
       displayName: Crank
       env:
-        SIGNALFX_SERVICE: dd-trace-dotnet
+        SIGNALFX_SERVICE_NAME: dd-trace-dotnet
 
   - job: LinuxArm64
     timeoutInMinutes: 60
@@ -1280,7 +1280,7 @@ stages:
         ./run.sh "linux_arm64"
       displayName: Crank
       env:
-        SIGNALFX_SERVICE: dd-trace-dotnet
+        SIGNALFX_SERVICE_NAME: dd-trace-dotnet
         SIGNALFX_ENV: CI
 
 - stage: coverage
@@ -1379,13 +1379,13 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/tracer/build/timeit/Samples.HttpMessageHandler
       displayName: Execute Samples.HttpMessageHandler benchmark
       env:
-        SIGNALFX_SERVICE: dd-trace-dotnet
+        SIGNALFX_SERVICE_NAME: dd-trace-dotnet
 
     - script: run.cmd
       workingDirectory: $(System.DefaultWorkingDirectory)/tracer/build/timeit/Samples.FakeDbCommand
       displayName: Execute Samples.FakeDbCommand benchmark
       env:
-        SIGNALFX_SERVICE: dd-trace-dotnet
+        SIGNALFX_SERVICE_NAME: dd-trace-dotnet
 
     - task: PowerShell@2
       displayName: Wait 20 seconds to agent flush before finishing pipeline

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,7 +26,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_HTTP_SERVER_ERROR_STATUSES` | The application's server http statuses to set spans as errors by. | `500-599` |
 | `SIGNALFX_HTTP_CLIENT_ERROR_STATUSES` | The application's client http statuses to set spans as errors by. | `400-599` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to activate sending partial traces to the agent. | `false` |
-| `SIGNALFX_SERVICE` | Application's default service name. |  |
+| `SIGNALFX_SERVICE_NAME` | Application's default service name. |  |
 | `SIGNALFX_ENV` | The value for the `deployment.environment` tag added to every span. |  |
 | `SIGNALFX_TRACE_ENABLED` | Enable to activate the tracer. | `true` |
 | `SIGNALFX_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` |
@@ -67,12 +67,12 @@ Environment variables are the main way to configure values. A setting configured
 
 For an application running on .NET Framework, web configuration file (`web.config`) or application configuration file (`app.config`) can be used to configure settings.
 
-See example with `SIGNALFX_SERVICE` overload.
+See example with `SIGNALFX_SERVICE_NAME` overload.
 
 ```xml
 <configuration>
   <appSettings>
-    <add key="SIGNALFX_SERVICE" value="my-service-name" />
+    <add key="SIGNALFX_SERVICE_NAME" value="my-service-name" />
   </appSettings>
 </configuration>
 ```
@@ -81,11 +81,11 @@ See example with `SIGNALFX_SERVICE` overload.
 
 Use environment variable `SIGNALFX_TRACE_CONFIG_FILE` or `web.config` / `app.config` to set configuration file path . This cannot be set via JSON configuration file.
 
-See example with `SIGNALFX_SERVICE` overload.
+See example with `SIGNALFX_SERVICE_NAME` overload.
 
 ```json
 {
-    "SIGNALFX_SERVICE": "my-service-name"
+    "SIGNALFX_SERVICE_NAME": "my-service-name"
 }
 ```
 
@@ -124,7 +124,7 @@ manager:
 1. Set the service name:
 
     ```bash
-    export SIGNALFX_SERVICE='my-service-name'
+    export SIGNALFX_SERVICE_NAME='my-service-name'
     ```
 
 1. Set the trace endpoint, e.g. [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector):
@@ -179,7 +179,7 @@ system where it will be running.
 1. Set the service name:
 
    ```batch
-   setx SIGNALFX_SERVICE my-service-name /m
+   setx SIGNALFX_SERVICE_NAME my-service-name /m
    ```
 
 1. Set the trace endpoint, e.g. [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector):

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -337,7 +337,7 @@ partial class Build : NukeBuild
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetApplicationArguments("-r net472 netcoreapp3.1 -m -f * --iterationTime 2000")
-                    .SetProcessEnvironmentVariable("SIGNALFX_SERVICE", "otel-trace-dotnet")
+                    .SetProcessEnvironmentVariable("SIGNALFX_SERVICE_NAME", "otel-trace-dotnet")
                     .SetProcessEnvironmentVariable("SIGNALFX_ENV", "CI")
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
                 );

--- a/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Properties/launchSettings.json
+++ b/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "SIGNALFX_LOGS_INJECTION": "true",
         "SIGNALFX_ENV": "dev",
-        "SIGNALFX_SERVICE": "Log4NetExample",
+        "SIGNALFX_SERVICE_NAME": "Log4NetExample",
         "SIGNALFX_VERSION": "1.0.0"
       }
     }

--- a/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Properties/launchSettings.json
+++ b/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Properties/launchSettings.json
@@ -6,7 +6,7 @@
         "DOTNET_ENVIRONMENT": "Development",
         "SIGNALFX_LOGS_INJECTION": "true",
         "SIGNALFX_ENV": "dev",
-        "SIGNALFX_SERVICE": "MicrosoftExtensionsExample",
+        "SIGNALFX_SERVICE_NAME": "MicrosoftExtensionsExample",
         "SIGNALFX_VERSION": "1.0.0",
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}",

--- a/tracer/samples/AutomaticTraceIdInjection/NLog40Example/Properties/launchSettings.json
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog40Example/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "SIGNALFX_LOGS_INJECTION": "true",
         "SIGNALFX_ENV": "dev",
-        "SIGNALFX_SERVICE": "NLog40Example",
+        "SIGNALFX_SERVICE_NAME": "NLog40Example",
         "SIGNALFX_VERSION": "1.0.0"
       }
     }

--- a/tracer/samples/AutomaticTraceIdInjection/NLog45Example/Properties/launchSettings.json
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog45Example/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "SIGNALFX_LOGS_INJECTION": "true",
         "SIGNALFX_ENV": "dev",
-        "SIGNALFX_SERVICE": "NLog45Example",
+        "SIGNALFX_SERVICE_NAME": "NLog45Example",
         "SIGNALFX_VERSION": "1.0.0"
       }
     }

--- a/tracer/samples/AutomaticTraceIdInjection/NLog46Example/Properties/launchSettings.json
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog46Example/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "SIGNALFX_LOGS_INJECTION": "true",
         "SIGNALFX_ENV": "dev",
-        "SIGNALFX_SERVICE": "NLog46Example",
+        "SIGNALFX_SERVICE_NAME": "NLog46Example",
         "SIGNALFX_VERSION": "1.0.0"
       }
     }

--- a/tracer/samples/AutomaticTraceIdInjection/SerilogExample/Properties/launchSettings.json
+++ b/tracer/samples/AutomaticTraceIdInjection/SerilogExample/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "environmentVariables": {
         "SIGNALFX_LOGS_INJECTION": "true",
         "SIGNALFX_ENV": "dev",
-        "SIGNALFX_SERVICE": "SerilogExample",
+        "SIGNALFX_SERVICE_NAME": "SerilogExample",
         "SIGNALFX_VERSION": "1.0.0"
       }
     }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -41,7 +41,7 @@ namespace environment {
     // Sets the default service name for every span.
     // If not set, Tracer will try to determine service name automatically
     // from application name (e.g. entry assembly or IIS application name).
-    const WSTRING service_name = WStr("SIGNALFX_SERVICE");
+    const WSTRING service_name = WStr("SIGNALFX_SERVICE_NAME");
 
     // Sets the "service_version" tag for every span that belong to the root service (and not an external service).
     const WSTRING service_version = WStr("SIGNALFX_VERSION");

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Tools.Runner
 
             if (!string.IsNullOrWhiteSpace(options.Service))
             {
-                envVars["SIGNALFX_SERVICE"] = options.Service;
+                envVars["SIGNALFX_SERVICE_NAME"] = options.Service;
             }
 
             if (!string.IsNullOrWhiteSpace(options.Version))

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Configuration
         /// and used to determine service name of some child spans.
         /// </summary>
         /// <seealso cref="TracerSettings.ServiceName"/>
-        public const string ServiceName = "SIGNALFX_SERVICE";
+        public const string ServiceName = "SIGNALFX_SERVICE_NAME";
 
         /// <summary>
         /// Configuration key for the application's version. Sets the "version" tag on every <see cref="Span"/>.

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/StatsdConfig.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/StatsdConfig.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Vendors.StatsdClient
         /// <summary>
         /// The name of the environment variable defining the service name
         /// </summary>
-        public const string ServiceEnvVar = "SIGNALFX_SERVICE";
+        public const string ServiceEnvVar = "SIGNALFX_SERVICE_NAME";
 
         /// <summary>
         /// The name of the environment variable defining the environment name

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.TestHelpers
                 "SIGNALFX_PROFILER_PROCESSES",
                 "SIGNALFX_DOTNET_TRACER_HOME",
                 "SIGNALFX_DISABLED_INTEGRATIONS",
-                "SIGNALFX_SERVICE",
+                "SIGNALFX_SERVICE_NAME",
                 "SIGNALFX_VERSION",
                 "SIGNALFX_TAGS",
                 "SIGNALFX_APPSEC_ENABLED",

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -195,13 +195,13 @@ namespace Datadog.Trace.Tests.Configuration
 
             if (key == "SIGNALFX_SERVICE_NAME")
             {
-                // We need to ensure SIGNALFX_SERVICE is empty.
+                // We need to ensure SIGNALFX_SERVICE_NAME is empty.
                 string originalServiceName = Environment.GetEnvironmentVariable(ConfigurationKeys.ServiceName);
                 Environment.SetEnvironmentVariable(ConfigurationKeys.ServiceName, null, EnvironmentVariableTarget.Process);
 
                 settings = GetTracerSettings(key, value);
 
-                // after load settings we can restore the original SIGNALFX_SERVICE
+                // after load settings we can restore the original SIGNALFX_SERVICE_NAME
                 Environment.SetEnvironmentVariable(ConfigurationKeys.ServiceName, originalServiceName, EnvironmentVariableTarget.Process);
             }
             else if (key == ConfigurationKeys.AgentHost || key == ConfigurationKeys.AgentPort)

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Configuration
         public const string ProfilerLogPath = "SIGNALFX_TRACE_LOG_PATH";
         public const string RuntimeMetricsEnabled = "SIGNALFX_RUNTIME_METRICS_ENABLED";
         public const string SerializationBatchInterval = "SIGNALFX_TRACE_BATCH_INTERVAL";
-        public const string ServiceName = "SIGNALFX_SERVICE";
+        public const string ServiceName = "SIGNALFX_SERVICE_NAME";
         public const string ServiceNameMappings = "SIGNALFX_TRACE_SERVICE_MAPPING";
         public const string ServiceVersion = "SIGNALFX_VERSION";
         public const string StartupDiagnosticLogEnabled = "SIGNALFX_TRACE_STARTUP_LOGS";

--- a/tracer/test/test-applications/regression/LargePayload/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/LargePayload/Properties/launchSettings.json
@@ -7,7 +7,7 @@
         "SIGNALFX_TRACE_TRANSPORT": "DATADOG-NAMED-PIPES",
         // These variables are to override environmental settings to be sure that the payload is always approximately the same size
         "SIGNALFX_ENV": "payload-test",
-        "SIGNALFX_SERVICE": "LargePayload",
+        "SIGNALFX_SERVICE_NAME": "LargePayload",
         "SIGNALFX_TAGS": "",
         "SIGNALFX_HOST": "PayloadHost" 
       },


### PR DESCRIPTION
to have same env. variable as on main

## Why

To support same env as on main

## What

Change `SIGNALFX_SERVICE` to `SIGNALFX_SERVICE_NAME`

## Tests

CI tests.
 
