### PR TITLE
Document configuration settings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,14 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 ### Breaking changes
 
 - There is no support for .NET older than .NET 4.6.2.
+- Rename `SIGNALFX_DOTNET_TRACER_CONFIG_FILE` configuration to `SIGNALFX_TRACE_CONFIG_FILE`.
+- Rename `SIGNALFX_PROPAGATOR` configuration to `SIGNALFX_PROPAGATORS`.
+- Rename `SIGNALFX_TRACE_GLOBAL_TAGS` configuration to `SIGNALFX_TAGS`.
+- Rename `SIGNALFX_TRACING_ENABLED` configuration to `SIGNALFX_TRACE_ENABLED`
+- Rename `SIGNALFX_ASPNET_TEMPLATE_NAMES_ENABLED` configuration to `SIGNALFX_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`.
+- Remove `SIGNALFX_ADD_CLIENT_IP_TO_SERVER_SPANS` configuration.
+  New, fixed behavior is equivalent to flag enabled.
+- Remove `SIGNALFX_SYNC_SEND` configuration.
 - Remove `SIGNALFX_APPEND_URL_PATH_TO_NAME` configuration as it was against the
   [OpenTelemetry Semantic conventions for HTTP spans](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name).
   Take notice that the URL is available via `http.url` tag.
@@ -43,13 +51,28 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
   requires that the resources (such us as [service](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#service))
   have to be immutable.
 - Remove `SIGNALFX_INTEGRATIONS`. This configuration is not needed.
-  The insrtumenation called `CallSite` was removed.
+  The instrumentation called `CallSite` was removed.
 - Deprecate `SIGNALFX_TRACE_LOG_PATH`. Please use `SIGNALFX_TRACE_LOG_DIRECTORY`.
 
 ### Enhancements
 
 - Adopt [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
   in most of the instrumentations.
+- Add `SIGNALFX_HTTP_SERVER_ERROR_STATUSES` configuration that controls server http statuses to set spans as errors by.
+- Add `SIGNALFX_HTTP_CLIENT_ERROR_STATUSES` configuration that controls client http statuses to set spans as errors by.
+- Add `SIGNALFX_MAX_TRACES_PER_SECOND` configuration that limits max number of traces sent per second.
+- Add `SIGNALFX_STDOUT_LOG_TEMPLATE` configuration that configures `stdout` template.
+- Add `SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` configuration that enables the updated WCF instrumentation that delays execution until later in the WCF pipeline when the WCF server exception handling is established.
+- Add `SIGNALFX_TRACE_HEADER_TAGS` configuration that sets a map of header keys to tag names.
+- Add `SIGNALFX_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED` configuration that closes consumer scope on method enter, and starts a new one on method exit.
+- Add `SIGNALFX_TRACE_LOG_DIRECTORY` configuration that sets directory for logs and overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present.
+- Add `SIGNALFX_TRACE_LOGGING_RATE` configuration that sets number of seconds between identical log messages for tracer log files.
+- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` that enables partial flush of traces.
+- Add `SIGNALFX_VERSION` configuration that sets application's version that will populate `version` tag on spans.
+- Add `SIGNALFX_TRACE_STARTUP_LOGS` configuration that enables diagnostic log at startup.
+- Add `SIGNALFX_TRACE_SAMPLE_RATE` configuration that sets the global rate for the sampler.
+- Add `SIGNALFX_TRACE_SAMPLING_RULES` configuration that is a comma separated list of sampling rules that enable custom sampling rules based on regular expressions.
+- Add `SIGNALFX_TRACE_{0}_ENABLED` configuration pattern that enables/disables specific integration.
 
 ---
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -50,13 +50,14 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TRACE_HEADER_TAGS` | Comma-separated map of header keys to tag name, that will be automatically applied as tags on traces. | `"key1:val1,key2:val2"` |
 | `SIGNALFX_MAX_TRACES_PER_SECOND` | The number of traces allowed to be submitted per second. | `100` |
 | `SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED` | Enable to add server trace information to HTTP response headers. | `true` |
-| `SIGNALFX_TRACE_STARTUP_LOGS` | Enable to activate diagnostic log at stratup. | `true` |
+| `SIGNALFX_TRACE_STARTUP_LOGS` | Enable to activate diagnostic log at startup. | `true` |
 | `SIGNALFX_TRACE_SAMPLING_RULES` | Comma separated list of sampling rules that enable custom sampling rules based on regular expressions. The rule is matched in order of specification. The first match in a list is used. The item "sample_rate" is required in decimal format. The item "service" is optional in regular expression format, to match on service name. The item "name" is optional in regular expression format, to match on operation name. | `'[{"sample_rate":0.5, "service":"cart.*"}],[{"sample_rate":0.2, "name":"http.request"}]'` |
 | `SIGNALFX_TRACE_SAMPLE_RATE` | The global rate for the sampler. By default, all traces are sampled. |  |
-| `SIGNALFX_TRACE_LOGGING_RATE` | The number of seconds between identical log messages for Tracer log files. Setting to 0 disables rate limiting. | `60` |
+| `SIGNALFX_TRACE_LOGGING_RATE` | The number of seconds between identical log messages for tracer log files. Setting to 0 disables rate limiting. | `60` |
 | `SIGNALFX_TRACE_LOG_DIRECTORY` | The directory of the .NET Tracer logs. Overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present. | Linux: `/var/log/signalfx/dotnet/`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\` |
 | `SIGNALFX_HTTP_SERVER_ERROR_STATUSES` | The application's server http statuses to set spans as errors by. | `500-599` |
 | `SIGNALFX_HTTP_CLIENT_ERROR_STATUSES` | The application's client http statuses to set spans as errors by. | `400-599` |
+| `SIGNALFX_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS` | Sets URLs that are skipped by the tracer. |  |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to activate sending partial traces to the agent. | `false` |
 | `SIGNALFX_SERVICE_NAME` | Application's default service name. |  |
 | `SIGNALFX_ENV` | The value for the `deployment.environment` tag added to every span. |  |
@@ -82,3 +83,5 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` | ASP.NET span and resource names are based on routing configuration if applicable. | `true` |
 | `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES` | Enable the tagging of a Elasticsearch command PostData as `db.statement`. It may introduce overhead for direct streaming users. | `true` |
 | `SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` | Enable the updated WCF instrumentation that delays execution until later in the WCF pipeline when the WCF server exception handling is established. | `false` |
+| `SIGNALFX_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED` | Enable to close consumer scope on method enter, and start a new one on method exit. | `true` |
+| `SIGNALFX_TRACE_{0}_ENABLED` | Configuration pattern for enabling/disabling specific integration, e.g in order to disable kafka integration, set `SIGNALFX_TRACE_KAFKA_ENABLED=0`|  |

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -84,4 +84,4 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES` | Enable the tagging of a Elasticsearch command PostData as `db.statement`. It may introduce overhead for direct streaming users. | `true` |
 | `SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` | Enable the updated WCF instrumentation that delays execution until later in the WCF pipeline when the WCF server exception handling is established. | `false` |
 | `SIGNALFX_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED` | Enable to close consumer scope on method enter, and start a new one on method exit. | `true` |
-| `SIGNALFX_TRACE_{0}_ENABLED` | Configuration pattern for enabling/disabling specific integration, e.g in order to disable kafka integration, set `SIGNALFX_TRACE_KAFKA_ENABLED=0`|  |
+| `SIGNALFX_TRACE_{0}_ENABLED` | Configuration pattern for enabling/disabling a specific library instrumentation, e.g in order to disable Kafka instrumentation, set `SIGNALFX_TRACE_Kafka_ENABLED=false` | `true` |

--- a/docs/internal-config.md
+++ b/docs/internal-config.md
@@ -14,11 +14,16 @@ These settings should be never used by the users.
 
 | Environment variable | Description | Default |
 |-|-|-|
-| `SIGNALFX_AGENT_HOST` | The host name of the targeted SatsD server. |  |
+| `SIGNALFX_APPSEC_ENABLED` | Enables the AppSec. | `false` |
+| `SIGNALFX_APPSEC_BLOCKING_ENABLED` | Enables the AppSec blocking. | `false` |
+| `SIGNALFX_APPSEC_RULES` | Overrides the default rules file provided. Must be a path to a valid JSON rules file. |  |
+| `SIGNALFX_APPSEC_IPHEADER` | Optional name of the custom header to take into account for the ip address. |  |
+| `SIGNALFX_APPSEC_EXTRA_HEADERS` | Optional custom headers the user wants to send. |  |
+| `SIGNALFX_AGENT_HOST` | The Agent host where the tracer can send traces. |  |
 | `SIGNALFX_TRACE_AGENT_URL` | Alias for `SIGNALFX_ENDPOINT_URL`. The URL to where trace exporters send traces. | `http://localhost:9411/api/v2/spans` |
-| `SIGNALFX_TRACE_AGENT_HOST` | The Agent host where the Tracer can send traces | `localhost` |
-| `SIGNALFX_TRACE_AGENT_PORT` | The Agent port where the Tracer can send traces | `9411` |
-| `SIGNALFX_TRACE_PIPE_NAME` | The named pipe where the Tracer can send traces. |  |
+| `SIGNALFX_TRACE_AGENT_HOSTNAME` | The Agent host where the tracer can send traces | `localhost` |
+| `SIGNALFX_TRACE_AGENT_PORT` | The Agent port where the tracer can send traces | `9411` |
+| `SIGNALFX_TRACE_PIPE_NAME` | The named pipe where the tracer can send traces. |  |
 | `SIGNALFX_TRACE_PIPE_TIMEOUT_MS` | The timeout in milliseconds for named pipes communication. | `100` |
 | `SIGNALFX_TRACE_BUFFER_SIZE` | The size in bytes of the trace buffer. | `1024 * 1024 * 10 (10MB)` |
 | `SIGNALFX_TRACE_BATCH_INTERVAL` | The batch interval in milliseconds for the serialization queue. | `100` |
@@ -26,14 +31,17 @@ These settings should be never used by the users.
 | `SIGNALFX_DOGSTATSD_PIPE_NAME` | The named pipe that DogStatsD binds to. |  |
 | `SIGNALFX_APM_RECEIVER_PORT` | The port for Trace Agent binding. | `8126` |
 | `SIGNALFX_TRACE_ANALYTICS_ENABLED` | Enable to activate default Analytics. | `false` |
+| `SIGNALFX_TRACE_{0}_ANALYTICS_ENABLED` | Enable to activate analytics for specific integration. | `false` |
+| `SIGNALFX_TRACE_{0}_ANALYTICS_SAMPLE_RATE` | Set sample rate for analytics in specific integration. |  |
 | `SIGNALFX_TRACE_SERVICE_MAPPING` | Comma-separated map of services to rename. | `"key1:val1,key2:val2"` |
 | `SIGNALFX_TRACE_METRICS_ENABLED` | Enable to activate internal metrics sent to DogStatsD. | `false` |
 | `SIGNALFX_TRACE_AGENT_PATH` | The Trace Agent path for when a standalone instance needs to be started. |  |
 | `SIGNALFX_TRACE_AGENT_ARGS` | Comma-separated list of arguments to be passed to the Trace Agent process. |  |
 | `SIGNALFX_DOGSTATSD_PATH` | The DogStatsD path for when a standalone instance needs to be started. |  |
-| `SIGNALFX_DOGSTATSD_ARGS` | Comma-separated list of arguments to be passed to the DogStatsD pricess. |  |
-| `SIGNALFX_TRACE_TRANSPORT` | Overrides the transport to use for communicating with the trace agent. Available values are: `datagod-tcp`, `datadog-named-pipes`. | `null` |
+| `SIGNALFX_DOGSTATSD_ARGS` | Comma-separated list of arguments to be passed to the DogStatsD process. |  |
+| `SIGNALFX_TRACE_TRANSPORT` | Overrides the transport to use for communicating with the trace agent. Available values are: `datagod-tcp`, `datadog-named-pipes`. |  |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` | The minimum number of closed spans in a trace before it's partially flushed. `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` has to be enabled for this to take effect. | `500` |
+| `SIGNALFX_CIVISIBILITY_ENABLED` | Enable to activate CI Visibility. | `false` |
 
 ## Unpublished settings
 | `SIGNALFX_METRICS_ENDPOINT_URL` | The URL to where metric exporters send metrics. | `http://localhost:9943/v2/datapoint` |

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -497,22 +497,6 @@ namespace Datadog.Trace.Configuration
             public const string AnalyticsSampleRate = "SIGNALFX_TRACE_{0}_ANALYTICS_SAMPLE_RATE";
         }
 
-        /// <summary>
-        /// String constants for debug configuration keys.
-        /// </summary>
-        internal static class Debug
-        {
-            /// <summary>
-            /// Configuration key for forcing the automatic instrumentation to only use the mdToken method lookup mechanism.
-            /// </summary>
-            public const string ForceMdTokenLookup = "SIGNALFX_TRACE_DEBUG_LOOKUP_MDTOKEN";
-
-            /// <summary>
-            /// Configuration key for forcing the automatic instrumentation to only use the fallback method lookup mechanism.
-            /// </summary>
-            public const string ForceFallbackLookup = "SIGNALFX_TRACE_DEBUG_LOOKUP_FALLBACK";
-        }
-
         internal static class FeatureFlags
         {
             /// <summary>


### PR DESCRIPTION
## Why
All of the settings supported should be documented.
## What
Update of `internal-config.md`, `advanced-config.md` and `CHANGELOG.md`.
Removal of unused configuration keys from `ConfigurationKeys`

## Tests
n/a
 
