### PR TITLE
More sampling overhead stats

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.h
@@ -15,6 +15,23 @@ extern "C"
 
 namespace trace
 {
+struct SamplingStatistics {
+    int microsSuspended;
+    int numThreads;
+    int totalFrames;
+    int nameCacheMisses;
+    SamplingStatistics() : microsSuspended(0), numThreads(0), totalFrames(0), nameCacheMisses(0)
+    {
+    }
+    SamplingStatistics(SamplingStatistics const& other) :
+        microsSuspended(other.microsSuspended),
+        numThreads(other.numThreads),
+        totalFrames(other.totalFrames),
+        nameCacheMisses(other.nameCacheMisses)
+    {
+    }
+};
+
 class ThreadSpanContext
 {
 public:
@@ -76,7 +93,7 @@ public:
     void RecordFrame(FunctionID fid, WSTRING& frame);
     void EndSample();
     void EndBatch();
-    void WriteFinalStats(int microsSuspended);
+    void WriteFinalStats(SamplingStatistics stats);
 
 private:
     void writeCodedFrameString(FunctionID fid, WSTRING& str);

--- a/tracer/src/Datadog.Trace/ThreadSampling/ThreadSampleNativeFormatParser.cs
+++ b/tracer/src/Datadog.Trace/ThreadSampling/ThreadSampleNativeFormatParser.cs
@@ -95,7 +95,10 @@ namespace Datadog.Trace.ThreadSampling
                 else if (op == 0x07)
                 {
                     int microsSuspended = ReadInt();
-                    Console.WriteLine("  clr was suspended for " + microsSuspended + " micros");
+                    int numThreads = ReadInt();
+                    int totalFrames = ReadInt();
+                    int nameCacheMisses = ReadInt();
+                    Console.WriteLine("  clr was suspended for " + microsSuspended + " micros threads=" + numThreads + " frames=" + totalFrames + " misses=" + nameCacheMisses);
                 }
                 else
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/ThreadSampler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/ThreadSampler_test.cpp
@@ -51,8 +51,8 @@ TEST(ThreadSamplerTest, BasicBufferBehavior)
     tsb.RecordFrame(7001, frame1);
     tsb.EndSample();
     tsb.EndBatch();
-    tsb.WriteFinalStats(100);
-    ASSERT_EQ(1278, tsb.buffer->size()); // not manually calculated but does depend on thread name limiting and not repeating frame strings
+    tsb.WriteFinalStats(SamplingStatistics());
+    ASSERT_EQ(1290, tsb.buffer->size()); // not manually calculated but does depend on thread name limiting and not repeating frame strings
     ASSERT_EQ(2, tsb.codes.size());
 }
 
@@ -82,10 +82,10 @@ TEST(ThreadSamplerTest, BufferOverrunBehavior)
         tsb.RecordFrame(7001, frame1);
         tsb.EndSample();
         tsb.EndBatch();
-        tsb.WriteFinalStats(100);
+        tsb.WriteFinalStats(SamplingStatistics());
     }
     // 200k buffer plus one more thread entry before it stops adding more
-    ASSERT_EQ(buf.size(), 205432);
+    ASSERT_TRUE(buf.size() < 210000 && buf.size() >= 200000);
 }
 
 TEST(ThreadSamplerTest, StaticBufferManagement)


### PR DESCRIPTION
Capture and report more thread sampling overhead stats:
- suspended microseconds (was there before)
- number of threads
- total number of frames
- name cache misses

This should be enough to track and debug basic behavior in the field.