### PR TITLE
Add info about the default service name

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -45,7 +45,7 @@ The following settings are common to most instrumentation scenarios:
 | Setting | Description | Default |
 |-|-|-|
 | `SIGNALFX_ENV` | The value for the `deployment.environment` tag added to every span. |  |
-| `SIGNALFX_SERVICE_NAME` | The name of the application or service. |  |
+| `SIGNALFX_SERVICE_NAME` | Optional setting, overrides the [default service name](default-service-name.md) used by the instrumentation. |  |
 | `SIGNALFX_VERSION` | The version of the application. When set, it populates the `version` tag on spans. |  |
 
 ## Global management settings

--- a/docs/default-service-name.md
+++ b/docs/default-service-name.md
@@ -10,7 +10,7 @@ the default service name is the __site name__ as defined by the
 [WEBSITE_SITE_NAME](https://docs.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet) 
 environment variable.
 
-2. For an ASP.NET hosted application, eg.: IIS .NET Framework apps, the default service name is `SiteName[/VirtualPath]`.
+2. For an ASP.NET hosted application, for example IIS .NET Framework apps, the default service name is `SiteName[/VirtualPath]`.
 
 3. For other applications the name of the [entry assembly](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=net-6.0)
 is used as the default service name. Typically this is the name of your .NET project file.

--- a/docs/default-service-name.md
+++ b/docs/default-service-name.md
@@ -15,7 +15,7 @@ environment variable.
 3. For other applications the name of the [entry assembly](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=net-6.0)
 is used as the default service name. Typically this is the name of your .NET project file.
 
-4. In the unlikely case that the [entry assembly is not available](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=net-6.0#remarks).
+4. If the [entry assembly is not available](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=net-6.0#remarks).
 The instrumentation tries to use the current process name.
 The process name can be `dotnet` if it is launched directly using an assembly, eg.: `dotnet InstrumentedApp.dll`.
 

--- a/docs/default-service-name.md
+++ b/docs/default-service-name.md
@@ -1,0 +1,22 @@
+# Default Service Name
+
+If the default service name doesn't fit well with your usage or naming conventions configure
+the [`SIGNALFX_SERVICE_NAME`](advanced-config.md) setting.
+The default service name is captured via the steps below,
+stopping at the first one that succeeds:
+
+1. For the [SignalFx .NET Tracing Azure Site Extension](../shared/src/azure-site-extension/README.md)
+the default service name is the __site name__ as defined by the
+[WEBSITE_SITE_NAME](https://docs.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet) 
+environment variable.
+
+2. For an ASP.NET hosted application, eg.: IIS .NET Framework apps, the default service name is `SiteName[/VirtualPath]`.
+
+3. For other applications the name of the [entry assembly](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=net-6.0)
+is used as the default service name. Typically this is the name of your .NET project file.
+
+4. In the unlikely case that the [entry assembly is not available](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=net-6.0#remarks).
+The instrumentation tries to use the current process name.
+The process name can be `dotnet` if it is launched directly using an assembly, eg.: `dotnet InstrumentedApp.dll`.
+
+5. If all steps above fail the default service name used is `UnknownService`.

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -4,7 +4,7 @@ By default, the installer enables IIS instrumentation for .NET Framework
 by setting the `Environment` registry key for W3SVC and WAS services
 located in the `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services` folder.
 
-For ASP.NET applications (ie.: those IIS applications running on the .NET Framework) the
+For ASP.NET applications, for example IIS applications running on the .NET Framework, the
 default service name is `ServiceName[\VirtualPath]`.
 For ASP.NET Core applications the default service name is the entry assembly name, typically
 the name of your .NET Core project.

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -8,7 +8,7 @@ For ASP.NET applications, for example IIS applications running on the .NET Frame
 default service name is `ServiceName[\VirtualPath]`.
 For ASP.NET Core applications the default service name is the entry assembly name, typically
 the name of your .NET Core project.
-If the defaults above don't fit well with your usage or naming conventions configure `SIGNALFX_SERVICE_NAME` as described in [advanced-config.md](advanced-config.md#configuration-methods).
+If the defaults don't fit well with your usage or naming conventions configure `SIGNALFX_SERVICE_NAME` as described in [advanced-config.md](advanced-config.md#configuration-methods).
 
 Consider using `web.config` as the configuration method
 to avoid potential configuration conflicts between other applications.

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -5,7 +5,7 @@ by setting the `Environment` registry key for W3SVC and WAS services
 located in the `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services` folder.
 
 For ASP.NET applications, for example IIS applications running on the .NET Framework, the
-default service name is `ServiceName[\VirtualPath]`.
+default service name is `ServiceName[/VirtualPath]`.
 For ASP.NET Core applications the default service name is the entry assembly name, typically
 the name of your .NET Core project.
 If the defaults don't fit well with your usage or naming conventions configure `SIGNALFX_SERVICE_NAME` as described in [advanced-config.md](advanced-config.md#configuration-methods).

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -4,7 +4,11 @@ By default, the installer enables IIS instrumentation for .NET Framework
 by setting the `Environment` registry key for W3SVC and WAS services
 located in the `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services` folder.
 
-Configure `SIGNALFX_SERVICE_NAME` as described in [advanced-config.md](advanced-config.md#configuration-methods).
+For ASP.NET applications (ie.: those IIS applications running on the .NET Framework) the
+default service name is `ServiceName[\VirtualPath]`.
+For ASP.NET Core applications the default service name is the entry assembly name, typically
+the name of your .NET Core project.
+If the defaults above don't fit well with your usage or naming conventions configure `SIGNALFX_SERVICE_NAME` as described in [advanced-config.md](advanced-config.md#configuration-methods).
 
 Consider using `web.config` as the configuration method
 to avoid potential configuration conflicts between other applications.


### PR DESCRIPTION
## Why

Especially for IIS configuring the `SIGNALFX_SERVICE_NAME` can be cumbersome to configure. We want to avoid this configuration if possible.

## What

Documenting the default service name and making the case that the user just needs to set it if the default doesn't work for their scenario.

## Tests

N/A (docs only)