### PR TITLE
Refine instrumented libraries docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,9 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 ## Unreleased
 
 ### General
+
 ### Breaking changes
+
 ### Enhancements
 
 ---
@@ -65,26 +67,49 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Enhancements
 
+- Add [Aerospike.Client](https://www.nuget.org/packages/Aerospike.Client/)
+  library instrumentation.
+- Add [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/)
+  and [`System.Data.SqlClient`](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient)
+  library instrumentation.
 - Adopt [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
   in most of the instrumentations.
-- Add `SIGNALFX_HTTP_SERVER_ERROR_STATUSES` configuration that controls server http statuses to set spans as errors by.
-- Add `SIGNALFX_HTTP_CLIENT_ERROR_STATUSES` configuration that controls client http statuses to set spans as errors by.
-- Add `SIGNALFX_MAX_TRACES_PER_SECOND` configuration that limits max number of traces sent per second.
+- Add `SIGNALFX_HTTP_SERVER_ERROR_STATUSES` configuration that controls server
+  HTTP statuses to set spans as errors.
+- Add `SIGNALFX_HTTP_CLIENT_ERROR_STATUSES` configuration that controls client
+  HTTP statuses to set spans as errors.
+- Add `SIGNALFX_MAX_TRACES_PER_SECOND` configuration that limits max number
+  of traces sent per second.
 - Add `SIGNALFX_STDOUT_LOG_TEMPLATE` configuration that configures `stdout` template.
-- Add `SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` configuration that enables the updated WCF instrumentation that delays execution until later in the WCF pipeline when the WCF server exception handling is established.
-- Add `SIGNALFX_TRACE_HEADER_TAGS` configuration that sets a map of header keys to tag names.
-- Add `SIGNALFX_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED` configuration that closes consumer scope on method enter, and starts a new one on method exit.
-- Add `SIGNALFX_TRACE_LOG_DIRECTORY` configuration that sets directory for logs and overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present.
-- Add `SIGNALFX_TRACE_LOGGING_RATE` configuration that sets number of seconds between identical log messages for tracer log files.
-- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` configuration that enables partial flush of traces.
-- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` configuration that sets minimum number of closed spans in a trace before it's partially flushed.
-- Add `SIGNALFX_VERSION` configuration that sets application's version that will populate `version` tag on spans.
-- Add `SIGNALFX_TRACE_STARTUP_LOGS` configuration that enables diagnostic log at startup.
-- Add `SIGNALFX_TRACE_SAMPLE_RATE` configuration that sets the global rate for the sampler.
-- Add `SIGNALFX_TRACE_SAMPLING_RULES` configuration that is a comma separated list of sampling rules that enable custom sampling rules based on regular expressions.
-- Add `SIGNALFX_TRACE_{0}_ENABLED` configuration pattern that enables/disables specific integration.
-- Add `SIGNALFX_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS` configuration that sets URLs skipped by the tracer.
-- Add `SIGNALFX_AZURE_APP_SERVICES` configuration that indicates the profiler is running in the context of Azure App Services.
+- Add `SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` configuration that
+  enables the updated WCF instrumentation that delays execution until later in
+  the WCF pipeline when the WCF server exception handling is established.
+- Add `SIGNALFX_TRACE_HEADER_TAGS` configuration that sets a map of header keys
+  to tag names.
+- Add `SIGNALFX_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED` configuration that
+  closes consumer scope on method enter, and starts a new one on method exit.
+- Add `SIGNALFX_TRACE_LOG_DIRECTORY` configuration that sets directory for logs
+  and overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present.
+- Add `SIGNALFX_TRACE_LOGGING_RATE` configuration that sets number of seconds
+  between identical log messages for tracer log files.
+- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` configuration that enables partial
+  flush of traces.
+- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` configuration that sets minimum
+  number of closed spans in a trace before it's partially flushed.
+- Add `SIGNALFX_VERSION` configuration that sets application's version that
+  will populate `version` tag on spans.
+- Add `SIGNALFX_TRACE_STARTUP_LOGS` configuration that enables diagnostic log
+  at startup.
+- Add `SIGNALFX_TRACE_SAMPLE_RATE` configuration that sets the global rate for
+  the sampler.
+- Add `SIGNALFX_TRACE_SAMPLING_RULES` configuration that is a comma-separated
+  list of sampling rules that enable custom sampling rules based on regular expressions.
+- Add `SIGNALFX_TRACE_{0}_ENABLED` configuration pattern that enables/disables
+  specific integration.
+- Add `SIGNALFX_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS` configuration that
+  sets URLs skipped by the tracer.
+- Add `SIGNALFX_AZURE_APP_SERVICES` configuration that indicates the profiler
+  is running in the context of Azure App Services.
 - `SIGNALFX_ENDPOINT_URL` now defaults to `http://localhost:9411/api/v2/spans`.
 
 ---

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -89,7 +89,7 @@ configure the following settings:
 | `SIGNALFX_TRACE_LOG_PATH` | (Deprecated) The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_DIAGNOSTIC_SOURCE_ENABLED` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. | `true` |
 | `SIGNALFX_DISABLED_INTEGRATIONS` | Comma-separated list of disabled library instrumentations. The available integration ID values can be found [here](instrumented-libraries.md). |  |
-| `SIGNALFX_PROPAGATORS` | Comma separated list of the propagators for the tracer. Available propagators are: `Datadog`, `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3` |
+| `SIGNALFX_PROPAGATORS` | Comma-separated list of the propagators for the tracer. Available propagators are: `Datadog`, `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3` |
 | `SIGNALFX_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | The maximum length an attribute value can have. Values longer than this are truncated. Values are completely truncated when set to 0, and ignored when set to a negative value. | `12000` |

--- a/docs/instrumented-libraries.md
+++ b/docs/instrumented-libraries.md
@@ -32,6 +32,14 @@ the [OpenTelemetry Trace Semantic Conventions](https://github.com/open-telemetry
 | WebRequest | [`System.Net.WebRequest`](https://docs.microsoft.com/en-us/dotnet/api/system.net.webreques) |
 | WinHttpHandler | [`System.Net.Http.WinHttpHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.winhttphandler) |
 
+[`System.Net.Http.HttpClient`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient)
+is instrumented by instrumenting:
+
+- [`System.Net.Http.CurlHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler#httpclienthandler-in-net-core)
+- [`System.Net.Http.MessageHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpmessagehandler)
+- [`System.Net.Http.SocketsHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler)
+- [`System.Net.Http.WinHttpHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.winhttphandler)
+
 ## Partially supported
 
 The libraries below are instrumented, though the instrumentation might not
@@ -52,7 +60,10 @@ produce appropriate spans.
 
 ## Details
 
-You can find out which methods and assemblies are being instrumented by inspecting the [InstrumentationDefinitions](../tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs) file. This is useful to check, for example, the version range of the library you're instrumenting.
+You can find out which methods and assemblies are being instrumented by inspecting
+the [InstrumentationDefinitions](../tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs)
+file. This is useful to check, for example, the version range of the library
+you are instrumenting.
 
 Each line contains following information (in order):
 


### PR DESCRIPTION
- Update changelog
- Describe that `HttpClient` is instrumented.
- Fix markdownlint errors
- Change `comma separated` to `comma-separated`.