### PR TITLE
Document the list of all instrumented libraries

### DIFF
--- a/docs/PULL_FROM_UPSTREAM.md
+++ b/docs/PULL_FROM_UPSTREAM.md
@@ -25,6 +25,12 @@
     * `git rebase -i <squash_sha>^`
     * Select top one as "pick" all coming from upstream as "squash" and let the ones that you made to fix build and test as "pick" so it is easier to review them separately.
 
+7. Make sure to update the documentation. Especially:
+    * [advanced-config.md](advanced-config.md)
+    * [internal-config.md](internal-config.md)
+    * [instrumented-libraries.md](instrumented-libraries.md)
+    * [CHANGELOG.md](CHANGELOG.md)
+
 ## Regenerating snapshot files
 
 Windows in Git Bash:

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ The SignalFx Instrumentationy for .NET registers an OpenTracing `GlobalTracer`
 so you can support existing custom instrumentation or add custom
 instrumentation to your application later.
 
-Conventions used by SignalFx Instrumentation for .NET are inspired by
+The conventions used by SignalFx Instrumentation for .NET are inspired by
 the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
 [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 with its [Zipkin Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ The SignalFx Instrumentationy for .NET registers an OpenTracing `GlobalTracer`
 so you can support existing custom instrumentation or add custom
 instrumentation to your application later.
 
-SignalFx Instrumentation for .NET convensions are inspired by
+Conventions used by SignalFx Instrumentation for .NET are inspired by
 the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
 [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 with its [Zipkin Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,8 @@ The SignalFx Instrumentationy for .NET registers an OpenTracing `GlobalTracer`
 so you can support existing custom instrumentation or add custom
 instrumentation to your application later.
 
-Whenever possible, SignalFx Instrumentation for .NET complies
-to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
+SignalFx Instrumentation for .NET convensions are inspired by
+the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
 [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 with its [Zipkin Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver)
 can be used to receive, process and export telemetry data.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,21 +34,13 @@ and [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/
 
 ## Requirements
 
-### Supported .NET versions
-
 - .NET Core 3.1, .NET 5.0 and higher on Windows and Linux (except Alpine Linux)
 - .NET Framework 4.6.2 and higher on Windows
 
-## Supported libraries and frameworks
+## Instrumented libraries and frameworks
 
-| Library | Versions Supported | Notes |
-| ---     | ---                | ---   |
-| Elasticsearch.Net | `Elasticsearch.Net` NuGet 5.3 - 7.x | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES=false` (`true` by default, which may introduce overhead for direct streaming users). |
-| HttpClient | Supported .NET versions | by way of `System.Net.Http.HttpClientHandler` and `HttpMessageHandler` instrumentations |
-| Npgsql | `Npqsql` NuGet 4.0+ | Provided via enhanced ADO.NET instrumentation |
-| ServiceStack.Redis | `ServiceStack.Redis` NuGet 4.0+ | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS=false` (`true` by default). |
-| StackExchange.Redis | `StackExchange.Redis` NuGet 1.0+ | Disable `db.statement` tagging with `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS=false` (`true` by default). |
-| WebClient | Supported .NET versions | by way of `System.Net.WebRequest` instrumentation |
+See [instrumented-libraries.md](instrumented-libraries.md)
+to know for which libraries and frameworks are instrumented.
 
 ## Get started
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -71,14 +71,14 @@ Use these environment variables to configure the tracing library:
 | `SIGNALFX_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |
 | `SIGNALFX_TRACE_LOG_PATH` | (Deprecated) The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. | `true` |
-| `SIGNALFX_DISABLED_INTEGRATIONS` | The integrations you want to disable, if any, separated by a comma. These are the supported integrations: `AspNetMvc`, `AspNetWebApi2`, `DbCommand`, `ElasticsearchNet5`, `ElasticsearchNet6`, `GraphQL`, `HttpMessageHandler`, `IDbCommand`, `MongoDb`, `NpgsqlCommand`, `OpenTracing`, `ServiceStackRedis`, `SqlCommand`, `StackExchangeRedis`, `Wcf`, `WebRequest` |  |
+| `SIGNALFX_DISABLED_INTEGRATIONS` | Comma-separated list of disabled library instrumentations. The available integration ID values can be found [here](instrumented-libraries.md). |  |
 | `SIGNALFX_PROPAGATORS` | Comma separated list of the propagators for the tracer. Available propagators are: `Datadog`, `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3` |
 | `SIGNALFX_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` |  Sets whether to intercept method calls when the caller method is inside a domain-neutral assembly. This is recommended when instrumenting IIS applications. | `false` |
 | `SIGNALFX_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | The maximum length an attribute value can have. Values longer than this are truncated. Values are completely truncated when set to 0, and ignored when set to a negative value. | `12000` |
 | `SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS` | Enable the tagging of a Mongo command BsonDocument as `db.statement`. | `true` |
-| `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS` | Enable the tagging of a Redis commands as `db.statement`. | `true` |
+| `SIGNALFX_INSTRUMENTATION_REDIS_TAG_COMMANDS` | Enable the tagging of a Redis command as `db.statement`. | `true` |
 | `SIGNALFX_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` | ASP.NET span and resource names are based on routing configuration if applicable. | `true` |
 | `SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES` | Enable the tagging of a Elasticsearch command PostData as `db.statement`. It may introduce overhead for direct streaming users. | `true` |
 | `SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` | Enable the updated WCF instrumentation that delays execution until later in the WCF pipeline when the WCF server exception handling is established. | `false` |

--- a/docs/instrumented-libraries.md
+++ b/docs/instrumented-libraries.md
@@ -52,7 +52,7 @@ produce appropriate spans.
 
 ## Details
 
-You can get exact information on the instrumented code [here](../tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs).
+You can find out which methods and assemblies are being instrumented by inspecting the [InstrumentationDefinitions](../tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs) file. This is useful to check, for example, the version range of the library you're instrumenting.
 
 Each line contains following information (in order):
 

--- a/docs/instrumented-libraries.md
+++ b/docs/instrumented-libraries.md
@@ -1,0 +1,79 @@
+# Instumented libraries and framework
+
+## Fully supported
+
+The libraries below should be fully supported and, whenever possible,
+comply to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
+
+| ID | Library |
+| -- | ---     |
+| Aerospike | [Aerospike.Client](https://www.nuget.org/packages/Aerospike.Client/) |
+| AspNet | ASP.NET 4.x |
+| AspNetCore | ASP.NET Core |
+| AspNetMvc | ASP.NET MVC |
+| AspNetWebApi2 | ASP.NET Web API 2 |
+| AwsSdk | [AWSSDK.Core](https://www.nuget.org/packages/AWSSDK.Core/) |
+| AwsSqs | [AWSSDK.SQS](https://www.nuget.org/packages/AWSSDK.SQS/) |
+| AzureFunctions | [Microsoft.Azure.WebJobs](https://www.nuget.org/packages/Microsoft.Azure.WebJobs/) |
+| CosmosDb | [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/) |
+| Couchbase | [CouchbaseNetClient](https://www.nuget.org/packages/CouchbaseNetClient/) |
+| CurlHandler | [`System.Net.Http.CurlHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler#httpclienthandler-in-net-core) |
+| ElasticsearchNet | [Elasticsearch.Net](https://www.nuget.org/packages/Elasticsearch.Net/) |
+| GraphQL | [GraphQL](https://www.nuget.org/packages/GraphQL/) |
+| HttpMessageHandler | [`System.Net.Http.MessageHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpmessagehandler) |
+| HttpSocketsHandler | [`System.Net.Http.SocketsHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler) |
+| ILogger | [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/) |
+| Kafka | [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka/) |
+| MongoDb | [MongoDB.Driver.Core](https://www.nuget.org/packages/MongoDB.Driver.Core/) |
+| Msmq | [`System.Messaging`](https://docs.microsoft.com/en-us/dotnet/api/system.messaging) |
+| MsTestV2 | [Microsoft.VisualStudio.TestPlatform](https://www.nuget.org/packages/Microsoft.VisualStudio.TestPlatform/) |
+| MySql | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) |
+| Npgsql | [Npgsql](https://www.nuget.org/packages/Npgsql/) |
+| NUnit | [NUnit](https://www.nuget.org/packages/NUnit/) |
+| Oracle | [Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) |
+| RabbitMQ | [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client/) |
+| ServiceRemoting | [Microsoft.ServiceFabric.Services.Remoting](https://www.nuget.org/packages/Microsoft.ServiceFabric.Services.Remoting/) |
+| ServiceStackRedis | [ServiceStack.Redis](https://www.nuget.org/packages/ServiceStack.Redis/) |
+| SqlClient | [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) and [`System.Data.SqlClient`](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient) |
+| Sqlite | [SQLite](https://www.nuget.org/packages/SQLite/) |
+| StackExchangeRedis | [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis/) |
+| Wcf | Windows Communication Foundation (WCF) |
+| WebRequest | [`System.Net.WebRequest`](https://docs.microsoft.com/en-us/dotnet/api/system.net.webreques) |
+| WinHttpHandler | [`System.Net.Http.WinHttpHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.winhttphandler) |
+| XUnit | [xunit](https://www.nuget.org/packages/xunit) |
+
+
+## Partially supported
+
+The libraries below are instrumented, yet the instrumentation, may not
+produce appropriate spans (e.g. the tags names and values may not
+comply to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
+
+## Learning details
+
+You can get exact infromartion what is being instrummented [here](../tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs).
+
+Each line contains following information about the instrumnted code in order:
+
+- Assembly name
+- Type name
+- Method name
+- Method signature (arguments and return) types
+- Minimum assembly version - major number
+- Minimum assembly version - minor number
+- Minimum assembly version - patch number
+- Maximum assembly version - major number
+- Maximum assembly version - minor number
+- Maximum assembly version - patch number
+
+For example:
+
+```csharp
+new("AerospikeClient", "Aerospike.Client.SyncCommand", "ExecuteCommand",  new[] { "System.Void" }, 4, 0, 0, 4, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Aerospike.SyncCommandIntegration"),
+```
+
+means that the following code is instrumented:
+
+- assembly: `AerospikeClient`, versions: [`4.0.0`, `5.0.0`)
+- type: `Aerospike.Client.SyncCommand`
+- method: `void ExecuteCommand()`

--- a/docs/instrumented-libraries.md
+++ b/docs/instrumented-libraries.md
@@ -34,7 +34,7 @@ the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry
 
 ## Partially supported
 
-The libraries below are instrumented, yet the instrumentation, may not
+The libraries below are instrumented, though the instrumentation might not
 produce appropriate spans.
 
 | ID | Library |

--- a/docs/instrumented-libraries.md
+++ b/docs/instrumented-libraries.md
@@ -2,8 +2,8 @@
 
 ## Fully supported
 
-The libraries below should be fully supported and, whenever possible,
-comply to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
+The libraries below should be fully supported and the conventions are inspired by
+the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
 
 | ID | Library |
 | -- | ---     |
@@ -12,11 +12,6 @@ comply to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open
 | AspNetCore | ASP.NET Core |
 | AspNetMvc | ASP.NET MVC |
 | AspNetWebApi2 | ASP.NET Web API 2 |
-| AwsSdk | [AWSSDK.Core](https://www.nuget.org/packages/AWSSDK.Core/) |
-| AwsSqs | [AWSSDK.SQS](https://www.nuget.org/packages/AWSSDK.SQS/) |
-| AzureFunctions | [Microsoft.Azure.WebJobs](https://www.nuget.org/packages/Microsoft.Azure.WebJobs/) |
-| CosmosDb | [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/) |
-| Couchbase | [CouchbaseNetClient](https://www.nuget.org/packages/CouchbaseNetClient/) |
 | CurlHandler | [`System.Net.Http.CurlHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler#httpclienthandler-in-net-core) |
 | ElasticsearchNet | [Elasticsearch.Net](https://www.nuget.org/packages/Elasticsearch.Net/) |
 | GraphQL | [GraphQL](https://www.nuget.org/packages/GraphQL/) |
@@ -25,14 +20,10 @@ comply to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open
 | ILogger | [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/) |
 | Kafka | [Confluent.Kafka](https://www.nuget.org/packages/Confluent.Kafka/) |
 | MongoDb | [MongoDB.Driver.Core](https://www.nuget.org/packages/MongoDB.Driver.Core/) |
-| Msmq | [`System.Messaging`](https://docs.microsoft.com/en-us/dotnet/api/system.messaging) |
-| MsTestV2 | [Microsoft.VisualStudio.TestPlatform](https://www.nuget.org/packages/Microsoft.VisualStudio.TestPlatform/) |
 | MySql | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) |
 | Npgsql | [Npgsql](https://www.nuget.org/packages/Npgsql/) |
-| NUnit | [NUnit](https://www.nuget.org/packages/NUnit/) |
 | Oracle | [Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) |
 | RabbitMQ | [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client/) |
-| ServiceRemoting | [Microsoft.ServiceFabric.Services.Remoting](https://www.nuget.org/packages/Microsoft.ServiceFabric.Services.Remoting/) |
 | ServiceStackRedis | [ServiceStack.Redis](https://www.nuget.org/packages/ServiceStack.Redis/) |
 | SqlClient | [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) and [`System.Data.SqlClient`](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient) |
 | Sqlite | [SQLite](https://www.nuget.org/packages/SQLite/) |
@@ -40,20 +31,30 @@ comply to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open
 | Wcf | Windows Communication Foundation (WCF) |
 | WebRequest | [`System.Net.WebRequest`](https://docs.microsoft.com/en-us/dotnet/api/system.net.webreques) |
 | WinHttpHandler | [`System.Net.Http.WinHttpHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.winhttphandler) |
-| XUnit | [xunit](https://www.nuget.org/packages/xunit) |
-
 
 ## Partially supported
 
 The libraries below are instrumented, yet the instrumentation, may not
-produce appropriate spans (e.g. the tags names and values may not
-comply to the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).
+produce appropriate spans.
 
-## Learning details
+| ID | Library |
+| -- | ---     |
+| AwsSdk | [AWSSDK.Core](https://www.nuget.org/packages/AWSSDK.Core/) |
+| AwsSqs | [AWSSDK.SQS](https://www.nuget.org/packages/AWSSDK.SQS/) |
+| AzureFunctions | [Microsoft.Azure.WebJobs](https://www.nuget.org/packages/Microsoft.Azure.WebJobs/) |
+| CosmosDb | [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/) |
+| Couchbase | [CouchbaseNetClient](https://www.nuget.org/packages/CouchbaseNetClient/) |
+| Msmq | [`System.Messaging`](https://docs.microsoft.com/en-us/dotnet/api/system.messaging) |
+| MsTestV2 | [Microsoft.VisualStudio.TestPlatform](https://www.nuget.org/packages/Microsoft.VisualStudio.TestPlatform/) |
+| NUnit | [NUnit](https://www.nuget.org/packages/NUnit/) |
+| ServiceRemoting | [Microsoft.ServiceFabric.Services.Remoting](https://www.nuget.org/packages/Microsoft.ServiceFabric.Services.Remoting/) |
+| XUnit | [xunit](https://www.nuget.org/packages/xunit) |
 
-You can get exact infromartion what is being instrummented [here](../tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs).
+## Details
 
-Each line contains following information about the instrumnted code in order:
+You can get exact information on the instrumented code [here](../tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs).
+
+Each line contains following information (in order):
 
 - Assembly name
 - Type name


### PR DESCRIPTION
## Why

The customers should not what code is auto-instrumented.

## What

- Document the list of all instrumented libraries
- Update pull from upstream process to make sure that everything is up-to-date
 
