### PR TITLE
fix SYSLIB0014 compilation warning for DownloadLibDdwaf build task

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -266,13 +266,17 @@ partial class Build
     Target DownloadLibDdwaf => _ => _
         .Unlisted()
         .After(CreateRequiredDirectories)
-        .Executes(() =>
+        .Executes(async () =>
         {
-            var wc = new WebClient();
             var libDdwafUri = new Uri($"https://www.nuget.org/api/v2/package/libddwaf/{LibDdwafVersion}");
             var libDdwafZip = TempDirectory / "libddwaf.zip";
 
-            wc.DownloadFile(libDdwafUri, libDdwafZip);
+            using (var httpClient = new HttpClient())
+            {
+                await using var stream = await httpClient.GetStreamAsync(libDdwafUri);
+                await using var file = File.Create(libDdwafZip);
+                await stream.CopyToAsync(file);
+            }
 
             Console.WriteLine($"{libDdwafZip} downloaded. Extracting to {LibDdwafDirectory}...");
 


### PR DESCRIPTION
## Why

Avoid reporting warnings in every PR on GitHup


## What

Remove SYSLIB0014 compilation warning from DownloadLibDdwaf nuke task. 
SYSLIB0014: 'WebClient.WebClient()' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.

## Tests

DownloadLibDdwaf passed locally.

## Notes

Similar PR for upstream: https://github.com/DataDog/dd-trace-dotnet/pull/2157