### PR TITLE
disable nullable feature to avoid warning on builds

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.ThreadSampling/Samples.ThreadSampling.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ThreadSampling/Samples.ThreadSampling.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION


## Why

to avoid warning on builds

## What

disable nullable feature on Samples.ThreadSampling

Samples.Shared is not supporting it
also other Samples are not supporting it

## Tests

N/A
