### PR TITLE
Add SIGNALFX_LOGS_ENDPOINT_URL env var

### DIFF
--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -56,6 +56,7 @@ These settings should be never used by the users.
 
 | Environment variable | Description | Default |
 |-|-|-|
+| `SIGNALFX_LOGS_ENDPOINT_URL` | The URL to where thread sampling exporters send stack traces. | `http://localhost:4318/v1/logs` |
 | `SIGNALFX_METRICS_ENDPOINT_URL` | The URL to where metric exporters send metrics. | `http://localhost:9943/v2/datapoint` |
 | `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. It is used to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
 | `SIGNALFX_RUNTIME_METRICS_ENABLED` | Enable to activate internal runtime metrics sent to SignalFx. | `false` |

--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -56,7 +56,7 @@ These settings should be never used by the users.
 
 | Environment variable | Description | Default |
 |-|-|-|
-| `SIGNALFX_LOGS_ENDPOINT_URL` | The URL to where thread sampling exporters send stack traces. | `http://localhost:4318/v1/logs` |
+| `SIGNALFX_LOGS_ENDPOINT_URL` | The URL to where logs are exported using [OTLP/HTTP v1 log protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) | `http://localhost:4318/v1/logs` |
 | `SIGNALFX_METRICS_ENDPOINT_URL` | The URL to where metric exporters send metrics. | `http://localhost:9943/v2/datapoint` |
 | `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. It is used to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
 | `SIGNALFX_RUNTIME_METRICS_ENABLED` | Enable to activate internal runtime metrics sent to SignalFx. | `false` |

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -62,6 +62,12 @@ namespace Datadog.Trace.Configuration
         public const string MetricsEndpointUrl = "SIGNALFX_METRICS_ENDPOINT_URL";
 
         /// <summary>
+        /// Configuration key for the URL where the Thread Sampler can send stack traces.
+        /// </summary>
+        /// <seealso cref="ExporterSettings.LogsEndpointUrl"/>
+        public const string LogsEndpointUrl = "SIGNALFX_LOGS_ENDPOINT_URL";
+
+        /// <summary>
         /// Configuration key for the trace endpoint. Same as <see creg="AgentUri"/> created
         /// for compatibility of previous version of SignalFx .NET Tracing.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -62,7 +62,8 @@ namespace Datadog.Trace.Configuration
         public const string MetricsEndpointUrl = "SIGNALFX_METRICS_ENDPOINT_URL";
 
         /// <summary>
-        /// Configuration key for the URL where the Thread Sampler can send stack traces.
+        /// Configuration key for the URL where the logs are exported.
+        /// Currently the Thread Sampler sends stack traces as logs.
         /// </summary>
         /// <seealso cref="ExporterSettings.LogsEndpointUrl"/>
         public const string LogsEndpointUrl = "SIGNALFX_LOGS_ENDPOINT_URL";

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -50,6 +50,7 @@ namespace Datadog.Trace.Configuration
             var isWindows = FrameworkDescription.Instance.OSPlatform == OSPlatform.Windows;
             ConfigureTraceTransport(source, isWindows);
             ConfigureMetricsTransport(source, isWindows);
+            ConfigureLogsTransport(source);
 
             PartialFlushEnabled = source?.GetBool(ConfigurationKeys.PartialFlushEnabled)
                 // default value
@@ -85,7 +86,7 @@ namespace Datadog.Trace.Configuration
         public Uri MetricsEndpointUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the Uri where the Thread Sampler can send stack traces.
+        /// Gets or sets the Uri where the logs are exported.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.LogsEndpointUrl"/>
         public Uri LogsEndpointUrl { get; set; }
@@ -172,10 +173,13 @@ namespace Datadog.Trace.Configuration
                              // default value
                              "http://localhost:9943/v2/datapoint";
             MetricsEndpointUrl = new Uri(metricsEndpointUrl);
+        }
 
-            var logsEndpointUrl = source?.GetString(ConfigurationKeys.MetricsEndpointUrl) ??
-                             // default value
-                             "http://localhost:4318/v1/logs";
+        private void ConfigureLogsTransport(IConfigurationSource source)
+        {
+            var logsEndpointUrl = source?.GetString(ConfigurationKeys.LogsEndpointUrl) ??
+                                  // default value
+                                  "http://localhost:4318/v1/logs";
             LogsEndpointUrl = new Uri(logsEndpointUrl);
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -85,6 +85,12 @@ namespace Datadog.Trace.Configuration
         public Uri MetricsEndpointUrl { get; set; }
 
         /// <summary>
+        /// Gets or sets the Uri where the Thread Sampler can send stack traces.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.LogsEndpointUrl"/>
+        public Uri LogsEndpointUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the timeout in milliseconds for the windows named pipe requests.
         /// Default is <c>100</c>.
         /// </summary>
@@ -166,6 +172,11 @@ namespace Datadog.Trace.Configuration
                              // default value
                              "http://localhost:9943/v2/datapoint";
             MetricsEndpointUrl = new Uri(metricsEndpointUrl);
+
+            var logsEndpointUrl = source?.GetString(ConfigurationKeys.MetricsEndpointUrl) ??
+                             // default value
+                             "http://localhost:4318/v1/logs";
+            LogsEndpointUrl = new Uri(logsEndpointUrl);
         }
 
         private void ConfigureTraceTransport(IConfigurationSource source, bool isWindows)

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.Configuration
             TracesPipeTimeoutMs = settings.TracesPipeTimeoutMs;
 
             MetricsEndpointUrl = settings.MetricsEndpointUrl;
+            LogsEndpointUrl = settings.LogsEndpointUrl;
             MetricsTransport = settings.MetricsTransport;
             MetricsPipeName = settings.MetricsPipeName;
             DogStatsdPort = settings.DogStatsdPort;
@@ -59,6 +60,12 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.MetricsEndpointUrl"/>
         public Uri MetricsEndpointUrl { get; }
+
+        /// <summary>
+        /// Gets the Uri where the Thread Sampler can send stack traces.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.LogsEndpointUrl"/>
+        public Uri LogsEndpointUrl { get; set; }
 
         /// <summary>
         /// Gets the windows pipe name where the Tracer can connect to the Agent.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -62,10 +62,10 @@ namespace Datadog.Trace.Configuration
         public Uri MetricsEndpointUrl { get; }
 
         /// <summary>
-        /// Gets the Uri where the Thread Sampler can send stack traces.
+        /// Gets the Uri where the logs are exported.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.LogsEndpointUrl"/>
-        public Uri LogsEndpointUrl { get; set; }
+        public Uri LogsEndpointUrl { get; }
 
         /// <summary>
         /// Gets the windows pipe name where the Tracer can connect to the Agent.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -69,6 +71,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.DogStatsdPort == i.DogStatsdPort,
                 (e, i) => e.MetricsTransport == i.MetricsTransport,
                 (e, i) => e.MetricsEndpointUrl == i.MetricsEndpointUrl,
+                (e, i) => e.LogsEndpointUrl == i.LogsEndpointUrl,
                 (e, i) => e.TracesTransport == i.TracesTransport,
                 (e, i) => e.TracesPipeTimeoutMs == i.TracesPipeTimeoutMs,
                 (e, i) => e.AgentUri == i.AgentUri,

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -33,6 +33,7 @@ namespace Datadog.Trace.Configuration
         public ExporterSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
         public System.Uri AgentUri { get; set; }
         public int DogStatsdPort { get; set; }
+        public System.Uri LogsEndpointUrl { get; set; }
         public System.Uri MetricsEndpointUrl { get; set; }
         public string MetricsPipeName { get; set; }
         public bool PartialFlushEnabled { get; set; }
@@ -70,6 +71,7 @@ namespace Datadog.Trace.Configuration
         public ImmutableExporterSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
         public System.Uri AgentUri { get; }
         public int DogStatsdPort { get; }
+        public System.Uri LogsEndpointUrl { get; }
         public System.Uri MetricsEndpointUrl { get; }
         public string MetricsPipeName { get; }
         public bool PartialFlushEnabled { get; }


### PR DESCRIPTION
## Why

Configuration needed by thread sampling exporter and the documentation for thread sampling.

## What

`SIGNALFX_LOGS_ENDPOINT_URL` env var to configure where to send logs.

## Tests

N/A

