### PR TITLE
Minor thread sampling tweaks

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
@@ -631,7 +631,7 @@ void ThreadSampler::ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR _n
     state->threadName.append(_name, cchName);
 }
 
-NameCache::NameCache(int maximumSize) : maxSize(maximumSize)
+NameCache::NameCache(size_t maximumSize) : maxSize(maximumSize)
 {
 }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.h
@@ -89,12 +89,12 @@ private:
 class NameCache
 {
 public:
-    NameCache(int maximumSize);
+    NameCache(size_t maximumSize);
     WSTRING* get(UINT_PTR key);
     void put(UINT_PTR key, WSTRING* val);
 
 private:
-    int maxSize;
+    size_t maxSize;
     std::list<std::pair<FunctionID, WSTRING*>> list;
     std::unordered_map<FunctionID, std::list<std::pair<FunctionID, WSTRING*>>::iterator> map;
 };

--- a/tracer/src/Datadog.Trace/ThreadSampling/ThreadSampleNativeFormatParser.cs
+++ b/tracer/src/Datadog.Trace/ThreadSampling/ThreadSampleNativeFormatParser.cs
@@ -41,7 +41,6 @@ namespace Datadog.Trace.ThreadSampling
                 pos++;
                 if (op == 0x01)
                 {
-                    // start batch, nothing here
                     int version = ReadInt();
                     if (version != 1)
                     {
@@ -107,7 +106,7 @@ namespace Datadog.Trace.ThreadSampling
 
         private string ReadString()
         {
-            int len = ReadInt();
+            short len = ReadShort();
             string s = new UnicodeEncoding().GetString(buf, pos, len * 2);
             pos += 2 * len;
             return s;

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/ThreadSampler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/ThreadSampler_test.cpp
@@ -52,7 +52,7 @@ TEST(ThreadSamplerTest, BasicBufferBehavior)
     tsb.EndSample();
     tsb.EndBatch();
     tsb.WriteFinalStats(100);
-    ASSERT_EQ(1284, tsb.buffer->size()); // not manually calculated but does depend on thread name limiting and not repeating frame strings
+    ASSERT_EQ(1278, tsb.buffer->size()); // not manually calculated but does depend on thread name limiting and not repeating frame strings
     ASSERT_EQ(2, tsb.codes.size());
 }
 
@@ -85,7 +85,7 @@ TEST(ThreadSamplerTest, BufferOverrunBehavior)
         tsb.WriteFinalStats(100);
     }
     // 200k buffer plus one more thread entry before it stops adding more
-    ASSERT_EQ(buf.size(), 205814); 
+    ASSERT_EQ(buf.size(), 205432);
 }
 
 TEST(ThreadSamplerTest, StaticBufferManagement)


### PR DESCRIPTION
- document buffer format a bit
- clean up some warnings
- reduce size of length prefix for strings since they are limited to 1k anyways
- fix type issue when NameCache was reused for class names
