### PR TITLE
Fix operation order

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/ThreadSampler.cpp
@@ -734,8 +734,8 @@ void NameCache::put(UINT_PTR key, WSTRING* val)
     {
         auto &lru = list.back();
         delete lru.second; // FIXME consider using WSTRING directly instead of WSTRING*
-        list.pop_back();
         map.erase(lru.first);
+        list.pop_back();
     }
 }
 


### PR DESCRIPTION
## Why

Fix reference usage.
## What

Reorder operations in `NameCache::put`.

## Tests

Existing
