### PR TITLE
Do not discourage setting SIGNALFX_SERVICE_NAME

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -45,7 +45,7 @@ The following settings are common to most instrumentation scenarios:
 | Setting | Description | Default |
 |-|-|-|
 | `SIGNALFX_ENV` | The value for the `deployment.environment` tag added to every span. |  |
-| `SIGNALFX_SERVICE_NAME` | Optional setting, overrides the [default service name](default-service-name.md) used by the instrumentation. |  |
+| `SIGNALFX_SERVICE_NAME` | The name of the application or service. | See [here](default-service-name.md)  |
 | `SIGNALFX_VERSION` | The version of the application. When set, it populates the `version` tag on spans. |  |
 
 ## Global management settings

--- a/docs/azure-instrumentation.md
+++ b/docs/azure-instrumentation.md
@@ -8,6 +8,11 @@
 4. Go to **Settings > Configuration**.
 5. Click **New application setting** to add the following settings:
 
+   Name of the instrumented service:
+   
+   * Name: `SIGNALFX_SERVICE_NAME`
+   * Value: `[my-service-name]`
+
    Access token: See [here](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html) to learn how to obtain one. 
 
    * Name: `SIGNALFX_ACCESS_TOKEN`


### PR DESCRIPTION
## Why

Mainly for sake of consistency with other languages/ecosystems.

## What

Do not discourage setting SIGNALFX_SERVICE_NAME as it is nothing bad if one uses it. We rather recommend specifying it explicitly.
