### PR TITLE
refactor ThreadSampling env vars

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
@@ -465,7 +465,7 @@ void CaptureSamples(ThreadSampler* ts, ICorProfilerInfo10* info10, SamplingHelpe
 
 int GetSamplingPeriod()
 {
-    WSTRING val = GetEnvironmentValue(environment::thread_sampling_period);
+    const WSTRING val = GetEnvironmentValue(environment::thread_sampling_period);
     if (val.empty())
     {
         return DEFAULT_SAMPLE_PERIOD;

--- a/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
+// Modified by Splunk Inc.
+
 using System.Threading;
 using Datadog.Trace.ClrProfiler;
 
@@ -11,21 +12,13 @@ namespace Datadog.Trace
 {
     internal class AsyncLocalScopeManager : ScopeManagerBase
     {
-        private static readonly bool PushScopeToNative;
+        private readonly bool _pushScopeToNative;
+
         private readonly AsyncLocal<Scope> _activeScope = new();
 
-        static AsyncLocalScopeManager()
+        public AsyncLocalScopeManager(bool pushScopeToNative)
         {
-            // FIXME JBLEY share logic or at least constants somewhere
-            var enabled = Environment.GetEnvironmentVariable("SIGNALFX_THREAD_SAMPLING_ENABLED");
-            if (enabled != null && (enabled.ToLower() == "1" || enabled.ToLower() == "true"))
-            {
-                PushScopeToNative = true;
-            }
-            else
-            {
-                PushScopeToNative = false;
-            }
+            _pushScopeToNative = pushScopeToNative;
         }
 
         public override Scope Active
@@ -38,7 +31,7 @@ namespace Datadog.Trace
             protected set
             {
                 _activeScope.Value = value;
-                if (PushScopeToNative)
+                if (_pushScopeToNative)
                 {
                     // nop
                     if (value == null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -13,7 +15,6 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.Logging;
 using Datadog.Trace.ServiceFabric;
-using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler
 {
@@ -180,11 +181,9 @@ namespace Datadog.Trace.ClrProfiler
             // Thread Sampling ("profiling") feature
             try
             {
-                // If you change this, change environment_variables.h too
-                var enabled = EnvironmentHelpers.GetEnvironmentVariable("SIGNALFX_THREAD_SAMPLING_ENABLED", "false");
-                if (enabled != null && (enabled.ToLower() == "1" || enabled.ToLower() == "true"))
+                if (TracerManager.Instance.Settings.ThreadSamplingEnabled)
                 {
-                    ThreadSampling.ThreadSampler.Initialize();
+                    ThreadSampling.ThreadSampler.Initialize(TracerManager.Instance.Settings.ThreadSamplingPeriod);
                 }
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -514,5 +514,22 @@ namespace Datadog.Trace.Configuration
             /// <seealso cref="TracerSettings.DelayWcfInstrumentationEnabled"/>
             public const string DelayWcfInstrumentationEnabled = "SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED";
         }
+
+        internal static class ThreadSampling
+        {
+            /// <summary>
+            /// Configuration key for enabling or disabling the thread sampling.
+            /// The default value is false (disabled)
+            /// </summary>
+            /// <seealso cref="TracerSettings.ThreadSamplingEnabled"/>
+            public const string Enabled = "SIGNALFX_THREAD_SAMPLING_ENABLED";
+
+            /// <summary>
+            /// Configuration key to set default thread sampling period.
+            /// The default value is 1000 milliseconds.
+            /// </summary>
+            /// <seealso cref="TracerSettings.ThreadSamplingPeriod"/>
+            public const string Period = "SIGNALFX_THREAD_SAMPLING_PERIOD";
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -84,6 +84,9 @@ namespace Datadog.Trace.Configuration
             Exporter = settings.Exporter;
             Propagators = settings.Propagators;
 
+            ThreadSamplingEnabled = settings.ThreadSamplingEnabled;
+            ThreadSamplingPeriod = settings.ThreadSamplingPeriod;
+
             // we cached the static instance here, because is being used in the hotpath
             // by IsIntegrationEnabled method (called from all integrations)
             _domainMetadata = DomainMetadata.Instance;
@@ -354,6 +357,16 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.Propagators"/>
         /// </summary>
         public HashSet<string> Propagators { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the thread sampling is enabled.
+        /// </summary>
+        public bool ThreadSamplingEnabled { get; }
+
+        /// <summary>
+        /// Gets a value for the thread sampling period.
+        /// </summary>
+        public TimeSpan ThreadSamplingPeriod { get; }
 
         /// <summary>
         /// Gets a value indicating whether to enable the updated WCF instrumentation that delays execution

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace
             sampler ??= GetSampler(settings);
             var propagator = CreateCompositePropagator(settings, traceIdConvention);
             agentWriter ??= GetAgentWriter(settings, statsd, sampler);
-            scopeManager ??= new AsyncLocalScopeManager();
+            scopeManager ??= new AsyncLocalScopeManager(settings.ThreadSamplingEnabled);
 
             if (settings.RuntimeMetricsEnabled)
             {


### PR DESCRIPTION
## Why

Cleanup scaffolding for Thread Sampling.
Values needed for exporter.

## What

Refactor reading env. variables for Thread Sampling

## Tests

Manual test for Console application. Still working.