### PR TITLE
replace  SIGNALFX_API_KEY by SIGNALFX_ACCESS_TOKEN

### DIFF
--- a/.azure-pipelines/mininal-pipeline.yml
+++ b/.azure-pipelines/mininal-pipeline.yml
@@ -57,7 +57,7 @@ variables:
   ddTracerHome: $(System.DefaultWorkingDirectory)/tracer/src/bin/dd-tracer-home
   tracerHome: $(System.DefaultWorkingDirectory)/tracer/src/bin/windows-tracer-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts
-  ddApiKey: $(SIGNALFX_API_KEY)
+  ddApiKey: $(SIGNALFX_ACCESS_TOKEN)
   isMainBranch: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
   SIGNALFX_DOTNET_TRACER_MSBUILD:
@@ -78,7 +78,7 @@ resources:
     ports:
     - 8126:8126
     env:
-      SIGNALFX_API_KEY: $(ddApiKey)
+      SIGNALFX_ACCESS_TOKEN: $(ddApiKey)
       SIGNALFX_INSIDE_CI: true
 
 # Stages

--- a/.azure-pipelines/third-party-test-suites.yml
+++ b/.azure-pipelines/third-party-test-suites.yml
@@ -13,7 +13,7 @@ schedules:
 variables:
   buildConfiguration: Release
   dotnetCoreSdk5Version: 5.0.103
-  ddApiKey: $(SIGNALFX_API_KEY)
+  ddApiKey: $(SIGNALFX_ACCESS_TOKEN)
   SIGNALFX_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages
@@ -28,7 +28,7 @@ resources:
     ports:
     - 8126:8126
     env:
-      SIGNALFX_API_KEY: $(ddApiKey)
+      SIGNALFX_ACCESS_TOKEN: $(ddApiKey)
       SIGNALFX_INSIDE_CI: true
 
 stages:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -71,7 +71,7 @@ variables:
   profilerHome: $(System.DefaultWorkingDirectory)/profiler/bin/profiler-home # Important, put the profiler assets into the working directory so it can be saved across build stages more easily
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts
-  ddApiKey: $(SIGNALFX_API_KEY)
+  ddApiKey: $(SIGNALFX_ACCESS_TOKEN)
   isMainBranch: $[in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main')]
   isMainOrReleaseBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -93,7 +93,7 @@ resources:
     ports:
     - 8126:8126
     env:
-      SIGNALFX_API_KEY: $(ddApiKey)
+      SIGNALFX_ACCESS_TOKEN: $(ddApiKey)
       SIGNALFX_INSIDE_CI: true
   repositories:
   - repository: dd-continuous-profiler-dotnet
@@ -1429,7 +1429,7 @@ stages:
         workingDirectory: system-tests
         displayName: Run tests
         env:
-          SIGNALFX_API_KEY: $(SYSTEM_TESTS_SIGNALFX_API_KEY)
+          SIGNALFX_ACCESS_TOKEN: $(SYSTEM_TESTS_SIGNALFX_ACCESS_TOKEN)
 
       - publish: system-tests/logs
         condition: always()

--- a/docs/internal-config.md
+++ b/docs/internal-config.md
@@ -32,7 +32,6 @@ These settings should be never used by the users.
 | `SIGNALFX_TRACE_AGENT_ARGS` | Comma-separated list of arguments to be passed to the Trace Agent process. |  |
 | `SIGNALFX_DOGSTATSD_PATH` | The DogStatsD path for when a standalone instance needs to be started. |  |
 | `SIGNALFX_DOGSTATSD_ARGS` | Comma-separated list of arguments to be passed to the DogStatsD pricess. |  |
-| `SIGNALFX_API_KEY` | The API key used by the Agent. |  |
 | `SIGNALFX_TRACE_TRANSPORT` | Overrides the transport to use for communicating with the trace agent. Available values are: `datagod-tcp`, `datadog-named-pipes`. | `null` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` | The minimum number of closed spans in a trace before it's partially flushed. `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` has to be enabled for this to take effect. | `500` |
 

--- a/tracer/samples/NugetDeployment/README.md
+++ b/tracer/samples/NugetDeployment/README.md
@@ -1,6 +1,6 @@
 # Agent configuration
 The `docker-compose.yml` file automatically starts the Datadog agent container image when running the applications.
-- `SIGNALFX_API_KEY` (required)
+- `SIGNALFX_ACCESS_TOKEN` (required)
 - `SIGNALFX_ENV` (optional)
 
 # Running samples

--- a/tracer/samples/NugetDeployment/docker-compose.yml
+++ b/tracer/samples/NugetDeployment/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8126"
     environment:
-      SIGNALFX_API_KEY: "${SIGNALFX_API_KEY:?Set SIGNALFX_API_KEY in your shell to send traces to Datadog}"
+      SIGNALFX_ACCESS_TOKEN: "${SIGNALFX_ACCESS_TOKEN:?Set SIGNALFX_ACCESS_TOKEN in your shell to send traces to Datadog}"
       SIGNALFX_APM_ENABLED: "true"
       SIGNALFX_APM_NON_LOCAL_TRAFFIC: "true"
       SIGNALFX_ENV: "${SIGNALFX_ENV}"

--- a/tracer/samples/WindowsContainer/README.md
+++ b/tracer/samples/WindowsContainer/README.md
@@ -6,7 +6,7 @@ This repo contains an example of setting up Datadog .NET automatic tracing for a
 ### How to use: 
 
 - Clone/download this repository
-- Update the `docker-compose.yml` by replacing the value for `SIGNALFX_API_KEY`
+- Update the `docker-compose.yml` by replacing the value for `SIGNALFX_ACCESS_TOKEN`
 - Run `docker-compose up` & navigate to `http://localhost:8000` 
 
 #### Resulting .NET 5 APM traces within Datadog: 

--- a/tracer/samples/WindowsContainer/docker-compose.yml
+++ b/tracer/samples/WindowsContainer/docker-compose.yml
@@ -15,6 +15,6 @@ services:
   datadog-agent:
     image: "gcr.io/datadoghq/agent:7"
     environment:
-      SIGNALFX_API_KEY: ${SIGNALFX_API_KEY}
+      SIGNALFX_ACCESS_TOKEN: ${SIGNALFX_ACCESS_TOKEN}
       SIGNALFX_APM_ENABLED: "true"
       SIGNALFX_APM_NON_LOCAL_TRAFFIC: "true"

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -396,12 +396,6 @@ namespace Datadog.Trace.Configuration
         public const string Propagators = "SIGNALFX_PROPAGATORS";
 
         /// <summary>
-        /// Configuration key for setting the API key, used by the Agent.
-        /// This key is here for troubleshooting purposes.
-        /// </summary>
-        public const string ApiKey = "SIGNALFX_API_KEY";
-
-        /// <summary>
         /// Configuration key for overriding the transport to use for communicating with the trace agent.
         /// Default value is <c>null</c>.
         /// Override options available: <c>datadog-tcp</c>, <c>datadog-named-pipes</c>

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
@@ -94,10 +94,10 @@ namespace Datadog.Trace.PlatformHelpers
 
                 if (IsRelevant)
                 {
-                    var apiKey = GetVariableIfExists(Configuration.ConfigurationKeys.ApiKey, environmentVariables);
+                    var apiKey = GetVariableIfExists(Configuration.ConfigurationKeys.SignalFxAccessToken, environmentVariables);
                     if (apiKey == null)
                     {
-                        Log.Error("The Azure Site Extension will not work if you have not configured SIGNALFX_API_KEY.");
+                        Log.Error($"The Azure Site Extension will not work if you have not configured {Configuration.ConfigurationKeys.SignalFxAccessToken}.");
                         IsUnsafeToTrace = true;
                         return;
                     }

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -215,10 +217,10 @@ namespace Datadog.Trace.Tests.PlatformHelpers
                 vars.Remove(AzureAppServices.InstanceNameKey);
             }
 
-            if (!vars.Contains(Datadog.Trace.Configuration.ConfigurationKeys.ApiKey))
+            if (!vars.Contains(Datadog.Trace.Configuration.ConfigurationKeys.SignalFxAccessToken))
             {
                 // This is a needed configuration for the AAS extension
-                vars.Add(Datadog.Trace.Configuration.ConfigurationKeys.ApiKey, "1");
+                vars.Add(Datadog.Trace.Configuration.ConfigurationKeys.SignalFxAccessToken, "1");
             }
 
             vars.Add(AzureAppServices.AzureAppServicesContextKey, "1");

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -19,7 +19,6 @@ namespace Datadog.Trace.Configuration
         public const string AgentHost = "SIGNALFX_AGENT_HOST";
         public const string AgentPort = "SIGNALFX_TRACE_AGENT_PORT";
         public const string AgentUri = "SIGNALFX_TRACE_AGENT_URL";
-        public const string ApiKey = "SIGNALFX_API_KEY";
         public const string AppSecBlockingEnabled = "SIGNALFX_APPSEC_BLOCKING_ENABLED";
         public const string AppSecCustomIpHeader = "SIGNALFX_APPSEC_IPHEADER";
         public const string AppSecEnabled = "SIGNALFX_APPSEC_ENABLED";

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.AllTriggers/Startup.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.AllTriggers/Startup.cs
@@ -12,7 +12,7 @@ namespace Samples.AzureFunctions.AllTriggers
 		{
 			builder.Services.AddHttpClient();
 
-			var apiKey = Environment.GetEnvironmentVariable("SIGNALFX_API_KEY");
+			var apiKey = Environment.GetEnvironmentVariable("SIGNALFX_ACCESS_TOKEN");
 			var logsInjectionEnabled = Environment.GetEnvironmentVariable("SIGNALFX_LOGS_INJECTION");
 
 			if (!string.IsNullOrWhiteSpace(apiKey) && logsInjectionEnabled.Equals("1"))


### PR DESCRIPTION
## Why

There were an issue while starting Azure Site Extension which forced to set up unused SIGNALFX_API_KEY

## What

Change SIGNALFX_API_KEY to SIGNALFX_ACCESS_TOKEN.
This token is now required to start tracing in Azure Site Extension to prevent log like 

`[ERR] The Azure Site Extension will not work if you have not configured SIGNALFX_API_KEY. { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }`

Now, if there is no SIGNALFX_ACCESS_TOKEN. Then following logs occurs
`[ERR] The Azure Site Extension will not work if you have not configured SIGNALFX_ACCESS_TOKEN. { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }`
## Tests

See #278
 
