### PR TITLE
enable alpine in build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,49 @@ jobs:
         path: ${{ env.artifacts }}/nuget/SignalFx.NET.Tracing.Azure.Site.Extension.*.nupkg
         name: nuget-packages
 
+  container-build:
+    name: Container Build 
+    strategy:
+      fail-fast: false
+      matrix:
+        base-image: [ alpine ]
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: | 
+          2.1.x
+          3.1.x
+          5.0.x
+          6.0.x
+    - name: Build Docker image
+      run: |
+        docker build \
+          --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
+          --tag dd-trace-dotnet/${{ matrix.base-image }}-builder \
+          --target builder \
+          --file "./tracer/build/_build/docker/${{ matrix.base-image }}.dockerfile" \
+          "./tracer/build/_build"
+    - name: Build in Docker container
+      run: |
+        docker run --rm \
+          --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project \
+          --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
+          --env tracerHome=/project/${relativeTracerHome} \
+          --env artifacts=/project/${relativeArtifacts} \
+          --env SIGNALFX_CLR_ENABLE_NGEN=${SIGNALFX_CLR_ENABLE_NGEN} \
+          dd-trace-dotnet/${{ matrix.base-image }}-builder \
+          dotnet /build/bin/Debug/_build.dll BuildTracerHome ZipTracerHome
+    - name: Publish Linux x64-musl packages
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ env.artifacts }}/linux-x64
+        name: linux-x64-musl-packages
+      if: (${{ job.status }} != 'cancelled')
+      continue-on-error: true
+
   managed-unit-tests:
     name: Managed unit tests
     strategy:
@@ -136,6 +179,49 @@ jobs:
       if: (${{ job.status }} != 'cancelled')
       continue-on-error: true
 
+  container-managed-unit-tests:
+    name: Container Managed unit tests 
+    strategy:
+      fail-fast: false
+      matrix:
+        base-image: [ alpine ]
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: | 
+          2.1.x
+          3.1.x
+          5.0.x
+          6.0.x
+    - name: Build Docker image
+      run: |
+        docker build \
+          --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
+          --tag dd-trace-dotnet/${{ matrix.base-image }}-tester \
+          --target tester \
+          --file "./tracer/build/_build/docker/${{ matrix.base-image }}.dockerfile" \
+          "./tracer/build/_build"
+    - name: Managed tests in Docker container
+      run: |
+        docker run --rm \
+          --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project \
+          --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
+          --env tracerHome=/project/${relativeTracerHome} \
+          --env artifacts=/project/${relativeArtifacts} \
+          --env SIGNALFX_CLR_ENABLE_NGEN=${SIGNALFX_CLR_ENABLE_NGEN} \
+          dd-trace-dotnet/${{ matrix.base-image }}-tester \
+          dotnet /build/bin/Debug/_build.dll BuildTracerHome BuildAndRunManagedUnitTests
+    - name: Publish managed tests results
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.base-image }}-managed-unit-tests-build_data
+        path: tracer/build_data
+      if: (${{ job.status }} != 'cancelled')
+      continue-on-error: true
+
   native-unit-tests:
     name: Native unit tests
     strategy:
@@ -157,6 +243,49 @@ jobs:
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
     - run: ./tracer/build.cmd BuildTracerHome BuildAndRunNativeUnitTests
+
+  container-native-unit-tests:
+    name: Container Native unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        base-image: [ alpine ]
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: | 
+          2.1.x
+          3.1.x
+          5.0.x
+          6.0.x
+    - name: Build Docker image
+      run: |
+        docker build \
+          --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
+          --tag dd-trace-dotnet/${{ matrix.base-image }}-builder \
+          --target builder \
+          --file "./tracer/build/_build/docker/${{ matrix.base-image }}.dockerfile" \
+          "./tracer/build/_build"
+    - name: Managed tests in Docker container
+      run: |
+        docker run --rm \
+          --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project \
+          --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
+          --env tracerHome=/project/${relativeTracerHome} \
+          --env artifacts=/project/${relativeArtifacts} \
+          --env SIGNALFX_CLR_ENABLE_NGEN=${SIGNALFX_CLR_ENABLE_NGEN} \
+          dd-trace-dotnet/${{ matrix.base-image }}-builder \
+          dotnet /build/bin/Debug/_build.dll BuildTracerHome BuildAndRunNativeUnitTests
+    - name: Publish native tests results
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.base-image }}-native-unit-tests-build_data
+        path: tracer/build_data
+      if: (${{ job.status }} != 'cancelled')
+      continue-on-error: true
 
   integration-tests:
     name: Integration tests 
@@ -203,8 +332,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #TODO: base-image: [ debian, alpine ]
-        base-image: [ debian ]
+        base-image: [ debian, alpine ]
         framework: [ netcoreapp3.1, net5.0, net6.0 ]
     runs-on: ubuntu-20.04
     timeout-minutes: 60

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        baseImage: [debian]
-        # TODO: baseImage: [alpine, debian]
+        baseImage: [alpine, debian]
     timeout-minutes: 30
     env:
       baseImage: ${{ matrix.baseImage }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### General
 
+- Bring back support for Alpine Linux.
+
 ### Breaking changes
 
 ### Enhancements

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ and [`ActivitySource`](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/
 
 ## Requirements
 
-- .NET Core 3.1, .NET 5.0 and higher on Windows and Linux (except Alpine Linux)
+- .NET Core 3.1, .NET 5.0 and higher on Windows and Linux
 - .NET Framework 4.6.1 and higher on Windows
 
 ## Instrumented libraries and frameworks
@@ -60,7 +60,7 @@ page.
 | `x86.msi`     | Windows 32-bit | x86 | `msiexec /i signalfx-dotnet-tracing-x86.msi /quiet` | |
 | `tar.gz` | Linux distributions using [qlibc](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing.tar.gz -C /opt/signalfx` | Currently, all [officially supported Linux distribtions](https://docs.microsoft.com/dotnet/core/install/linux) except Alpine use glibc |
 | `amd64.deb`   | Debian-based Linux distributions | x64 | `dpkg -i signalfx-dotnet-tracing.deb` | DEB package |
-<!-- TODO: | `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /` | Alpine Linux uses musl | -->
+| `musl.tar.gz` | x64 Linux distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) | x64 | `tar -xf signalfx-dotnet-tracing-musl.tar.gz -C /opt/signalfx` | Alpine Linux uses musl |
 
 On Linux, after the installation, you can optionally create the log directory:
 


### PR DESCRIPTION
## Why

.NET supports alpine by default.

## What

Enable build pipeline on Linux Alpine.

## Tests

CI
tar.gz layout same as for Debian.