### PR TITLE
Add .NET 6.0 to requirements and Add nuke global tool as optional tool.

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -12,38 +12,47 @@ Minimum requirements:
     - Optional: ASP.NET and web development (to build samples)
   - Individual components
     - .NET Framework 4.7 targeting pack
-- [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
-- [.NET 5.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) to run 32-bit tests locally
+- [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
+- [.NET 6.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) to run 32-bit tests locally
 - Optional: [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
 - Optional: [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) to test in .NET Core 3.0 locally.
 - Optional: [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1) to test in .NET Core 3.1 locally.
+- Optional: [ASP.NET 5.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/5.0) to test in .NET 5.0 locally.
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - [WiX Toolset Visual Studio Extension](https://wixtoolset.org/releases/) to build installer from Visual Studio
 - Optional: [Docker for Windows](https://docs.docker.com/docker-for-windows/) to build Linux binaries and run integration tests on Linux containers. See [section on Docker Compose](#building-and-running-tests-with-docker-compose).
+- Optional: [Nuke as Global Tool](https://nuke.build/docs/getting-started/setup.html) to be able to call nuke tasks directly.
   - Requires Windows 10 (1607 Anniversary Update, Build 14393 or newer)
 
 This repository uses [Nuke](https://nuke.build/) for build automation.
 To see a list of possible targets run:
 
 ```cmd
-.\build.cmd --help
+.\tracer\build.cmd --help
 ```
+
+or, if you installed Nuke as Global Tool
+
+```cmd
+nuke --help
+```
+
 
 For example:
 
 ```powershell
 # Clean and build the main tracer project
-.\build.cmd Clean BuildTracerHome
+.\tracer\build.cmd Clean BuildTracerHome
 
 # Build and run managed and native unit tests. Requires BuildTracerHome to have previously been run
-.\build.cmd BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests 
+.\tracer\build.cmd BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests 
 
 # Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
-.\build.cmd PackageTracerHome 
+.\tracer\build.cmd PackageTracerHome 
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-.\build.cmd BuildAndRunWindowsIntegrationTests
+.\tracer\build.cmd BuildAndRunWindowsIntegrationTests
 ```
 
 ## Linux
@@ -52,13 +61,13 @@ The recommended approach for Linux is to build using Docker. You can use this ap
 
 ```bash
 # Clean and build the main tracer project
-./build_in_docker.sh Clean BuildTracerHome
+./tracer/build_in_docker.sh Clean BuildTracerHome
 
 # Build and run managed unit tests. Requires BuildTracerHome to have previously been run
-./build_in_docker.sh BuildAndRunManagedUnitTests 
+./tracer/build_in_docker.sh BuildAndRunManagedUnitTests 
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-./build_in_docker.sh BuildAndRunLinuxIntegrationTests
+./tracer/build_in_docker.sh BuildAndRunLinuxIntegrationTests
 ```
 
 ## Visual Studio Code


### PR DESCRIPTION
## Why

Keep dev documentation up to date.

## What

Add .NET 6.0 to requirements.
Add nuke global tool as optional tool.

## Tests

N/A
 
