### PR TITLE
Remove settings used by upstream exporter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,8 +78,6 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
   HTTP statuses to set spans as errors.
 - Add `SIGNALFX_HTTP_CLIENT_ERROR_STATUSES` configuration that controls client
   HTTP statuses to set spans as errors.
-- Add `SIGNALFX_MAX_TRACES_PER_SECOND` configuration that limits max number
-  of traces sent per second.
 - Add `SIGNALFX_STDOUT_LOG_TEMPLATE` configuration that configures `stdout` template.
 - Add `SIGNALFX_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` configuration that
   enables the updated WCF instrumentation that delays execution until later in
@@ -92,18 +90,10 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
   and overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present.
 - Add `SIGNALFX_TRACE_LOGGING_RATE` configuration that sets number of seconds
   between identical log messages for tracer log files.
-- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` configuration that enables partial
-  flush of traces.
-- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` configuration that sets minimum
-  number of closed spans in a trace before it's partially flushed.
 - Add `SIGNALFX_VERSION` configuration that sets application's version that
   will populate `version` tag on spans.
 - Add `SIGNALFX_TRACE_STARTUP_LOGS` configuration that enables diagnostic log
   at startup.
-- Add `SIGNALFX_TRACE_SAMPLE_RATE` configuration that sets the global rate for
-  the sampler.
-- Add `SIGNALFX_TRACE_SAMPLING_RULES` configuration that is a comma-separated
-  list of sampling rules that enable custom sampling rules based on regular expressions.
 - Add `SIGNALFX_TRACE_{0}_ENABLED` configuration pattern that enables/disables
   specific integration.
 - Add `SIGNALFX_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS` configuration that

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,10 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
   and overrides the value in `SIGNALFX_TRACE_LOG_PATH` if present.
 - Add `SIGNALFX_TRACE_LOGGING_RATE` configuration that sets number of seconds
   between identical log messages for tracer log files.
+- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` configuration that enables partial
+  flush of traces.
+- Add `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` configuration that sets minimum
+  number of closed spans in a trace before it's partially flushed.
 - Add `SIGNALFX_VERSION` configuration that sets application's version that
   will populate `version` tag on spans.
 - Add `SIGNALFX_TRACE_STARTUP_LOGS` configuration that enables diagnostic log

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -75,9 +75,6 @@ Use following settings to configure where the telemetry data is being exported.
 |-|-|-|
 | `SIGNALFX_ACCESS_TOKEN` | Your Splunk Observabilty Cloud access token for your organization. It enables sending traces directly to the Splunk Observabilty Cloud ingest endpoint. |  |
 | `SIGNALFX_ENDPOINT_URL` | The URL to where trace exporters send traces. | `http://localhost:9411/api/v2/spans` |
-| `SIGNALFX_MAX_TRACES_PER_SECOND` | The number of traces allowed to be submitted per second. | `100` |
-| `SIGNALFX_TRACE_SAMPLE_RATE` | The global rate for the sampler. By default, all traces are sampled. |  |
-| `SIGNALFX_TRACE_SAMPLING_RULES` | Comma-separated list of sampling rules that enable custom sampling rules based on regular expressions. Rule are matched by order of specification. Only the first match is used. The item "sample_rate" must be in decimal format. Both `service` and `name` accept regular expressions. | `'[{"sample_rate":0.5, "service":"cart.*"}],[{"sample_rate":0.2, "name":"http.request"}]'` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to activate sending partial traces to the agent. | `false` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` | The minimum number of closed spans in a trace before it's partially flushed. `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` has to be enabled for this to take effect. | `500` |
 

--- a/docs/internal-config.md
+++ b/docs/internal-config.md
@@ -23,8 +23,8 @@ These settings should be never used by the users.
 | `SIGNALFX_APPSEC_BLOCKING_ENABLED` | Enables the AppSec blocking. | `false` |
 | `SIGNALFX_APPSEC_ENABLED` | Enables the AppSec. | `false` |
 | `SIGNALFX_APPSEC_EXTRA_HEADERS` | Optional custom headers the user wants to send. |  |
-| `SIGNALFX_APPSEC_KEEP_TRACES` | Specifies if the AppSec traces should be explicitly kept or droped. | `true` |
 | `SIGNALFX_APPSEC_IPHEADER` | Optional name of the custom header to take into account for the ip address. |  |
+| `SIGNALFX_APPSEC_KEEP_TRACES` | Specifies if the AppSec traces should be explicitly kept or droped. | `true` |
 | `SIGNALFX_APPSEC_RULES` | Overrides the default rules file provided. Must be a path to a valid JSON rules file. |  |
 | `SIGNALFX_CIVISIBILITY_ENABLED` | Enable to activate CI Visibility. | `false` |
 | `SIGNALFX_DOGSTATSD_ARGS` | Comma-separated list of arguments to be passed to the DogStatsD process. |  |
@@ -32,6 +32,7 @@ These settings should be never used by the users.
 | `SIGNALFX_DOGSTATSD_PIPE_NAME` | The named pipe that DogStatsD binds to. |  |
 | `SIGNALFX_DOGSTATSD_PORT` | The port of the targeted StatsD server. | `8125` |
 | `SIGNALFX_INTERNAL_TRACE_VERSION_COMPATIBILITY` | Enables the compatibility with other versions of tracer. | `false` |
+| `SIGNALFX_MAX_TRACES_PER_SECOND` | The number of traces allowed to be submitted per second. | `100` |
 | `SIGNALFX_TRACE_{0}_ANALYTICS_ENABLED` | Enable to activate analytics for specific integration. | `false` |
 | `SIGNALFX_TRACE_{0}_ANALYTICS_SAMPLE_RATE` | Set sample rate for analytics in specific integration. |  |
 | `SIGNALFX_TRACE_AGENT_ARGS` | Comma-separated list of arguments to be passed to the Trace Agent process. |  |
@@ -44,8 +45,12 @@ These settings should be never used by the users.
 | `SIGNALFX_TRACE_BUFFER_SIZE` | The size in bytes of the trace buffer. | `1024 * 1024 * 10 (10MB)` |
 | `SIGNALFX_TRACE_LOG_PATH` | (Deprecated) The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_TRACE_METRICS_ENABLED` | Enable to activate internal metrics sent to DogStatsD. | `false` |
+| `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to activate sending partial traces to the agent. | `false` |
+| `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` | The minimum number of closed spans in a trace before it's partially flushed. `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` has to be enabled for this to take effect. | `500` |
 | `SIGNALFX_TRACE_PIPE_NAME` | The named pipe where the tracer can send traces. |  |
 | `SIGNALFX_TRACE_PIPE_TIMEOUT_MS` | The timeout in milliseconds for named pipes communication. | `100` |
+| `SIGNALFX_TRACE_SAMPLE_RATE` | The global rate for the sampler. By default, all traces are sampled. |  |
+| `SIGNALFX_TRACE_SAMPLING_RULES` | Comma-separated list of sampling rules that enable custom sampling rules based on regular expressions. Rule are matched by order of specification. Only the first match is used. The item "sample_rate" must be in decimal format. Both `service` and `name` accept regular expressions. | `'[{"sample_rate":0.5, "service":"cart.*"}],[{"sample_rate":0.2, "name":"http.request"}]'` |
 | `SIGNALFX_TRACE_SERVICE_MAPPING` | Comma-separated map of services to rename. | `"key1:val1,key2:val2"` |
 | `SIGNALFX_TRACE_TRANSPORT` | Overrides the transport to use for communicating with the trace agent. Available values are: `datagod-tcp`, `datadog-named-pipes`. |  |
 

--- a/docs/internal-config.md
+++ b/docs/internal-config.md
@@ -45,8 +45,6 @@ These settings should be never used by the users.
 | `SIGNALFX_TRACE_BUFFER_SIZE` | The size in bytes of the trace buffer. | `1024 * 1024 * 10 (10MB)` |
 | `SIGNALFX_TRACE_LOG_PATH` | (Deprecated) The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_TRACE_METRICS_ENABLED` | Enable to activate internal metrics sent to DogStatsD. | `false` |
-| `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to activate sending partial traces to the agent. | `false` |
-| `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` | The minimum number of closed spans in a trace before it's partially flushed. `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` has to be enabled for this to take effect. | `500` |
 | `SIGNALFX_TRACE_PIPE_NAME` | The named pipe where the tracer can send traces. |  |
 | `SIGNALFX_TRACE_PIPE_TIMEOUT_MS` | The timeout in milliseconds for named pipes communication. | `100` |
 | `SIGNALFX_TRACE_SAMPLE_RATE` | The global rate for the sampler. By default, all traces are sampled. |  |


### PR DESCRIPTION
## Why

These settings are not used https://github.com/signalfx/signalfx-dotnet-tracing/blob/next-ver/tracer/src/Datadog.Trace/TracerManagerFactory.cs#L148-L156

## What

Remove settings that are not used by Zipkin exporter

## Tests

None for these changes.

I also want to test if our tracer will work with the following settings:
- `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED=true`
- `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS=1`

These env vars are only used in `TraceContext.cs`. I think it should work but I prefer testing before we have it documented.