### PR TITLE
Remove Datadog propagator from documentation

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -92,7 +92,7 @@ configure the following settings:
 
 | Setting | Description | Default |
 |-|-|-|
-| `SIGNALFX_PROPAGATORS` | Comma-separated list of the propagators for the tracer. Available propagators are: `Datadog`, `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3` |
+| `SIGNALFX_PROPAGATORS` | Comma-separated list of the propagators for the tracer. Available propagators are: `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3` |
 
 ## Library-specific instrumentation settings
 


### PR DESCRIPTION
## Why

We do not support Datadog configuration

## What

Remove the configuration value that we do not support.
