### PR TITLE
Add Splunk notice to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
+
 # SignalFx Instrumentation for .NET
 
 The SignalFx Instrumentationy for .NET provides automatic instrumentations


### PR DESCRIPTION
## What

This small PR adds the acquisition notice with a link to the README file.
Changes from #273

## Tests

N/A