### PR TITLE
remove usuned variable

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
@@ -517,7 +517,6 @@ DWORD WINAPI SamplingThreadMain(_In_ LPVOID param)
     int sleepMillis = GetSamplingPeriod();
     ThreadSampler* ts = (ThreadSampler*) param;
     ICorProfilerInfo10* info10 = ts->info10;
-    HRESULT hr;
     SamplingHelper helper;
     helper.info10 = info10;
 


### PR DESCRIPTION
## Why

Have PRs a bit cleaner

## What

Remove unused variable

## Tests

N/A

## Notes

Other warnings occurring in PRs requires investigation of C++ size type behavior.
