### PR TITLE
Update CI to use main as the default branch

### DIFF
--- a/.azure-pipelines/mininal-pipeline.yml
+++ b/.azure-pipelines/mininal-pipeline.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - next-ver
+      - main
       - release/*
       - hotfix/*
       - refs/tags/*
@@ -45,7 +45,7 @@ schedules:
     displayName: Daily 3am (UTC) build
     branches:
       include:
-        - next-ver
+        - main
     always: true
 
 # Global variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - next-ver
     tags:
     - 'v*'
     paths-ignore:
@@ -49,7 +48,7 @@ env:
   ddTracerHome: ${{ github.workspace }}/tracer/src/bin/dd-tracer-home
   tracerHome: ${{ github.workspace }}/tracer/src/bin/windows-tracer-home
   artifacts: ${{ github.workspace }}/tracer/src/bin/artifacts
-  isMainBranch: $[eq(github.ref, 'refs/heads/next-ver')]
+  isMainBranch: $[eq(github.ref, 'refs/heads/main')]
   NugetPackageDirectory: ${{ github.workspace }}/packages
   relativeNugetPackageDirectory: packages
   dotnetToolTag: build-dotnet-tool


### PR DESCRIPTION
## Why

Changing `next-ver` to `main`

## What

Update CI workflows
