### PR TITLE
Fix graphql service name mapping

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommon.cs
@@ -25,6 +25,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
         internal const string IntegrationName = nameof(Configuration.IntegrationId.GraphQL);
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.GraphQL;
 
+        private const string ServiceName = "graphql";
         private const string ParseOperationName = "graphql.parse"; // Instrumentation not yet implemented
         private const string ValidateOperationName = "graphql.validate";
         private const string ExecuteOperationName = "graphql.execute";
@@ -45,7 +46,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
             try
             {
                 var tags = new GraphQLTags();
-                scope = tracer.StartActiveInternal(ValidateOperationName, tags: tags);
+                var serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
+                scope = tracer.StartActiveInternal(ValidateOperationName, serviceName: serviceName, tags: tags);
 
                 var span = scope.Span;
                 span.LogicScope = ValidateOperationName;
@@ -82,7 +84,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
                     : $"{operationType} {operationName}";
 
                 var tags = new GraphQLTags();
-                scope = tracer.StartActiveInternal(operation, tags: tags);
+                var serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
+                scope = tracer.StartActiveInternal(operation, serviceName: serviceName, tags: tags);
 
                 var span = scope.Span;
                 span.Type = SpanTypes.GraphQL;

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -42,9 +42,7 @@ namespace Datadog.Trace.Configuration
         {
             Environment = source?.GetString(ConfigurationKeys.Environment);
 
-            ServiceName = source?.GetString(ConfigurationKeys.ServiceName) ??
-                          // backwards compatibility for names used in the past
-                          source?.GetString("SIGNALFX_SERVICE_NAME");
+            ServiceName = source?.GetString(ConfigurationKeys.ServiceName);
 
             ServiceVersion = source?.GetString(ConfigurationKeys.ServiceVersion);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if NETFRAMEWORK
 
 using System;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if !NETCOREAPP2_1
 using Datadog.Trace.TestHelpers;
 using Xunit;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if NETFRAMEWORK
 using Datadog.Trace.TestHelpers;
 using Xunit;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if NETFRAMEWORK
 using Datadog.Trace.TestHelpers;
 using Xunit;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if !NETCOREAPP2_1
 using Datadog.Trace.TestHelpers;
 using Xunit;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if NETFRAMEWORK
 using Datadog.Trace.TestHelpers;
 using Xunit;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if !NETCOREAPP2_1
 using Datadog.Trace.TestHelpers;
 using Xunit;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System.Linq;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Linq;
 using Datadog.Trace.TestHelpers;

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/GraphQL/GraphQLCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/GraphQL/GraphQLCommonTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using Datadog.Trace.Agent;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DogStatsd;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.GraphQL
+{
+    public class GraphQLCommonTests
+    {
+        [Fact]
+        public void Mapped_service_name_should_be_used_if_provided_for_validate()
+        {
+            var settings = DefaultSettings();
+
+            settings.SetServiceNameMappings(new[] { new KeyValuePair<string, string>("graphql", "my-custom-name") });
+
+            var span = CreateSpanFromValidate(settings);
+
+            span.ServiceName.Should().Be("my-custom-name", "service name mappings should be reflected in service name");
+            span.Tags.GetTag(Tags.Version).Should().BeNull("service version should not be set for spans with mapped service name");
+        }
+
+        [Fact]
+        public void Default_service_name_and_version_should_be_used_if_no_mapping_is_configured_for_validate()
+        {
+            var settings = DefaultSettings();
+
+            var span = CreateSpanFromValidate(settings);
+
+            span.ServiceName.Should().Be("TestService", "default service name should be used");
+            span.Tags.GetTag(Tags.Version).Should().Be("1.2.3", "service version should be set for spans with default service name");
+        }
+
+        [Fact]
+        public void Mapped_service_name_should_be_used_if_provided_for_execute()
+        {
+            var settings = DefaultSettings();
+
+            settings.SetServiceNameMappings(new[] { new KeyValuePair<string, string>("graphql", "my-custom-name") });
+
+            var span = CreateSpanFromExecute(settings);
+
+            span.ServiceName.Should().Be("my-custom-name", "service name mappings should be reflected in service name");
+            span.Tags.GetTag(Tags.Version).Should().BeNull("service version should not be set for spans with mapped service name");
+        }
+
+        [Fact]
+        public void Default_service_name_and_version_should_be_used_if_no_mapping_is_configured_for_execute()
+        {
+            var settings = DefaultSettings();
+
+            var span = CreateSpanFromExecute(settings);
+
+            span.ServiceName.Should().Be("TestService", "default service name should be used");
+            span.Tags.GetTag(Tags.Version).Should().Be("1.2.3", "service version should be set for spans with default service name");
+        }
+
+        private static Span CreateSpanFromExecute(TracerSettings settings)
+        {
+            var tracer = new Tracer(settings, new Mock<IAgentWriter>().Object, null, null, new NoOpStatsd());
+
+            var document = Mock.Of<IDocument>(doc => doc.OriginalQuery == "query");
+            var executionContext =
+                Mock.Of<IExecutionContext>(
+                    ec =>
+                        ec.Document == document &&
+                        ec.Operation == Mock.Of<IOperation>(op => op.Name == "query" && op.OperationType == OperationTypeProxy.Query));
+            var scope = GraphQLCommon.CreateScopeFromExecuteAsync(tracer, executionContext);
+
+            var span = scope.Span;
+            return span;
+        }
+
+        private static Span CreateSpanFromValidate(TracerSettings settings)
+        {
+            var tracer = new Tracer(settings, new Mock<IAgentWriter>().Object, null, null, new NoOpStatsd());
+
+            var scope = GraphQLCommon.CreateScopeFromValidate(tracer, Mock.Of<IDocument>(doc => doc.OriginalQuery == "query"));
+
+            var span = scope.Span;
+            return span;
+        }
+
+        private static TracerSettings DefaultSettings()
+        {
+            return new TracerSettings { ServiceName = "TestService", ServiceVersion = "1.2.3" };
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/CustomTestFramework.cs
@@ -1,0 +1,135 @@
+// <copyright file="CustomTestFramework.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// Modified by Splunk Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Datadog.Trace.ClrProfiler.Managed.Tests.CustomTestFramework", "Datadog.Trace.ClrProfiler.Managed.Tests")]
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class CustomTestFramework : XunitTestFramework
+    {
+        public CustomTestFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+        }
+
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        {
+            return new CustomExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+        }
+
+        private class CustomExecutor : XunitTestFrameworkExecutor
+        {
+            public CustomExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink)
+                : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
+            {
+            }
+
+            protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+            {
+                using (var assemblyRunner = new CustomAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+                {
+                    await assemblyRunner.RunAsync();
+                }
+            }
+        }
+
+        private class CustomAssemblyRunner : XunitTestAssemblyRunner
+        {
+            public CustomAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+                : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+            {
+            }
+
+            protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
+            {
+                return new CustomTestCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), cancellationTokenSource).RunAsync();
+            }
+        }
+
+        private class CustomTestCollectionRunner : XunitTestCollectionRunner
+        {
+            private readonly IMessageSink _diagnosticMessageSink;
+
+            public CustomTestCollectionRunner(ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+                : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+            {
+                _diagnosticMessageSink = diagnosticMessageSink;
+            }
+
+            protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+            {
+                return new CustomTestClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, CollectionFixtureMappings)
+                   .RunAsync();
+            }
+        }
+
+        private class CustomTestClassRunner : XunitTestClassRunner
+        {
+            public CustomTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings)
+                : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+            {
+            }
+
+            protected override Task<RunSummary> RunTestMethodAsync(ITestMethod testMethod, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, object[] constructorArguments)
+            {
+                return new CustomTestMethodRunner(testMethod, this.Class, method, testCases, this.DiagnosticMessageSink, this.MessageBus, new ExceptionAggregator(this.Aggregator), this.CancellationTokenSource, constructorArguments)
+                   .RunAsync();
+            }
+        }
+
+        private class CustomTestMethodRunner : XunitTestMethodRunner
+        {
+            private readonly IMessageSink _diagnosticMessageSink;
+
+            public CustomTestMethodRunner(ITestMethod testMethod, IReflectionTypeInfo @class, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments)
+                : base(testMethod, @class, method, testCases, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource, constructorArguments)
+            {
+                _diagnosticMessageSink = diagnosticMessageSink;
+            }
+
+            protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
+            {
+                var parameters = string.Empty;
+
+                if (testCase.TestMethodArguments != null)
+                {
+                    parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString() ?? "null"));
+                }
+
+                var test = $"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}({parameters})";
+
+                _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"STARTED: {test}"));
+
+                try
+                {
+                    var result = await base.RunTestCaseAsync(testCase);
+
+                    var status = result.Failed > 0 ? "FAILURE" : "SUCCESS";
+
+                    _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"{status}: {test} ({result.Time}s)"));
+
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"ERROR: {test} ({ex.Message})"));
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -1,6 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <None Remove="xunit.runner.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
 
     <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/xunit.runner.json
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": true
+}


### PR DESCRIPTION
## Why

GraphQL integration service name mapping should work similarly to other instrumentations.

## What

Use configured service name mapping in GraphQL instrumentation.
Annotations for modified files where missing.
Removal of redundant fallback.
Addition of CustomTestFramework for better visibility into tests (basically copied from other test project).

## Tests

Added in PR.
 
