### PR TITLE
Adjust configuration keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,7 +34,6 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 - There is no support for .NET older than .NET 4.6.2.
 - Rename `SIGNALFX_DOTNET_TRACER_CONFIG_FILE` configuration to `SIGNALFX_TRACE_CONFIG_FILE`.
 - Rename `SIGNALFX_PROPAGATOR` configuration to `SIGNALFX_PROPAGATORS`.
-- Rename `SIGNALFX_TRACE_GLOBAL_TAGS` configuration to `SIGNALFX_TAGS`.
 - Rename `SIGNALFX_TRACING_ENABLED` configuration to `SIGNALFX_TRACE_ENABLED`
 - Rename `SIGNALFX_ASPNET_TEMPLATE_NAMES_ENABLED` configuration to `SIGNALFX_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`.
 - Remove `SIGNALFX_ADD_CLIENT_IP_TO_SERVER_SPANS` configuration.

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -64,7 +64,7 @@ The following settings are common to most instrumentation scenarios:
 |-|-|-|
 | `SIGNALFX_DISABLED_INTEGRATIONS` | Comma-separated list of disabled library instrumentations. The available integration ID values can be found [here](instrumented-libraries.md). |  |
 | `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | The maximum length an attribute value can have. Values longer than this are truncated. Values are discarded entirely when set to 0, and ignored when set to a negative value. | `12000` |
-| `SIGNALFX_TAGS` | Comma-separated list of key-value pairs that specify global span tags. For example: `"key1:val1,key2:val2"` |  |
+| `SIGNALFX_TRACE_GLOBAL_TAGS` | Comma-separated list of key-value pairs that specify global span tags. For example: `"key1:val1,key2:val2"` |  |
 | `SIGNALFX_TRACE_{0}_ENABLED` | Configuration pattern for enabling or disabling a specific [library instrumentation](instrumented-libraries.md). For example, in order to disable Kafka instrumentation, set `SIGNALFX_TRACE_Kafka_ENABLED=false` | `true` |
 
 ## Exporter settings

--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -39,7 +39,6 @@ These settings should be never used by the users.
 | `SIGNALFX_TRACE_AGENT_HOSTNAME` | The Agent host where the tracer can send traces | `localhost` |
 | `SIGNALFX_TRACE_AGENT_PATH` | The Trace Agent path for when a standalone instance needs to be started. |  |
 | `SIGNALFX_TRACE_AGENT_PORT` | The Agent port where the tracer can send traces | `9411` |
-| `SIGNALFX_TRACE_AGENT_URL` | Alias for `SIGNALFX_ENDPOINT_URL`. The URL to where trace exporters send traces. | `http://localhost:9411/api/v2/spans` |
 | `SIGNALFX_TRACE_ANALYTICS_ENABLED` | Enable to activate default Analytics. | `false` |
 | `SIGNALFX_TRACE_BATCH_INTERVAL` | The batch interval in milliseconds for the serialization queue. | `100` |
 | `SIGNALFX_TRACE_BUFFER_SIZE` | The size in bytes of the trace buffer. | `1024 * 1024 * 10 (10MB)` |

--- a/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.OpenTracing
         /// <summary>
         /// Create a new Datadog compatible ITracer implementation with the given parameters
         /// </summary>
-        /// <param name="agentEndpoint">The agent endpoint where the traces will be sent (default is http://localhost:8126).</param>
+        /// <param name="agentEndpoint">The agent endpoint where the traces will be sent (default is http://localhost:9411/api/v2/spans).</param>
         /// <param name="defaultServiceName">Default name of the service (default is the name of the executing assembly).</param>
         /// <param name="isDebugEnabled">Turns on all debug logging (this may have an impact on application performance).</param>
         /// <returns>A Datadog compatible ITracer implementation</returns>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -131,7 +131,7 @@ namespace Datadog.Trace.Tools.Runner
 
             if (!string.IsNullOrWhiteSpace(options.AgentUrl))
             {
-                envVars["SIGNALFX_TRACE_AGENT_URL"] = options.AgentUrl;
+                envVars["SIGNALFX_ENDPOINT_URL"] = options.AgentUrl;
             }
 
             if (!string.IsNullOrWhiteSpace(options.EnvironmentValues))
@@ -303,7 +303,7 @@ namespace Datadog.Trace.Tools.Runner
             var env = new NameValueCollection();
             if (!string.IsNullOrWhiteSpace(agentUrl))
             {
-                env["SIGNALFX_TRACE_AGENT_URL"] = agentUrl;
+                env["SIGNALFX_ENDPOINT_URL"] = agentUrl;
             }
 
             var globalSettings = GlobalSettings.CreateDefaultConfigurationSource();

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -14,7 +14,6 @@ namespace Datadog.Trace.Configuration
     {
         /// <summary>
         /// Configuration key for the Agent host where the Tracer can send traces.
-        /// Overridden by <see cref="AgentUri"/> if present.
         /// Default value is "localhost".
         /// </summary>
         /// <seealso cref="ExporterSettings.AgentUri"/>
@@ -63,18 +62,9 @@ namespace Datadog.Trace.Configuration
         public const string MetricsEndpointUrl = "SIGNALFX_METRICS_ENDPOINT_URL";
 
         /// <summary>
-        /// Configuration key for the Agent URL where the Tracer can send traces.
-        /// Overrides values in <see cref="AgentHost"/> and <see cref="AgentPort"/> if present.
-        /// Default value is "http://localhost:8126".
-        /// </summary>
-        /// <seealso cref="ExporterSettings.AgentUri"/>
-        public const string AgentUri = "SIGNALFX_TRACE_AGENT_URL";
-
-        /// <summary>
         /// Configuration key for the trace endpoint. Same as <see creg="AgentUri"/> created
         /// for compatibility of previous version of SignalFx .NET Tracing.
         /// </summary>
-        /// <seealso cref="AgentUri"/>
         public const string EndpointUrl = "SIGNALFX_ENDPOINT_URL";
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Configuration
         /// Configuration key for a list of tags to be applied globally to spans.
         /// </summary>
         /// <seealso cref="TracerSettings.GlobalTags"/>
-        public const string GlobalTags = "SIGNALFX_TAGS";
+        public const string GlobalTags = "SIGNALFX_TRACE_GLOBAL_TAGS";
 
         /// <summary>
         /// Configuration key for a map of header keys to tag names.

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets or sets the Uri where the Tracer can connect to the Agent.
-        /// Default is <c>"http://localhost:8126"</c>.
+        /// Default is <c>"http://localhost:9411/api/v2/spans"</c>.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.AgentHost"/>
         /// <seealso cref="ConfigurationKeys.AgentPort"/>

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -67,7 +67,6 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets the Uri where the Tracer can connect to the Agent.
         /// Default is <c>"http://localhost:8126"</c>.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.AgentUri"/>
         /// <seealso cref="ConfigurationKeys.AgentHost"/>
         /// <seealso cref="ConfigurationKeys.AgentPort"/>
         public Uri AgentUri { get; set; }
@@ -185,8 +184,7 @@ namespace Datadog.Trace.Configuration
                             // default value
                             DefaultAgentPort;
 
-            var agentUri = source?.GetString(ConfigurationKeys.AgentUri) ??
-                           source?.GetString(ConfigurationKeys.EndpointUrl) ??
+            var agentUri = source?.GetString(ConfigurationKeys.EndpointUrl) ??
                            // default value
                            $"http://{agentHost}:{agentPort}/api/v2/spans";
 

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -149,8 +149,7 @@ namespace Datadog.Trace.Configuration
         private static bool TryLoadJsonConfigurationFile(IConfigurationSource configurationSource, out JsonConfigurationSource jsonConfigurationSource)
         {
             // if environment variable is not set, look for default file name in the current directory
-            var configurationFileName = configurationSource.GetString(ConfigurationKeys.ConfigurationFileName) ??
-                                        configurationSource.GetString("SIGNALFX_DOTNET_TRACER_CONFIG_FILE");
+            var configurationFileName = configurationSource.GetString(ConfigurationKeys.ConfigurationFileName);
 
             return TryLoadJsonConfigurationFile(configurationFileName, out jsonConfigurationSource);
         }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets the Uri where the Tracer can connect to the Agent.
-        /// Default is <c>"http://localhost:8126"</c>.
+        /// Default is <c>"http://localhost:9411/api/v2/spans"</c>.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.AgentHost"/>
         /// <seealso cref="ConfigurationKeys.AgentPort"/>

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -50,7 +50,6 @@ namespace Datadog.Trace.Configuration
         /// Gets the Uri where the Tracer can connect to the Agent.
         /// Default is <c>"http://localhost:8126"</c>.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.AgentUri"/>
         /// <seealso cref="ConfigurationKeys.AgentHost"/>
         /// <seealso cref="ConfigurationKeys.AgentPort"/>
         public Uri AgentUri { get; }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -80,8 +80,6 @@ namespace Datadog.Trace.Configuration
                                           100;
 
             GlobalTags = source?.GetDictionary(ConfigurationKeys.GlobalTags) ??
-                         // backwards compatibility for names used in the past
-                         source?.GetDictionary("SIGNALFX_TRACE_GLOBAL_TAGS") ??
                          // default value (empty)
                          new ConcurrentDictionary<string, string>();
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -170,7 +170,7 @@ namespace Datadog.Trace.TestHelpers
                 "SIGNALFX_DISABLED_INTEGRATIONS",
                 "SIGNALFX_SERVICE_NAME",
                 "SIGNALFX_VERSION",
-                "SIGNALFX_TAGS",
+                "SIGNALFX_TRACE_GLOBAL_TAGS",
                 "SIGNALFX_APPSEC_ENABLED",
                 "SIGNALFX_INSTRUMENTATION_MONGODB_TAG_COMMANDS",
                 "SIGNALFX_INSTRUMENTATION_ELASTICSEARCH_TAG_QUERIES",

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -209,14 +209,14 @@ namespace Datadog.Trace.Tests.Configuration
             }
             else if (key == ConfigurationKeys.AgentHost || key == ConfigurationKeys.AgentPort)
             {
-                // We need to ensure SIGNALFX_TRACE_AGENT_URL is empty.
-                string originalAgentUri = Environment.GetEnvironmentVariable(ConfigurationKeys.AgentUri);
-                Environment.SetEnvironmentVariable(ConfigurationKeys.AgentUri, null, EnvironmentVariableTarget.Process);
+                // We need to ensure SIGNALFX_ENDPOINT_URL is empty.
+                string originalAgentUri = Environment.GetEnvironmentVariable(ConfigurationKeys.EndpointUrl);
+                Environment.SetEnvironmentVariable(ConfigurationKeys.EndpointUrl, null, EnvironmentVariableTarget.Process);
 
                 settings = GetTracerSettings(key, value);
 
-                // after load settings we can restore the original SIGNALFX_TRACE_AGENT_URL
-                Environment.SetEnvironmentVariable(ConfigurationKeys.AgentUri, originalAgentUri, EnvironmentVariableTarget.Process);
+                // after load settings we can restore the original SIGNALFX_ENDPOINT_URL
+                Environment.SetEnvironmentVariable(ConfigurationKeys.EndpointUrl, originalAgentUri, EnvironmentVariableTarget.Process);
             }
             else
             {

--- a/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.Tests
         {
             var settings = new NameValueCollection
             {
-                { ConfigurationKeys.AgentUri, original }
+                { ConfigurationKeys.EndpointUrl, original }
             };
 
             var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings));

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/LegacyCommandLineArgumentsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/LegacyCommandLineArgumentsTests.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             environmentVariables["SIGNALFX_SERVICE_NAME"].Should().Be("TestService");
             environmentVariables["SIGNALFX_VERSION"].Should().Be("TestVersion");
             environmentVariables["SIGNALFX_DOTNET_TRACER_HOME"].Should().Be("TestTracerHome");
-            environmentVariables["SIGNALFX_TRACE_AGENT_URL"].Should().Be(agentUrl);
+            environmentVariables["SIGNALFX_ENDPOINT_URL"].Should().Be(agentUrl);
             environmentVariables["SIGNALFX_CIVISIBILITY_ENABLED"].Should().Be("1");
             environmentVariables["VAR1"].Should().Be("A");
             environmentVariables["VAR2"].Should().Be("B");
@@ -109,7 +109,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
                 environmentVariables["SIGNALFX_SERVICE_NAME"].Should().Be("TestService");
                 environmentVariables["SIGNALFX_VERSION"].Should().Be("TestVersion");
                 environmentVariables["SIGNALFX_DOTNET_TRACER_HOME"].Should().Be("TestTracerHome");
-                environmentVariables["SIGNALFX_TRACE_AGENT_URL"].Should().Be("TestAgentUrl");
+                environmentVariables["SIGNALFX_ENDPOINT_URL"].Should().Be("TestAgentUrl");
                 environmentVariables["VAR1"].Should().Be("A");
                 environmentVariables["VAR2"].Should().Be("B");
             }

--- a/tracer/test/test-applications/regression/LargePayload/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/LargePayload/Properties/launchSettings.json
@@ -8,7 +8,7 @@
         // These variables are to override environmental settings to be sure that the payload is always approximately the same size
         "SIGNALFX_ENV": "payload-test",
         "SIGNALFX_SERVICE_NAME": "LargePayload",
-        "SIGNALFX_TAGS": "",
+        "SIGNALFX_TRACE_GLOBAL_TAGS": "",
         "SIGNALFX_HOST": "PayloadHost" 
       },
       "nativeDebugging": false


### PR DESCRIPTION
## Why

Adjust configuration keys used by the tracer.

## What

- Remove `SIGNALFX_TAGS`, `SIGNALFX_DOTNET_TRACER_CONFIG_FILE` and `SIGNALFX_TRACE_AGENT_URL` aliases

## Tests

Local tests.
Smoke test with backend: https://app.signalfx.com/#/apm/traces/620428ba4c7a27c41e012e2d875fd929 
