### PR TITLE
fix link to the icon

### DIFF
--- a/tracer/src/Directory.Build.props
+++ b/tracer/src/Directory.Build.props
@@ -10,7 +10,7 @@
 
     <!-- NuGet packages -->
     <IsPackable>true</IsPackable>
-    <PackageIconUrl>https://github.com/signalfx/signalfx-dotnet-tracing/raw/master/signalfx-logo-64x64.png</PackageIconUrl>
+    <PackageIconUrl>https://github.com/signalfx/signalfx-dotnet-tracing/raw/main/signalfx-logo-64x64.png</PackageIconUrl>
     <PackageIcon>packageIcon.png</PackageIcon>
     <PackageProjectUrl>https://docs.signalfx.com/en/latest/apm/apm-instrument/apm-dotnet.html</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
## Why

Cleanup references in nuget

## What

Fix link to the icon.

## Tests

New link opens in the browser : )
