### PR TITLE
remove misleading log from propagator

### DIFF
--- a/tracer/src/Datadog.Trace/Propagation/PropagationHelpers.cs
+++ b/tracer/src/Datadog.Trace/Propagation/PropagationHelpers.cs
@@ -11,19 +11,25 @@ namespace Datadog.Trace.Propagation
         public static TraceId ParseTraceId<T>(T carrier, Func<T, string, IEnumerable<string>> getter, string headerName, ITraceIdConvention traceIdConvention, IDatadogLogger logger)
         {
             var headerValues = getter(carrier, headerName) ?? Enumerable.Empty<string>();
+            var hasValue = false;
 
             foreach (var headerValue in headerValues)
             {
                 var traceId = traceIdConvention.CreateFromString(headerValue);
                 if (traceId == TraceId.Zero)
                 {
+                    hasValue = true;
                     continue;
                 }
 
                 return traceId;
             }
 
-            logger.Warning("Could not parse {HeaderName} headers: {HeaderValues}", headerName, string.Join(",", headerValues));
+            if (hasValue)
+            {
+                logger.Warning("Could not parse {HeaderName} headers: {HeaderValues}", headerName, string.Join(",", headerValues));
+            }
+
             return TraceId.Zero;
         }
 


### PR DESCRIPTION
## Why

Avoid misleading logs

## What

Remove misleading log, when there is no header to parse.
Fixed in similar way, as it is done in datadog propagator.

## Tests

See #278.

Logs after fix
```
2021-12-22 09:41:19.936 +00:00 [INF] ByRef instrumentation enabled. { MachineName: ".", Process: "[3436 w3wp]", AppDomain: "[2 /LM/W3SVC/456090899/ROOT-1-132846396773107753]", TracerVersion: "0.2.2.0" }
2021-12-22 09:41:20.202 +00:00 [INF] The profiler has been initialized with 257 definitions. { MachineName: ".", Process: "[3436 w3wp]", AppDomain: "[2 /LM/W3SVC/456090899/ROOT-1-132846396773107753]", TracerVersion: "0.2.2.0" }
2021-12-22 09:41:20.202 +00:00 [INF] [Assembly metadata] Location: C:\home\signalfx\tracing\v0.2.2\net461\SignalFx.Tracing.dll, CodeBase: file:///C:/home/signalfx/tracing/v0.2.2/net461/SignalFx.Tracing.dll, GAC: False, HostContext: 0, SecurityRuleSet: Level2 { MachineName: ".", Process: "[3436 w3wp]", AppDomain: "[2 /LM/W3SVC/456090899/ROOT-1-132846396773107753]", TracerVersion: "0.2.2.0" }
2021-12-22 09:41:20.623 +00:00 [INF] TRACER CONFIGURATION - {"date":"2021-12-22T09:41:20.5614331+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.14393.0","version":"0.2.2.0","platform":"x86","lang":".NET Framework","lang_version":"4.8","env":null,"enabled":true,"service":"azuremvc48-web-app-sfx020","agent_url":"https://ingest.us0.signalfx.com/v2/trace","metrics_agent_url":"http://localhost:9943/v2/datapoint","debug":false,"health_checks_enabled":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":false,"disabled_integrations":[],"routetemplate_resourcenames_enabled":true,"partialflush_enabled":false,"partialflush_minspans":500,"runtime_id":"fc39f135-a9c4-4d46-bc6e-540871659141","agent_reachable":true,"agent_error":"","appsec_enabled":false,"appsec_blocking_enabled":false,"appsec_rules_file_path":"(default)","appsec_libddwaf_version":"(none)"} { MachineName: ".", Process: "[3436 w3wp]", AppDomain: "[2 /LM/W3SVC/456090899/ROOT-1-132846396773107753]", TracerVersion: "0.2.2.0" }

```

Before changes
```

Tons of log related to Could not parse x-b3-traceid headers: - consider to change to debug/remove at all.
2021-12-22 06:46:55.345 +00:00 [INF] ByRef instrumentation enabled. { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:46:55.607 +00:00 [INF] The profiler has been initialized with 257 definitions. { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:46:55.610 +00:00 [INF] [Assembly metadata] Location: C:\home\signalfx\tracing\v0.2.1\netcoreapp3.1\SignalFx.Tracing.dll, CodeBase: file:///C:/home/signalfx/tracing/v0.2.1/netcoreapp3.1/SignalFx.Tracing.dll, GAC: False, HostContext: 0, SecurityRuleSet: None { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:46:55.669 +00:00 [ERR] The Azure Site Extension will not work if you have not configured SIGNALFX_API_KEY. { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:46:55.830 +00:00 [INF] Initializing ServiceFabric instrumentation { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:46:55.940 +00:00 [INF] TRACER CONFIGURATION - {"date":"2021-12-22T06:46:55.9188959+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.14393.0","version":"0.2.1.0","platform":"x86","lang":".NET Core","lang_version":"3.1.18","env":null,"enabled":false,"service":"azure3.1-web-app-sfx020","agent_url":"https://ingest.us0.signalfx.com/v2/trace","metrics_agent_url":"http://localhost:9943/v2/datapoint","debug":false,"health_checks_enabled":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":false,"disabled_integrations":[],"routetemplate_resourcenames_enabled":true,"partialflush_enabled":false,"partialflush_minspans":500,"runtime_id":"ffdf30ff-57b4-45f2-b3f6-d6bbcf642f9e","agent_reachable":true,"agent_error":"","appsec_enabled":false,"appsec_blocking_enabled":false,"appsec_rules_file_path":"(default)","appsec_libddwaf_version":"(none)"} { MachineName: ".", Process: "[12640 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:45.403 +00:00 [INF] ByRef instrumentation enabled. { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:45.621 +00:00 [INF] The profiler has been initialized with 257 definitions. { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:45.625 +00:00 [INF] [Assembly metadata] Location: C:\home\signalfx\tracing\v0.2.1\netcoreapp3.1\SignalFx.Tracing.dll, CodeBase: file:///C:/home/signalfx/tracing/v0.2.1/netcoreapp3.1/SignalFx.Tracing.dll, GAC: False, HostContext: 0, SecurityRuleSet: None { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:45.843 +00:00 [INF] Initializing ServiceFabric instrumentation { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:45.954 +00:00 [INF] TRACER CONFIGURATION - {"date":"2021-12-22T06:57:45.9339301+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.14393.0","version":"0.2.1.0","platform":"x86","lang":".NET Core","lang_version":"3.1.18","env":null,"enabled":true,"service":"azure3.1-web-app-sfx020","agent_url":"https://ingest.us0.signalfx.com/v2/trace","metrics_agent_url":"http://localhost:9943/v2/datapoint","debug":false,"health_checks_enabled":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":false,"disabled_integrations":[],"routetemplate_resourcenames_enabled":true,"partialflush_enabled":false,"partialflush_minspans":500,"runtime_id":"e92b35da-0b6c-4950-856f-a6e10c3c1d9d","agent_reachable":true,"agent_error":"","appsec_enabled":false,"appsec_blocking_enabled":false,"appsec_rules_file_path":"(default)","appsec_libddwaf_version":"(none)"} { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:46.877 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:48.050 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:48.050 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:58.535 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:59.016 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:57:59.047 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:58:49.745 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:58:50.801 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:58:51.255 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 06:58:51.289 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:49.949 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:50.405 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:50.446 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:52.101 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:52.267 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:52.311 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:53.101 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:53.260 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:00:53.281 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:01:04.329 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:01:04.770 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
2021-12-22 07:01:04.801 +00:00 [WRN] Could not parse x-b3-traceid headers:  { MachineName: ".", Process: "[20604 w3wp]", AppDomain: "[1 MyFirstZaureWebApp]", AssemblyLoadContext: null, TracerVersion: "0.2.1.0" }
```