### PR TITLE
Add bug bash to the release process

### DIFF
--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -14,7 +14,7 @@
    it is time to perform a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
    When testing, we should:
    
-   - use different testing environemnts,
+   - use different testing environments,
    - use different sample applications,
    - test different features,
    - follow the documentation (e.g. do not use the developer's build output,

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -20,7 +20,7 @@
    - follow the documentation (e.g. do not use the developer's build output,
      but use the installation packages instead). 
 
-5. Create a signed tag for the merged commit
+5. Create a signed tag for the merged commit.
 
    ***IMPORTANT***: It is critical you use the same tag
    that you used in the previous steps!

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -8,7 +8,7 @@
 
 2. Update the [CHANGELOG.md](../CHANGELOG.md) with the new release.
 
-3. Create a Pull Request on GitHub with the changes above. 
+3. Create a Pull Request on GitHub with the changes above.
 
 4. Once the Pull Request with all the version changes has been approved and merged
    it is time to perform a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -10,7 +10,7 @@
 
 3. Create a Pull Request on GitHub with the changes above.
 
-4. Consider performing a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
+4. _Optional_. Consider performing a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
    This could be useful especially when introducing significant changes.
    When testing, we should:
    

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -8,10 +8,19 @@
 
 2. Update the [CHANGELOG.md](../CHANGELOG.md) with the new release.
 
-3. Create a Pull Request on GitHub with the changes above.
+3. Create a Pull Request on GitHub with the changes above. 
 
 4. Once the Pull Request with all the version changes has been approved and merged
-   it is time to create a signed tag for the merged commit.
+   it is time to perform a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
+   When testing, we should:
+   
+   - use different testing environemnts,
+   - use different sample applications,
+   - test different features,
+   - follow the documentation (e.g. do not use the developer's build output,
+     but use the installation packages instead). 
+
+5. Create a signed tag for the merged commit
 
    ***IMPORTANT***: It is critical you use the same tag
    that you used in the previous steps!

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -10,8 +10,10 @@
 
 3. Create a Pull Request on GitHub with the changes above.
 
-4. _Optional_. Consider performing a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
+4. _Optional_. Consider organizing a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
    This could be useful especially when introducing significant changes.
+   The bug bash can take place after the release, but it is good
+   to prepare for it in advance.
    When testing, we should:
    
    - use different testing environments,

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -10,8 +10,8 @@
 
 3. Create a Pull Request on GitHub with the changes above.
 
-4. Once the Pull Request with all the version changes has been approved and merged
-   it is time to perform a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
+4. Consider performing a [bug bash](https://en.wikipedia.org/wiki/Bug_bash).
+   This could be useful especially when introducing significant changes.
    When testing, we should:
    
    - use different testing environments,


### PR DESCRIPTION
## Why

I find [bug bash](https://en.wikipedia.org/wiki/Bug_bash) as a very pragmatic testing tool. While automated tests can find a lot of issues their test suite is "closed". Moreover, nothing replaces the creativity of a human being trying to break things. If colleagues from other teams could be involved they can stress also other problems that we are not aware of  (like inconsistencies between languages, not clear documentation). At last bug bash is usually end-to-end testing therefore it helps finding issues in other systems such as Collector or Backend.

Side note: I remember that we had periodic bug bashes organized by @flands. I found them useful also as an onboarding experience (and I was able to find issues as a newbie),

## What

Add bug bash to the release process.