### PR TITLE
thread sampling every 10s

### DIFF
--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -61,5 +61,5 @@ These settings should be never used by the users.
 | `SIGNALFX_METRICS_EXPORTER` | Metrics exporter to be used. It is used to encode and dispatch metrics. Available values are: `SignalFx`, `StatsD`. | `SignalFx` |
 | `SIGNALFX_RUNTIME_METRICS_ENABLED` | Enable to activate internal runtime metrics sent to SignalFx. | `false` |
 | `SIGNALFX_THREAD_SAMPLING_ENABLED` | Enable to activate thread sampling. | `false` |
-| `SIGNALFX_THREAD_SAMPLING_PERIOD` | Sampling period. It defines how often the threads are stopped in order to fetch all stack traces. This value cannot be lower than `1000` milliseconds. | `1000` |
+| `SIGNALFX_THREAD_SAMPLING_PERIOD` | Sampling period. It defines how often the threads are stopped in order to fetch all stack traces. This value cannot be lower than `1000` milliseconds. | `10000` |
 | `SIGNALFX_TRACE_AZURE_FUNCTIONS_ENABLED` | Set to instrument within Azure functions. | `false` |

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
@@ -21,7 +21,7 @@
 #define SAMPLES_BUFFER_DEFAULT_SIZE 20 * 1024
 
 // If you change these, change ThreadSampler.cs too
-#define DEFAULT_SAMPLE_PERIOD 1000
+#define DEFAULT_SAMPLE_PERIOD 10000
 #define MINIMUM_SAMPLE_PERIOD 1000
 
 // FIXME make configurable (hidden)?

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -633,7 +633,7 @@ namespace Datadog.Trace.Configuration
         private static TimeSpan GetThreadSamplingPeriod(IConfigurationSource source)
         {
             // If you change any of these constants, check with ThreadSampler.cpp first
-            var defaultSamplePeriod = TimeSpan.FromMilliseconds(value: 1000);
+            var defaultSamplePeriod = TimeSpan.FromMilliseconds(value: 10000);
             const int minimumSamplePeriod = 1000;
 
             var period = source?.GetInt32(ConfigurationKeys.ThreadSampling.Period);


### PR DESCRIPTION
## Why

To have same default settings as Java profiler

## What

Thread sampling every 10s
