### PR TITLE
changing TargetFramework to TargetFrameworks

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Samples.SqlServer.NetFramework20.csproj
+++ b/tracer/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Samples.SqlServer.NetFramework20.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- override to only build/run net461 -->
-    <TargetFramework Condition="'$(OS)' == 'Windows_NT'">net461</TargetFramework>
-    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
## Why & What

changing TargetFramework to TargetFrameworks

in Directory.props TargetFrameworks is defined, so overwirte by TargetFramework is not working
it leads to compilation errors when you open whole solution

## Tests

CI