### PR TITLE
Publish NuGet packages in GH workflows

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -49,7 +49,13 @@ jobs:
     steps:
       - run: git config --system core.longpaths true
       - uses: actions/checkout@v2
-      - uses: microsoft/setup-msbuild@v1.0.2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: | 
+            2.1.x
+            3.1.x
+            5.0.x
+            6.0.x
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Publish Windows MSI

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -37,7 +37,8 @@ jobs:
           --env artifacts=/project/tracer/src/bin/artifacts \
           dd-trace-dotnet/${baseImage}-builder \
           dotnet /build/bin/Debug/_build.dll Clean BuildTracerHome ZipTracerHome
-    - uses: actions/upload-artifact@v2
+    - name: Publish Linux x64 packages
+      uses: actions/upload-artifact@v2
       with:
         name: artifacts
         path: ./tracer/src/bin/artifacts/linux-x64
@@ -51,10 +52,17 @@ jobs:
       - uses: microsoft/setup-msbuild@v1.0.2
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
-      - uses: actions/upload-artifact@v2
+      - name: Publish Windows MSI
+        uses: actions/upload-artifact@v2
         with:
           name: artifacts
           path: tracer/bin/artifacts/*/en-us
+      - name: Publish NuGet packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: nuget-packages
+          path: ${{ env.artifacts }}/nuget
+          
 
   create_release:
     runs-on: ubuntu-20.04

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Publish NuGet packages
         uses: actions/upload-artifact@v2
         with:
-          name: nuget-packages
-          path: ${{ env.artifacts }}/nuget
+          name: nuget
+          path: tracer/bin/artifacts/nuget
           
 
   create_release:
@@ -86,7 +86,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v}
       # TODO: Extract release notes
       - name: Create Release
-        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft --prerelease artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi artifacts/nuget/*
+        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft --prerelease artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi nuget/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -80,7 +80,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v}
       # TODO: Extract release notes
       - name: Create Release
-        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft --prerelease artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi
+        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft --prerelease artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi artifacts/nuget/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
       with:
         path: ${{ env.artifacts }}/linux-x64
         name: linux-x64-packages
+    - name: Publish NuGet packages
+      if: ${{ runner.os == 'Windows' }}
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ env.artifacts }}/nuget
+        name: nuget-packages
 
   managed-unit-tests:
     name: Managed unit tests


### PR DESCRIPTION
## Why

We need to publish https://www.nuget.org/packages/SignalFx.NET.Tracing.Azure.Site.Extension/ during `v0.2.0` release.

## What

Publish NuGet packages in GH workflows as artifacts. Then once can manually use the build artifacts during a release.

## Tests

- Release workflow
  - https://github.com/pellared/signalfx-dotnet-tracing/actions/runs/1655728798
  - https://github.com/pellared/signalfx-dotnet-tracing/releases/tag/v0.22.2
  - https://github.com/pellared/signalfx-dotnet-tracing/releases/tag/untagged-fd23269be9d148a68236

something looks wrong with the `REALSING.md` - I will address it tomorrow as a separate PR. see: https://github.com/pellared/signalfx-dotnet-tracing/releases

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/5067549/148133791-063495d2-0762-442d-9775-517ecdfd59a5.png">



- CI workflow
  - https://github.com/signalfx/signalfx-dotnet-tracing/actions/runs/1655660444
  - nuget artifacts content: 
<img width="314" alt="image" src="https://user-images.githubusercontent.com/5067549/148131104-e1f0499b-d835-4e09-8fa6-babb470e3475.png">
