### PR TITLE
use otel/opentelemetry-collector-contrib:0.42.0

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -9,9 +9,10 @@ services:
       - "14250:14250"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.40.0
+    image: otel/opentelemetry-collector-contrib:0.42.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
+    command: --config /etc/otel/config.yaml
     environment:
       - JAEGER_ENDPOINT=jaeger:14250
       - SPLUNK_ACCESS_TOKEN


### PR DESCRIPTION
## Notes

it was not possible due to breaking/undocumented change in default configuration
between 0.40.0 and 0.42.0

For delatils see
for 0.40.0: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9516285e706b9a4a8918372050cdad923bc72c25/cmd/otelcontribcol/Dockerfile#L15
for 0.42.0: https://github.com/open-telemetry/opentelemetry-collector-releases/blob/606b9299551267c8c80c818b057f08a9444458d7/distributions/otelcol-contrib/Dockerfile#L19

## Why & What

sync with last release of otel-collector-contrib

## Tests

Local tests.
 
