### PR TITLE
Rewrite the 'Get started' instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ page.
 | `x86_64.rpm`  | Red Hat-based Linux distributions | x64 | `rpm -ivh signalfx-dotnet-tracing.rpm` | RPM package |
 | `x64.msi`     | Windows 64-bit | x64 |  `msiexec /i signalfx-dotnet-tracing-x64.msi /quiet` | |
 | `x86.msi`     | Windows 32-bit | x86 | `msiexec /i signalfx-dotnet-tracing-x86.msi /quiet` | |
-| `tar.gz` | x64 Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) except Alpine use glibc |
+| `tar.gz` | Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) except Alpine use glibc |
 | `amd64.deb`   | Debian-based Linux distributions | x64 | `dpkg -i signalfx-dotnet-tracing.debm` | DEB package |
 <!-- TODO: | `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /` | Alpine Linux uses musl | -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,11 +62,11 @@ page.
 | Sufix         | Operating System    | Architecture | Installing via Command Line | Notes |
 | ---           | ---                 | ---          | ---          | ---   |
 | `x86_64.rpm`  | Red Hat-based Linux distributions | x64 | `rpm -ivh signalfx-dotnet-tracing.rpm` | RPM package |
-| `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /` | Alpine Linux uses musl |
 | `x64.msi`     | Windows 64-bit | x64 |  `msiexec /i signalfx-dotnet-tracing-x64.msi /quiet` | |
 | `x86.msi`     | Windows 32-bit | x86 | `msiexec /i signalfx-dotnet-tracing-x86.msi /quiet` | |
 | `musl.tar.gz` | x64 Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x86 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) but Alpine uses glibc |
 | `amd64.deb`   | Debian-based Linux distributions | x64 | `dpkg -i signalfx-dotnet-tracing.debm` | DEB package |
+<!-- TODO: | `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /` | Alpine Linux uses musl | -->
 
 :warning: On Linux, after the installation, you need to additionally run:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ and [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/
 
 ### Supported .NET versions
 
-- .NET Core 3.1, .NET 5.0 and higher on Windows and Linux
+- .NET Core 3.1, .NET 5.0 and higher on Windows and Linux (except Alpine Linux)
 - .NET Framework 4.6.2 and higher on Windows
 
 ## Supported libraries and frameworks

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ You can find the latest installation packages on the
 [Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest)
 page.
 
-| Sufix         | Operating System    | Architecture | Installing via Command Line | Notes |
+| File         | Operating system    | Architecture | Install command | Notes |
 | ---           | ---                 | ---          | ---          | ---   |
 | `x86_64.rpm`  | Red Hat-based Linux distributions | x64 | `rpm -ivh signalfx-dotnet-tracing.rpm` | RPM package |
 | `x64.msi`     | Windows 64-bit | x64 |  `msiexec /i signalfx-dotnet-tracing-x64.msi /quiet` | |
@@ -81,8 +81,8 @@ $Env:COR_PROFILER = "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"      # Select the .
 $Env:COR_ENABLE_PROFILING = "1"                                   # Enable the .NET Framework Profiler
 $Env:CORECLR_PROFILER = "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"  # Select the .NET (Core) Profiler
 $Env:CORECLR_ENABLE_PROFILING = "1"                               # Enable the .NET (Core) Profiler
-# now the auto-instrumentation is configured in this shell session
-# you can set additional settings and run your application e.g.
+# Now the autoinstrumentation is configured in this shell session.
+# You can set additional settings and run your application, for example:
 $Env:SIGNALFX_SERVICE_NAME = "my-service-name"                    # Set the service name
 dotnet run                                                        # Run your application                                                     
 ```
@@ -91,8 +91,8 @@ dotnet run                                                        # Run your app
 
 ```bash
 source /opt/signalfx/defaults.env               # Enable the .NET (Core) Profiler
-# now the auto-instrumentation is configured in this shell session
-# you can set additional settings and run your application e.g.
+# Now the autoinstrumentation is configured in this shell session.
+# You can set additional settings and run your application, for example:
 export SIGNALFX_SERVICE_NAME="my-service-name"  # Set the service name
 dotnet run                                      # Run your application 
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ page.
 | `amd64.deb`   | Debian-based Linux distributions | x64 | `dpkg -i signalfx-dotnet-tracing.debm` | DEB package |
 <!-- TODO: | `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /` | Alpine Linux uses musl | -->
 
-:warning: On Linux, after the installation, you need to additionally run:
+On Linux, after the installation, you need to additionally run:
 
 ```bash
 /opt/signalfx/createLogPath.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ page.
 /opt/signalfx/createLogPath.sh
 ```
 
-### Instrument an application on Windows
+### Instrument a .NET application on Windows
 
 ```powershell
 $Env:COR_PROFILER = "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"      # Select the .NET Framework Profiler
@@ -87,7 +87,7 @@ $Env:SIGNALFX_SERVICE_NAME = "my-service-name"                    # Set the serv
 dotnet run                                                        # Run your application                                                     
 ```
 
-### Instrument an application on Linux
+### Instrument a .NET application on Linux
 
 ```bash
 source /opt/signalfx/defaults.env               # Enable the .NET (Core) Profiler
@@ -97,7 +97,7 @@ export SIGNALFX_SERVICE_NAME="my-service-name"  # Set the service name
 dotnet run                                      # Run your application 
 ```
 
-### Instrument a Windows Service
+### Instrument a Windows Service running a .NET application running
 
 <!-- TODO:
 
@@ -122,7 +122,7 @@ Enable instrumentation for a specific Windows service:
    reg add HKLM\SYSTEM\CurrentControlSet\Services\<ServiceName>\Environment /v CORECLR_ENABLE_PROFILING /d 1
    ```
 
-### Instrument IIS
+### Instrument an ASP.NET application deployed on IIS
 
 <!-- TODO -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,13 +50,13 @@ and [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/
 
 ## Get started
 
-Make sure  you set up the Splunk OpenTelemtry Collector
+Make sure you set up the [Splunk OpenTelemtry Collector](https://github.com/signalfx/splunk-otel-collector)
 to receive telemetry data.
 
 ### Installation
 
 You can find the latest installation packages on the
-[Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases/lastest)
+[Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest)
 page.
 
 | Sufix         | Operating System    | Architecture | Installing via Command Line | Notes |

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ page.
 | `x86_64.rpm`  | Red Hat-based Linux distributions | x64 | `rpm -ivh signalfx-dotnet-tracing.rpm` | RPM package |
 | `x64.msi`     | Windows 64-bit | x64 |  `msiexec /i signalfx-dotnet-tracing-x64.msi /quiet` | |
 | `x86.msi`     | Windows 32-bit | x86 | `msiexec /i signalfx-dotnet-tracing-x86.msi /quiet` | |
-| `musl.tar.gz` | x64 Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x86 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) but Alpine uses glibc |
+| `tar.gz` | x64 Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) but Alpine uses glibc |
 | `amd64.deb`   | Debian-based Linux distributions | x64 | `dpkg -i signalfx-dotnet-tracing.debm` | DEB package |
 <!-- TODO: | `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /` | Alpine Linux uses musl | -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ page.
 | `x86_64.rpm`  | Red Hat-based Linux distributions | x64 | `rpm -ivh signalfx-dotnet-tracing.rpm` | RPM package |
 | `x64.msi`     | Windows 64-bit | x64 |  `msiexec /i signalfx-dotnet-tracing-x64.msi /quiet` | |
 | `x86.msi`     | Windows 32-bit | x86 | `msiexec /i signalfx-dotnet-tracing-x86.msi /quiet` | |
-| `tar.gz` | x64 Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) but Alpine uses glibc |
+| `tar.gz` | x64 Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) except Alpine use glibc |
 | `amd64.deb`   | Debian-based Linux distributions | x64 | `dpkg -i signalfx-dotnet-tracing.debm` | DEB package |
 <!-- TODO: | `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /` | Alpine Linux uses musl | -->
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -54,7 +54,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TRACE_SAMPLING_RULES` | Comma separated list of sampling rules taht enabled custom sampling rules based on regular expressions. The rule is matched in order of specification. The first match in a list is used. The item "sample_rate" is required in decimal format. The item "service" is optional in regular expression format, to match on service name. The item "name" is optional in regular expression format, to match on operation name. | `'[{"sample_rate":0.5, "service":"cart.*"}],[{"sample_rate":0.2, "name":"http.request"}]'` |
 | `SIGNALFX_TRACE_SAMPLE_RATE` | The global rate for the sampler. |  |
 | `SIGNALFX_TRACE_LOGGING_RATE` | The number of seconds between identical log messages for Tracer log files. Setting to 0 disables rate limiting. | `60` |
-| `SIGNALFX_TRACE_LOG_DIRECTORY` | The directory of the .NET Tracer logs. Overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present. | Linux: `/var/log/signalfx/dotnet/`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\` |
+| `SIGNALFX_TRACE_LOG_DIRECTORY` | The directory of the .NET Tracer logs. Overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present. | Linux: `/var/log/signalfx/dotnet/`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\` |
 | `SIGNALFX_HTTP_SERVER_ERROR_STATUSES` | The application's server http statuses to set spans as errors by. | `500-599` |
 | `SIGNALFX_HTTP_CLIENT_ERROR_STATUSES` | The application's client http statuses to set spans as errors by. | `400-599` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to activate sending partial traces to the agent. | `false` |
@@ -69,7 +69,7 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_STDOUT_LOG_TEMPLATE` | Configures `stdout` log template. See more about Serilog formatting options [here](https://github.com/serilog/serilog/wiki/Configuration-Basics#output-templates). | `"[{Level:u3}] {Message:lj} {NewLine}{Exception}{NewLine}"` |
 | `SIGNALFX_FILE_LOG_ENABLED` | Enable file logging. This is enabled by default. | `true` |
 | `SIGNALFX_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |
-| `SIGNALFX_TRACE_LOG_PATH` | (Deprecated) The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
+| `SIGNALFX_TRACE_LOG_PATH` | (Deprecated) The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. | `true` |
 | `SIGNALFX_DISABLED_INTEGRATIONS` | The integrations you want to disable, if any, separated by a comma. These are the supported integrations: `AspNetMvc`, `AspNetWebApi2`, `DbCommand`, `ElasticsearchNet5`, `ElasticsearchNet6`, `GraphQL`, `HttpMessageHandler`, `IDbCommand`, `MongoDb`, `NpgsqlCommand`, `OpenTracing`, `ServiceStackRedis`, `SqlCommand`, `StackExchangeRedis`, `Wcf`, `WebRequest` |  |
 | `SIGNALFX_PROPAGATORS` | Comma separated list of the propagators for the tracer. Available propagators are: `Datadog`, `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,9 +4,9 @@ Check if you are not hitting one of the issues listed below.
 
 ## Linux instrumentation not working
 
-The proper binary needs to be selected when deploying to Linux,
+The proper installation package needs to be selected when deploying to Linux,
 eg.: the default Microsoft .NET images are based on Debian and should use
-the `deb` package, see the [Linux](README.md#Linux) setup section.
+the `deb` package.
 
 If you are not sure what is the Linux distribution being used try the following commands:
 
@@ -19,14 +19,22 @@ cat /proc/version
 
 ## High CPU usage
 
-The default installation of auto-instrumentation enables tracing all .NET processes
-on the box.
-In the typical scenarios (dedicated VMs or containers), this is not a problem.
-Use the environment variables `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` and `SIGNALFX_PROFILER_PROCESSES`
-to include/exclude applications from the tracing auto-instrumentation.
+Check if you have not enabled the auto-instrumentation globally
+by setting the environment variables on system or user level.
+
+If it was really intended, then use the
+`SIGNALFX_PROFILER_EXCLUDE_PROCESSES` and `SIGNALFX_PROFILER_PROCESSES`
+environment variables to include/exclude applications from the tracing auto-instrumentation.
 These are ";" delimited lists that control the inclusion/exclusion of processes.
 
 ## Investigating other issues
+
+Check that all [settings](advanced-config.md) are properly configured.
+
+If you need to check the environment variables for a process on Windows, use a tool
+like [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer).
+On Linux you can simply run: `cat /proc/<pid>/environ`
+where `<pid>` is the Process ID.
 
 If none of the suggestions above solves your issue, detailed logs are necessary.
 Follow the steps below to get detailed logs.


### PR DESCRIPTION
## Why

The current installation instructions needed some care.

## What

1. Restructure (adept to make it similar to https://github.com/signalfx/splunk-otel-java and https://github.com/signalfx/splunk-otel-python as well as make it better in general)
2. Now the instructions recommend enabling the auto-instrumentation per application instead of turning it globally. Enabling it globally causes too much overhead for the whole Windows ecosystem (see troubleshooting). Also it was not "aligned" with Linux instructions which were doing it "per application". Datadog also does not have any instructions to install it globally. If it would be good then the MSI would do it.
3. Change the command prompt (batch) scripts to PowerShell

## Tests

- Tested on Windows. The only missing thing is setting the `SIGNALFX_ENDPOINT_URL` but this will be not needed when the update its default value
- The instructions for Linux are almost the same (ordering of the commands changed, added comments, removed the log correlation setting). I will test it anyway as part of my current story. If anything is wrong then I will simply make PRs or create new stories (depending on the issue) - but everything should be fine 😉 
 