### PR TITLE
docs: Use SIGNALFX_ENV in instrumentation instructions and fix IIS instrumentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ $Env:CORECLR_PROFILER = "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"  # Select the .
 # Now the auto-instrumentation is configured in this shell session.
 # You can set additional settings and run your application, for example:
 $Env:SIGNALFX_SERVICE_NAME = "my-service-name"                    # Set the service name
-$Env:SIGNALFX_ENV = "development"                                 # Set the environment name
+$Env:SIGNALFX_ENV = "production"                                 # Set the environment name
 dotnet run                                                        # Run your application                                                     
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@ export SIGNALFX_DOTNET_TRACER_HOME="/opt/signalfx"                              
 # Now the auto-instrumentation is configured in this shell session.
 # You can set additional settings and run your application, for example:
 export SIGNALFX_SERVICE_NAME="my-service-name"  # Set the service name
-export SIGNALFX_ENV="development"               # Set the environment name
+export SIGNALFX_ENV="production"                # Set the environment name
 dotnet run                                      # Run your application 
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ $Env:CORECLR_PROFILER = "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"  # Select the .
 # Now the auto-instrumentation is configured in this shell session.
 # You can set additional settings and run your application, for example:
 $Env:SIGNALFX_SERVICE_NAME = "my-service-name"                    # Set the service name
-$Env:SIGNALFX_ENV = "production"                                 # Set the environment name
+$Env:SIGNALFX_ENV = "production"                                  # Set the environment name
 dotnet run                                                        # Run your application                                                     
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@ $Env:CORECLR_PROFILER = "{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"  # Select the .
 # Now the auto-instrumentation is configured in this shell session.
 # You can set additional settings and run your application, for example:
 $Env:SIGNALFX_SERVICE_NAME = "my-service-name"                    # Set the service name
+$Env:SIGNALFX_ENV = "development"                                 # Set the environment name
 dotnet run                                                        # Run your application                                                     
 ```
 
@@ -113,6 +114,7 @@ export SIGNALFX_DOTNET_TRACER_HOME="/opt/signalfx"                              
 # Now the auto-instrumentation is configured in this shell session.
 # You can set additional settings and run your application, for example:
 export SIGNALFX_SERVICE_NAME="my-service-name"  # Set the service name
+export SIGNALFX_ENV="development"               # Set the environment name
 dotnet run                                      # Run your application 
 ```
 

--- a/docs/azure-instrumentation.md
+++ b/docs/azure-instrumentation.md
@@ -12,27 +12,12 @@
 
 5. Click **New application setting** to add the following settings:
 
-   Name of the instrumented service:
-
-   * Name: `SIGNALFX_SERVICE_NAME`
-   * Value: `my-service-name`
-
-   Deployment environment of the instrumented service:
-
-   * Name: `SIGNALFX_ENV`
-   * Value: `development`
-
-   Access token: See [here](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html)
-   to learn how to obtain one.
-
-   * Name: `SIGNALFX_ACCESS_TOKEN`
-   * Value: `[secret]`
-
-   In the endpoint URL, ``splunk-realm`` is the [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints).
-   For example, ``us0``.
-
-   * Name: `SIGNALFX_ENDPOINT_URL`
-   * Value: `https://ingest.[splunk-realm].signalfx.com/v2/trace`
+   | Name | Value | Description |
+   | - | - | - |
+   | `SIGNALFX_SERVICE_NAME` | `my-service-name` | Name of the instrumented service. |
+   | `SIGNALFX_ENV` | `development` | Deployment environment of the instrumented service. |
+   | `SIGNALFX_ACCESS_TOKEN` | `[splunk-access-token]` | Access token. See [here](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html) to learn how to obtain one. |
+   | `SIGNALFX_ENDPOINT_URL` |  `https://ingest.[splunk-realm].signalfx.com/v2/trace` | In the endpoint URL, `splunk-realm` is the [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints). For example, `us0`. |
 
 6. Restart the application in App Service.
 

--- a/docs/azure-instrumentation.md
+++ b/docs/azure-instrumentation.md
@@ -15,7 +15,7 @@
    | Name | Value | Description |
    | - | - | - |
    | `SIGNALFX_SERVICE_NAME` | `my-service-name` | Name of the instrumented service. |
-   | `SIGNALFX_ENV` | `development` | Deployment environment of the instrumented service. |
+   | `SIGNALFX_ENV` | `production` | Deployment environment of the instrumented service. |
    | `SIGNALFX_ACCESS_TOKEN` | `[splunk-access-token]` | Access token. See [here](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html) to learn how to obtain one. |
    | `SIGNALFX_ENDPOINT_URL` |  `https://ingest.[splunk-realm].signalfx.com/v2/trace` | In the endpoint URL, `splunk-realm` is the [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints). For example, `us0`. |
 

--- a/docs/azure-instrumentation.md
+++ b/docs/azure-instrumentation.md
@@ -26,7 +26,7 @@
    to learn how to obtain one.
 
    * Name: `SIGNALFX_ACCESS_TOKEN`
-   * Value: `secret`
+   * Value: `[secret]`
 
    In the endpoint URL, ``splunk-realm`` is the [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints).
    For example, ``us0``.

--- a/docs/azure-instrumentation.md
+++ b/docs/azure-instrumentation.md
@@ -3,26 +3,39 @@
 ## App Service
 
 1. Choose your app in Azure App Service.
+
 2. Go to **Development Tools > Extensions**.
+
 3. Find and install the **SignalFx .NET Tracing** extension.
+
 4. Go to **Settings > Configuration**.
+
 5. Click **New application setting** to add the following settings:
 
    Name of the instrumented service:
-   
-   * Name: `SIGNALFX_SERVICE_NAME`
-   * Value: `[my-service-name]`
 
-   Access token: See [here](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html) to learn how to obtain one. 
+   * Name: `SIGNALFX_SERVICE_NAME`
+   * Value: `my-service-name`
+
+   Deployment environment of the instrumented service:
+
+   * Name: `SIGNALFX_ENV`
+   * Value: `development`
+
+   Access token: See [here](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html)
+   to learn how to obtain one.
 
    * Name: `SIGNALFX_ACCESS_TOKEN`
-   * Value: `[splunk-observability-cloud-access-token]`
+   * Value: `secret`
 
-   In the endpoint URL, ``splunk-realm`` is the [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints). For example, ``us0``.
+   In the endpoint URL, ``splunk-realm`` is the [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints).
+   For example, ``us0``.
 
    * Name: `SIGNALFX_ENDPOINT_URL`
    * Value: `https://ingest.[splunk-realm].signalfx.com/v2/trace`
+
 6. Restart the application in App Service.
 
-
-> **Tip:** To reduce latency and benefit from OTel Collector features, you can set the endpoint URL setting to a Collector instance running in Azure VM over an Azure private network.
+> **Tip:** To reduce latency and benefit from OTel Collector features,
+> you can set the endpoint URL setting to a Collector instance running
+> in Azure VM over an Azure private network.

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -13,7 +13,7 @@ Edit the `web.config` file of your application to add the required settings:
 <configuration>
   <appSettings>
     <add key="SIGNALFX_SERVICE_NAME" value="my-service-name" />
-    <add key="SIGNALFX_ENV" value="development" />
+    <add key="SIGNALFX_ENV" value="production" />
   </appSettings>
 </configuration>
 ```
@@ -32,7 +32,7 @@ to set the required settings:
         <environmentVariable name="CORECLR_ENABLE_PROFILING" value="1" />
         <environmentVariable name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" />
         <environmentVariable name="SIGNALFX_SERVICE_NAME" value="my-service-name" />
-        <environmentVariable name="SIGNALFX_ENV" value="development" />
+        <environmentVariable name="SIGNALFX_ENV" value="production" />
       </environmentVariables>
     </aspNetCore>
   </system.webServer>

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -1,14 +1,38 @@
 # Instrument an ASP.NET application deployed on IIS
 
-By default, the installer enables IIS instrumentation for .NET Framework
+## Instrument an ASP.NET 4.x application
+
+By default, all ASP.NET 4.x application deployed to IIS are instrumented.
+The installer enables IIS instrumentation for .NET Framework
 by setting the `Environment` registry key for W3SVC and WAS services
 located in the `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services` folder.
 
-For ASP.NET applications, for example IIS applications running on the .NET Framework, the
-default service name is `ServiceName[/VirtualPath]`.
-For ASP.NET Core applications the default service name is the entry assembly name, typically
-the name of your .NET Core project.
-If the defaults don't fit well with your usage or naming conventions configure `SIGNALFX_SERVICE_NAME` as described in [advanced-config.md](advanced-config.md#configuration-methods).
+Edit the `web.config` file of your application to add the required settings:
 
-Consider using `web.config` as the configuration method
-to avoid potential configuration conflicts between other applications.
+```xml
+<configuration>
+  <appSettings>
+    <add key="SIGNALFX_SERVICE_NAME" value="my-service-name" />
+    <add key="SIGNALFX_ENV" value="development" />
+  </appSettings>
+</configuration>
+```
+
+## Instrument an ASP.NET Core application
+
+Edit the `web.config` file of your application to set the following environment variables:
+
+```xml
+<configuration>
+  <system.webServer>
+    <aspNetCore .....>
+      <environmentVariables>
+        <environmentVariable name="CORECLR_ENABLE_PROFILING" value="1" />
+        <environmentVariable name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" />
+        <environmentVariable name="SIGNALFX_SERVICE_NAME" value="my-service-name" />
+        <environmentVariable name="SIGNALFX_ENV" value="development" />
+      </environmentVariables>
+    </aspNetCore>
+  </system.webServer>
+</configuration>
+```

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -20,12 +20,14 @@ Edit the `web.config` file of your application to add the required settings:
 
 ## Instrument an ASP.NET Core application
 
-Edit the `web.config` file of your application to set the following environment variables:
+Add following [`environmentVariable`](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/web-config#set-environment-variables)
+elements to the `web.config` file of your application
+to set the required settings:
 
 ```xml
 <configuration>
   <system.webServer>
-    <aspNetCore .....>
+    <aspNetCore ... >
       <environmentVariables>
         <environmentVariable name="CORECLR_ENABLE_PROFILING" value="1" />
         <environmentVariable name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" />

--- a/docs/windows-service-instrumentation.md
+++ b/docs/windows-service-instrumentation.md
@@ -19,7 +19,7 @@ $svcName = "MySrv"    # The name of the Windows Service you want to instrument
    "CORECLR_ENABLE_PROFILING=1",                              # Enable the .NET (Core) Profiler
    "CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}", # Select the .NET (Core) Profiler
    "SIGNALFX_SERVICE_NAME=my-service-name"                    # Set the service name
-   "SIGNALFX_ENV=development"                                 # Set the environment name
+   "SIGNALFX_ENV=production"                                 # Set the environment name
 )
 Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$svcName -Name Environment -Value $vars
 # Now each time you start the service, it will be auto-instrumented.

--- a/docs/windows-service-instrumentation.md
+++ b/docs/windows-service-instrumentation.md
@@ -19,7 +19,7 @@ $svcName = "MySrv"    # The name of the Windows Service you want to instrument
    "CORECLR_ENABLE_PROFILING=1",                              # Enable the .NET (Core) Profiler
    "CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}", # Select the .NET (Core) Profiler
    "SIGNALFX_SERVICE_NAME=my-service-name"                    # Set the service name
-   "SIGNALFX_ENV=production"                                 # Set the environment name
+   "SIGNALFX_ENV=production"                                  # Set the environment name
 )
 Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$svcName -Name Environment -Value $vars
 # Now each time you start the service, it will be auto-instrumented.

--- a/docs/windows-service-instrumentation.md
+++ b/docs/windows-service-instrumentation.md
@@ -19,6 +19,7 @@ $svcName = "MySrv"    # The name of the Windows Service you want to instrument
    "CORECLR_ENABLE_PROFILING=1",                              # Enable the .NET (Core) Profiler
    "CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}", # Select the .NET (Core) Profiler
    "SIGNALFX_SERVICE_NAME=my-service-name"                    # Set the service name
+   "SIGNALFX_ENV=development"                                 # Set the environment name
 )
 Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\$svcName -Name Environment -Value $vars
 # Now each time you start the service, it will be auto-instrumented.


### PR DESCRIPTION
## Why

1. The user should set `SIGNALFX_ENV`
2. The installer does not automatically instrument the ASP.NET Core apps deployed on IIS.

## What

1. Update instrumentation instructions to set `SIGNALFX_ENV`
2. Rewrite the IIS instrumentation docs

## Tests

@dszmigielski tested the instrumentation of ASP.NET Core app deployed to IIS. Thanks you 🙇 https://app.signalfx.com/#/apm/traces/275177c9ebb1d60a0c27d4b05dd9bd40
