### PR TITLE
Azure site extension

### DIFF
--- a/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
+++ b/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
@@ -21,7 +21,7 @@
     <file src=".\applicationHost.xdt" target="content" />
     <file src=".\install.cmd" target="content" />
     <file src=".\scmApplicationHost.xdt" target="content" />
-    <file src="..\..\..\tracer\bin\tracer-home\**\*.*" target="content\tracer" />
+    <file src="$TracerHomeDirectory$\**\*.*" target="content\tracer" />
     <file src="..\..\..\signalfx-logo-64x64.png" target="icon.png" />
   </files>
 </package>

--- a/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
+++ b/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>SignalFx.NET.Tracing.Azure.Site.Extension</id>
+    <version>0.1.16.0</version>
+    <title>SignalFx .NET Tracing</title>
+    <authors>SignalFx</authors>
+    <icon>icon.png</icon>
+    <license type="expression">Apache-2.0</license>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      SignalFx .NET Tracing packaged as an Azure Site Extension.
+    </description>
+    <projectUrl>https://github.com/signalfx/signalfx-dotnet-tracing</projectUrl>
+    <tags>AzureSiteExtension SignalFx .NET Tracing</tags>
+    <packageTypes>
+      <packageType name="AzureSiteExtension" />
+    </packageTypes>  
+  </metadata>
+  <files>
+    <file src=".\applicationHost.xdt" target="content" />
+    <file src=".\install.cmd" target="content" />
+    <file src=".\scmApplicationHost.xdt" target="content" />
+    <file src="..\..\src\bin\windows-tracer-home\**\*.*" target="content\tracer" />
+    <file src="..\..\signalfx-logo-64x64.png" target="icon.png" />
+  </files>
+</package>

--- a/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
+++ b/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>SignalFx.NET.Tracing.Azure.Site.Extension</id>
-    <version>0.1.16.0</version>
+    <version>0.2.0.0</version>
     <title>SignalFx .NET Tracing</title>
     <authors>SignalFx</authors>
     <icon>icon.png</icon>

--- a/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
+++ b/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
@@ -21,7 +21,7 @@
     <file src=".\applicationHost.xdt" target="content" />
     <file src=".\install.cmd" target="content" />
     <file src=".\scmApplicationHost.xdt" target="content" />
-    <file src="..\..\src\bin\windows-tracer-home\**\*.*" target="content\tracer" />
-    <file src="..\..\signalfx-logo-64x64.png" target="icon.png" />
+    <file src="..\..\..\tracer\bin\tracer-home\**\*.*" target="content\tracer" />
+    <file src="..\..\..\signalfx-logo-64x64.png" target="icon.png" />
   </files>
 </package>

--- a/shared/src/azure-site-extension/README.md
+++ b/shared/src/azure-site-extension/README.md
@@ -1,0 +1,8 @@
+# SignalFx .NET Tracing Azure Site Extension
+
+Code in this folder is used to build a [Azure Site Extension](https://github.com/projectkudu/kudu/wiki/Azure-Site-Extensions)
+that installs the [SignalFx .NET Tracing](../../README.md).
+
+An Azure Site Extension is a specially crafted [NuGet package](https://www.nuget.org/)
+that is used to customize [IIS](https://www.iis.net/) running the user code.
+ 

--- a/shared/src/azure-site-extension/applicationHost.xdt
+++ b/shared/src/azure-site-extension/applicationHost.xdt
@@ -17,7 +17,7 @@
         <add name="CORECLR_PROFILER_PATH_64" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 
         <add name="SIGNALFX_DOTNET_TRACER_HOME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="SIGNALFX_TRACE_LOG_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="SIGNALFX_TRACE_LOG_DIRECTORY" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 
@@ -35,7 +35,7 @@
         <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.2.0" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.2.0\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_TRACE_LOG_DIRECTORY" value="%HOME%\LogFiles\signalfx\tracing\v0.2.0\" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
       </environmentVariables>

--- a/shared/src/azure-site-extension/applicationHost.xdt
+++ b/shared/src/azure-site-extension/applicationHost.xdt
@@ -25,14 +25,14 @@
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.2.0\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.2.0\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.2.0\win-x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.2.0\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.2.0\win-x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.2.0" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_TRACE_LOG_DIRECTORY" value="%HOME%\LogFiles\signalfx\tracing\v0.2.0\" xdt:Locator="Match(name)" xdt:Transform="Insert"/>

--- a/shared/src/azure-site-extension/applicationHost.xdt
+++ b/shared/src/azure-site-extension/applicationHost.xdt
@@ -17,7 +17,6 @@
         <add name="CORECLR_PROFILER_PATH_64" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
 
         <add name="SIGNALFX_DOTNET_TRACER_HOME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
-        <add name="SIGNALFX_INTEGRATIONS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="SIGNALFX_TRACE_LOG_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
@@ -36,7 +35,6 @@
         <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.2.0" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.2.0\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.2.0\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>

--- a/shared/src/azure-site-extension/applicationHost.xdt
+++ b/shared/src/azure-site-extension/applicationHost.xdt
@@ -26,18 +26,18 @@
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.1.16\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.16\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.16\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.2.0\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.16\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.16\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.2.0\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.2.0\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
-        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.1.16" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.1.16\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.1.16\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.2.0" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.2.0\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.2.0\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
       </environmentVariables>

--- a/shared/src/azure-site-extension/applicationHost.xdt
+++ b/shared/src/azure-site-extension/applicationHost.xdt
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <system.webServer>
+    <runtime xdt:Transform="InsertIfMissing" >
+      <environmentVariables xdt:Transform="InsertIfMissing">
+        <add name="COMPLUS_LoaderOptimization" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+
+        <add name="COR_ENABLE_PROFILING" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="COR_PROFILER" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="COR_PROFILER_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="COR_PROFILER_PATH_32" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="COR_PROFILER_PATH_64" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+
+        <add name="CORECLR_ENABLE_PROFILING" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="CORECLR_PROFILER" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="CORECLR_PROFILER_PATH_32" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="CORECLR_PROFILER_PATH_64" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+
+        <add name="SIGNALFX_DOTNET_TRACER_HOME" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="SIGNALFX_INTEGRATIONS" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="SIGNALFX_TRACE_LOG_PATH" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="SIGNALFX_AZURE_APP_SERVICES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+        <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" xdt:Locator="Match(name)" xdt:Transform="RemoveAll"/>
+
+        <!-- We're unable to instrument domain-neutral assemblies when our managed assemblies are not in the GAC, so force LoaderOptimization to be LoaderOptimization.SingleDomain -->
+        <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v0.1.16\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.16\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.16\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v0.1.16\x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v0.1.16\x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+
+        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v0.1.16" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_INTEGRATIONS" value="%HOME%\signalfx\tracing\v0.1.16\integrations.json" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_TRACE_LOG_PATH" value="%HOME%\LogFiles\signalfx\tracing\v0.1.16\dotnet-profiler.log" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+      </environmentVariables>
+    </runtime>
+  </system.webServer>
+</configuration>

--- a/shared/src/azure-site-extension/install.cmd
+++ b/shared/src/azure-site-extension/install.cmd
@@ -8,7 +8,7 @@ echo Extension directory is %extensionBaseDir%
 echo Site root directory is %siteHome%
 
 REM Create version specific tracer directory
-SET tracerDir=%siteHome%\signalfx\tracing\v0.1.16
+SET tracerDir=%siteHome%\signalfx\tracing\v0.2.0
 if not exist %tracerDir% mkdir %tracerDir%
 
 REM Copy tracer to version specific directory

--- a/shared/src/azure-site-extension/install.cmd
+++ b/shared/src/azure-site-extension/install.cmd
@@ -1,0 +1,17 @@
+@echo off
+
+echo Starting install
+
+SET extensionBaseDir=%~dp0
+SET siteHome=%HOME%
+echo Extension directory is %extensionBaseDir%
+echo Site root directory is %siteHome%
+
+REM Create version specific tracer directory
+SET tracerDir=%siteHome%\signalfx\tracing\v0.1.16
+if not exist %tracerDir% mkdir %tracerDir%
+
+REM Copy tracer to version specific directory
+ROBOCOPY %extensionBaseDir%tracer %tracerDir% /E /purge
+
+echo Finished install

--- a/shared/src/azure-site-extension/scmApplicationHost.xdt
+++ b/shared/src/azure-site-extension/scmApplicationHost.xdt
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!-- This file exists to prevent applicationHost.xdt from being applied to scm host that runs
+      other dotnet processes (dotnet build, csc etc. )-->
+</configuration>

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -7,10 +7,12 @@ using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.MSBuild;
+using Nuke.Common.Tools.NuGet;
 using Nuke.Common.Utilities.Collections;
 using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
+using static Nuke.Common.Tools.NuGet.NuGetTasks;
 
 // #pragma warning disable SA1306
 // #pragma warning disable SA1134
@@ -258,6 +260,17 @@ partial class Build : NukeBuild
                     .CombineWith(ProjectsToPack, (x, project) => x
                         .SetProject(project)),
                 degreeOfParallelism: 2);
+        })
+        .Executes(() =>
+        {
+            NuGetPack(s => s
+                    .SetTargetPath(SharedDirectory / "src" / "azure-site-extension" / "Azure.Site.Extension.nuspec")
+                    .SetOutputDirectory(ArtifactsDirectory / "nuget")
+                    .SetProperty("TracerHomeDirectory", TracerHomeDirectory)
+                    .SetProperty("NoWarn", "NU5100")
+                    .SetProperty("NoBuild", true)
+                    .SetProperty("NoDefaultExcludes", true)
+            );
         });
 
     Target BuildDistributionNuget => _ => _

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -177,6 +177,17 @@ namespace PrepareRelease
                 "src/WindowsInstaller/WindowsInstaller.wixproj",
                 WixProjReplace);
 
+            // Azure Site Extension updates
+            SynchronizeVersion(
+                "../shared/src/azure-site-extension/applicationHost.xdt",
+                text => Regex.Replace(text, VersionPattern(), VersionString()));
+            SynchronizeVersion(
+                "../shared/src/azure-site-extension/Azure.Site.Extension.nuspec",
+                text => Regex.Replace(text, VersionPattern(), VersionString()));
+            SynchronizeVersion(
+                "../shared/src/azure-site-extension/install.cmd",
+                text => Regex.Replace(text, VersionPattern(), VersionString()));
+
             Console.WriteLine($"Completed synchronizing versions to {VersionString()}");
         }
 


### PR DESCRIPTION
## Why

Bring functionality from the main branch to the next-ver

## What

Azure Site Extension

## Tests

Locally created nuget package. Deployed to the private nuget server.
Extension installed on .NET Core 3.1 and .NET 4.8 Framework.
Traces displayed in APM website.
 
![image](https://user-images.githubusercontent.com/5972917/147061600-7546080f-a8f0-47a1-9cff-f4ca7a336276.png)

## Notes
To be done in separate request
 * Instrumentation is not working if there is no SIGNALFX_API_KEY configured. Which is not needed in fact.
 * Each request produces logs similar to 2021-12-22 07:01:04.801 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
 * Ensure that our release job is publishing also new package.
