### PR TITLE
Add SIGNALFX_REALM env variable

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -20,6 +20,13 @@ namespace Datadog.Trace.Configuration
         public const string AgentHost = "SIGNALFX_AGENT_HOST";
 
         /// <summary>
+        /// Configuration key for the SignalFx ingest realm, where the Tracer can send telemetry signals.
+        /// </summary>
+        /// <seealso cref="ExporterSettings.MetricsEndpointUrl"/>
+        /// <seealso cref="ExporterSettings.AgentUri"/>
+        public const string IngestRealm = "SIGNALFX_REALM";
+
+        /// <summary>
         /// Configuration key for the Agent port where the Tracer can send traces.
         /// Default value is 8126.
         /// </summary>

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Xunit;
 
@@ -68,7 +69,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.CustomSamplingRules), null };
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
             yield return new object[] { CreateFunc(s => s.TracerMetricsEnabled), false };
-            yield return new object[] { CreateFunc(s => s.ExporterSettings.DogStatsdPort), 8125 };
+            yield return new object[] { CreateFunc(s => s.ExporterSettings.DogStatsdPort), 9943 };
             yield return new object[] { CreateFunc(s => s.RecordedValueMaxLength), 12000 };
         }
 
@@ -77,7 +78,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.TraceEnabled, "true", CreateFunc(s => s.TraceEnabled), true };
             yield return new object[] { ConfigurationKeys.TraceEnabled, "false", CreateFunc(s => s.TraceEnabled), false };
 
-            yield return new object[] { ConfigurationKeys.AgentHost, "test-host", CreateFunc(s => s.ExporterSettings.AgentUri), new Uri("http://test-host:9411/api/v2/spans") };
+            yield return new object[] { ConfigurationKeys.IngestRealm, "realm", CreateFunc(s => s.ExporterSettings.AgentUri), new Uri("https://ingest.realm.signalfx.com/v2/trace") };
+            yield return new object[] { ConfigurationKeys.IngestRealm, "realm", CreateFunc(s => s.ExporterSettings.MetricsEndpointUrl), new Uri("https://ingest.realm.signalfx.com/v2/datapoint") };
             yield return new object[] { ConfigurationKeys.AgentPort, "9000", CreateFunc(s => s.ExporterSettings.AgentUri), new Uri("http://127.0.0.1:9000/api/v2/spans") };
 
             yield return new object[] { ConfigurationKeys.EndpointUrl, "http://localhost:9411/api/v2/spans", CreateFunc(s => s.ExporterSettings.AgentUri), new Uri("http://127.0.0.1:9411/api/v2/spans") };
@@ -113,6 +115,12 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.Exporter, "datadogagent", CreateFunc(s => s.Exporter), ExporterType.DatadogAgent };
             yield return new object[] { ConfigurationKeys.Exporter, "Zipkin", CreateFunc(s => s.Exporter), ExporterType.Zipkin };
             yield return new object[] { ConfigurationKeys.Exporter, "unknown", CreateFunc(s => s.Exporter), ExporterType.Default };
+
+            yield return new object[] { ConfigurationKeys.MetricsExporter, null, CreateFunc(s => s.MetricsExporter), MetricsExporterType.Default };
+            yield return new object[] { ConfigurationKeys.MetricsExporter, string.Empty, CreateFunc(s => s.MetricsExporter), MetricsExporterType.Default };
+            yield return new object[] { ConfigurationKeys.MetricsExporter, "StatsD", CreateFunc(s => s.MetricsExporter), MetricsExporterType.StatsD };
+            yield return new object[] { ConfigurationKeys.MetricsExporter, "SignalFx", CreateFunc(s => s.MetricsExporter), MetricsExporterType.SignalFx };
+            yield return new object[] { ConfigurationKeys.MetricsExporter, "unknown", CreateFunc(s => s.MetricsExporter), MetricsExporterType.Default };
 
             yield return new object[] { ConfigurationKeys.Convention, null, CreateFunc(s => s.Convention), ConventionType.Default };
             yield return new object[] { ConfigurationKeys.Convention, string.Empty, CreateFunc(s => s.Convention), ConventionType.Default };

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Specialized;
+﻿// Modified by Splunk Inc.
+
+using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
 using FluentAssertions;
 using Xunit;
@@ -32,23 +34,23 @@ public class ExporterSettingsTests
     [Fact]
     public void If_nondefault_signalfx_realm_is_configured_then_direct_ingest_endpoint_for_traces_is_used()
     {
-        var collection = new NameValueCollection { { "SIGNALFX_REALM", "realm" } };
+        var collection = new NameValueCollection { { "SIGNALFX_REALM", "test-realm" } };
         var configuration = new NameValueConfigurationSource(collection);
 
         var settings = new ExporterSettings(configuration);
 
-        settings.AgentUri.Should().Be("https://ingest.realm.signalfx.com/v2/trace");
+        settings.AgentUri.Should().Be("https://ingest.test-realm.signalfx.com/v2/trace");
     }
 
     [Fact]
     public void If_nondefault_signalfx_realm_is_configured_then_direct_ingest_endpoint_for_metrics_is_used()
     {
-        var collection = new NameValueCollection { { "SIGNALFX_REALM", "realm" } };
+        var collection = new NameValueCollection { { "SIGNALFX_REALM", "test-realm" } };
         var configuration = new NameValueConfigurationSource(collection);
 
         var settings = new ExporterSettings(configuration);
 
-        settings.MetricsEndpointUrl.Should().Be("https://ingest.realm.signalfx.com/v2/datapoint");
+        settings.MetricsEndpointUrl.Should().Be("https://ingest.test-realm.signalfx.com/v2/datapoint");
     }
 
     [Theory]
@@ -108,7 +110,7 @@ public class ExporterSettingsTests
     {
         var collection = new NameValueCollection
         {
-            { "SIGNALFX_REALM", "realm" },
+            { "SIGNALFX_REALM", "test-realm" },
             { "SIGNALFX_ENDPOINT_URL", "http://127.0.0.1:9411/api/v2/spans" }
         };
         var configuration = new NameValueConfigurationSource(collection);
@@ -123,7 +125,7 @@ public class ExporterSettingsTests
     {
         var collection = new NameValueCollection
         {
-            { "SIGNALFX_REALM", "realm" },
+            { "SIGNALFX_REALM", "test-realm" },
             { "SIGNALFX_METRICS_ENDPOINT_URL", "http://127.0.0.1:9943/v2/datapoint" }
         };
         var configuration = new NameValueConfigurationSource(collection);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -1,0 +1,135 @@
+﻿using System.Collections.Specialized;
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration;
+
+public class ExporterSettingsTests
+{
+    [Fact]
+    public void If_there_is_no_trace_endpoint_configuration_then_local_traces_collector_is_used()
+    {
+        var collection = new NameValueCollection();
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.AgentUri.Should().Be("http://127.0.0.1:9411/api/v2/spans");
+    }
+
+    [Fact]
+    public void If_there_is_no_metrics_endpoint_configuration_then_local_metrics_collector_is_used()
+    {
+        var collection = new NameValueCollection();
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.MetricsEndpointUrl.Should().Be("http://localhost:9943/v2/datapoint");
+    }
+
+    [Fact]
+    public void If_nondefault_signalfx_realm_is_configured_then_direct_ingest_endpoint_for_traces_is_used()
+    {
+        var collection = new NameValueCollection { { "SIGNALFX_REALM", "realm" } };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.AgentUri.Should().Be("https://ingest.realm.signalfx.com/v2/trace");
+    }
+
+    [Fact]
+    public void If_nondefault_signalfx_realm_is_configured_then_direct_ingest_endpoint_for_metrics_is_used()
+    {
+        var collection = new NameValueCollection { { "SIGNALFX_REALM", "realm" } };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.MetricsEndpointUrl.Should().Be("https://ingest.realm.signalfx.com/v2/datapoint");
+    }
+
+    [Theory]
+    [InlineData("none")]
+    [InlineData("NONE")]
+    public void If_default_signalfx_realm_is_configured_then_local_traces_collector_is_used(string configuredRealm)
+    {
+        var collection = new NameValueCollection { { "SIGNALFX_REALM", configuredRealm } };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.AgentUri.Should().Be("http://127.0.0.1:9411/api/v2/spans");
+    }
+
+    [Theory]
+    [InlineData("none")]
+    [InlineData("NONE")]
+    public void If_default_signalfx_realm_is_configured_to_none_then_local_metrics_collector_is_used(string configuredRealm)
+    {
+        var collection = new NameValueCollection { { "SIGNALFX_REALM", configuredRealm } };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.MetricsEndpointUrl.Should().Be("http://localhost:9943/v2/datapoint");
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:9411/api/v2/spans")]
+    [InlineData("https://remotehost/v2/trace")]
+    public void If_traces_endpoint_is_configured_then_its_used_as_provided(string configuredEndpoint)
+    {
+        var collection = new NameValueCollection { { "SIGNALFX_ENDPOINT_URL", configuredEndpoint } };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.AgentUri.Should().Be(configuredEndpoint);
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1:9943/v2/datapoint")]
+    [InlineData("https://remotehost/v2/datapoint")]
+    public void If_metrics_endpoint_is_configured_then_its_used_as_provided(string configuredEndpoint)
+    {
+        var collection = new NameValueCollection { { "SIGNALFX_METRICS_ENDPOINT_URL", configuredEndpoint } };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.MetricsEndpointUrl.Should().Be(configuredEndpoint);
+    }
+
+    [Fact]
+    public void Endpoint_url_takes_precedence_over_signalfx_realm_for_traces()
+    {
+        var collection = new NameValueCollection
+        {
+            { "SIGNALFX_REALM", "realm" },
+            { "SIGNALFX_ENDPOINT_URL", "http://127.0.0.1:9411/api/v2/spans" }
+        };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.AgentUri.Should().Be("http://127.0.0.1:9411/api/v2/spans");
+    }
+
+    [Fact]
+    public void Endpoint_url_takes_precedence_over_signalfx_realm_for_metrics()
+    {
+        var collection = new NameValueCollection
+        {
+            { "SIGNALFX_REALM", "realm" },
+            { "SIGNALFX_METRICS_ENDPOINT_URL", "http://127.0.0.1:9943/v2/datapoint" }
+        };
+        var configuration = new NameValueConfigurationSource(collection);
+
+        var settings = new ExporterSettings(configuration);
+
+        settings.MetricsEndpointUrl.Should().Be("http://127.0.0.1:9943/v2/datapoint");
+    }
+}


### PR DESCRIPTION
## Why
Simplify endpoint configuration for traces and metrics.

## What

Addition of new SIGNALFX_REALM env variable.
Documentation to be updated with a separate PR.

## Tests

Included in PR.
 
