### PR TITLE
Add internal documentation for thread sampling

### DIFF
--- a/docs/internal-config.md
+++ b/docs/internal-config.md
@@ -38,6 +38,6 @@ These settings should be never used by the users.
 ## Unpublished settings
 | `SIGNALFX_METRICS_ENDPOINT_URL` | The URL to where metric exporters send metrics. | `http://localhost:9943/v2/datapoint` |
 | `SIGNALFX_RUNTIME_METRICS_ENABLED` | Enable to activate internal runtime metrics sent to SignalFx. | `false` |
-| `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. The tracer uses it to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
+| `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. It is used to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
 | `SIGNALFX_THREAD_SAMPLING_ENABLED` | Enable to activate thread sampling. | `false` |
-| `SIGNALFX_THREAD_SAMPLING_PERIOD` | Sampling period. The tracer uses it to stop threads for a short amount of time and fetch all stack traces. This value cannot be lower that `1000` milliseconds. | `1000` |
+| `SIGNALFX_THREAD_SAMPLING_PERIOD` | Sampling period. It defines how often the threads are stopped in order to fetch all stack traces. This value cannot be lower than `1000` milliseconds. | `1000` |

--- a/docs/internal-config.md
+++ b/docs/internal-config.md
@@ -38,6 +38,6 @@ These settings should be never used by the users.
 ## Unpublished settings
 | `SIGNALFX_METRICS_ENDPOINT_URL` | The URL to where metric exporters send metrics. | `http://localhost:9943/v2/datapoint` |
 | `SIGNALFX_RUNTIME_METRICS_ENABLED` | Enable to activate internal runtime metrics sent to SignalFx. | `false` |
-| `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. The Tracer uses it to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
-| `SIGNALFX_THREAD_SAMPLING_ENABLED` | Enable to activate thread sampling sent to SignalFx. | `false` |
-| `SIGNALFX_THREAD_SAMPLING_PERIOD` | Sampling period to be used. The Tracer uses it to stop threads for shorto amount of time and fetch all stack traces. This value cannot be lower that `1000` ms. | `1000` |
+| `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. The tracer uses it to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
+| `SIGNALFX_THREAD_SAMPLING_ENABLED` | Enable to activate thread sampling. | `false` |
+| `SIGNALFX_THREAD_SAMPLING_PERIOD` | Sampling period. The tracer uses it to stop threads for a short amount of time and fetch all stack traces. This value cannot be lower that `1000` milliseconds. | `1000` |

--- a/docs/internal-config.md
+++ b/docs/internal-config.md
@@ -39,3 +39,5 @@ These settings should be never used by the users.
 | `SIGNALFX_METRICS_ENDPOINT_URL` | The URL to where metric exporters send metrics. | `http://localhost:9943/v2/datapoint` |
 | `SIGNALFX_RUNTIME_METRICS_ENABLED` | Enable to activate internal runtime metrics sent to SignalFx. | `false` |
 | `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. The Tracer uses it to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
+| `SIGNALFX_THREAD_SAMPLING_ENABLED` | Enable to activate thread sampling sent to SignalFx. | `false` |
+| `SIGNALFX_THREAD_SAMPLING_PERIOD` | Sampling period to be used. The Tracer uses it to stop threads for shorto amount of time and fetch all stack traces. This value cannot be lower that `1000` ms. | `1000` |


### PR DESCRIPTION
## Why

Keep internal doc up to date.

## What

Internal docs for `SIGNALFX_THREAD_SAMPLING_PERIOD` and `SIGNALFX_THREAD_SAMPLING_ENABLED`.

## Tests

N/A
