### PR TITLE
Revert "update otel/opentelemetry-collector-contrib to 0.42.0 (#303)"

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "14250:14250"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.42.0
+    image: otel/opentelemetry-collector-contrib:0.40.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
     environment:


### PR DESCRIPTION
This reverts commit 342c546dd66e591db7aa22a8d6d944b5317f04dd.

## Why

1. The new version of collector output is noisy. It logs more than configured
2. The metrics pipeline does not work (discovered by @lachmatt) - probably connected with `signalfxreceiver`
3. The trace pipeline does not work (discovered by @pellared) - reason unknown maybe something with `jaegerexpoter`

Maybe something is wrong with https://github.com/signalfx/signalfx-dotnet-tracing/blob/next-ver/dev/otel-config.yaml for `otel/opentelemetry-collector-contrib:0.42.0`? 

## What

Revert "update otel/opentelemetry-collector-contrib to 0.42.0 (#303)"

Bring back `otel/opentelemetry-collector-contrib:0.40.0`