### PR TITLE
Bump Verify.XUnit from 11.12.1 to 15.1.1

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Verify.Xunit" Version="11.12.1" />
+    <PackageReference Include="Verify.Xunit" Version="15.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Verify.Xunit" Version="11.12.1" />
+    <PackageReference Include="Verify.Xunit" Version="15.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -48,11 +50,12 @@ namespace Datadog.Trace.TestHelpers
                 settings.UseParameters(parameters);
             }
 
+            VerifierSettings.MemberConverter<MockSpan, Dictionary<string, string>>(x => x.Tags, ScrubStackTraceForErrors);
+
             settings.ModifySerialization(_ =>
             {
                 _.IgnoreMember<MockSpan>(s => s.Duration);
                 _.IgnoreMember<MockSpan>(s => s.Start);
-                _.MemberConverter<MockSpan, Dictionary<string, string>>(x => x.Tags, ScrubStackTraceForErrors);
             });
 
             settings.AddScrubber(builder => ReplaceRegex(builder, LocalhostRegex, "localhost:00000"));

--- a/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
 
     <!-- FIXME: Verify.Xunit brings version 5.0.0 of the MS.Ext.Logging.Abstractions, force a downgrade to avoid runtime error. -->
-    <PackageReference Include="Verify.Xunit" Version="11.12.1" />
+    <PackageReference Include="Verify.Xunit" Version="15.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
 
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Verify.Xunit" Version="11.12.1" />
+    <PackageReference Include="Verify.Xunit" Version="15.1.1" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -20,7 +20,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -29,9 +29,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,7 +42,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -51,9 +51,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -45,9 +45,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=__statusCode=200.verified.txt
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -22,7 +22,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -31,9 +31,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -22,7 +22,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -31,9 +31,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -29,9 +29,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -29,9 +29,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=__statusCode=200.verified.txt
@@ -49,9 +49,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -29,9 +29,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -44,7 +44,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -53,9 +53,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -49,9 +49,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -44,7 +44,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -53,9 +53,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -49,9 +49,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -51,9 +51,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -51,9 +51,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -22,7 +22,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -31,9 +31,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -22,7 +22,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -31,9 +31,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -29,9 +29,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -29,9 +29,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -49,9 +49,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -49,9 +49,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -44,7 +44,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: This was a bad request.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: This was a bad request.
 at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       signalfx.tracing.library: dotnet-tracing,
@@ -53,9 +53,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -49,9 +49,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -26,9 +26,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -44,7 +44,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Input was not a status code,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Input was not a status code
 at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input),
       signalfx.tracing.library: dotnet-tracing,
@@ -53,9 +53,9 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -49,9 +49,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -51,9 +51,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -51,9 +51,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Identifier(Int32)' in 'Samples.AspNetMvc4.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -47,9 +47,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -71,9 +71,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -18,10 +18,10 @@
       net.peer.ip: ::1,
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
@@ -31,9 +31,9 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -58,10 +58,10 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       language: dotnet,
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
-      sfx.error.message: 
+      sfx.error.message:
 The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
 Parameter name: parameters
 at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -56,7 +56,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       net.peer.ip: ::1,
       sfx.error.kind: System.Exception,
       sfx.error.message: Oops, it broke.,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.Exception: Oops, it broke.
 at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -69,7 +69,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -48,9 +48,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -67,7 +67,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -69,7 +69,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -48,9 +48,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -67,7 +67,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -69,7 +69,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -48,9 +48,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -67,7 +67,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -69,7 +69,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -46,9 +46,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -48,9 +48,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -67,7 +67,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       net.peer.ip: ::1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       span.kind: server,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
 at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -32,7 +32,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
 at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
       signalfx.tracing.library: dotnet-tracing,
@@ -41,9 +41,9 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -30,9 +30,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -50,9 +50,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -48,9 +48,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -27,9 +27,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -21,7 +21,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -30,9 +30,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -50,9 +50,9 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -25,9 +25,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -19,7 +19,7 @@
       runtime-id: Guid_1,
       sfx.error.kind: System.ArgumentException,
       sfx.error.message: Passed in value was not 'true': false,
-      sfx.error.stack: 
+      sfx.error.stack:
 System.ArgumentException: Passed in value was not 'true': false
 at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       signalfx.tracing.library: dotnet-tracing,
@@ -28,9 +28,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -48,9 +48,9 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -23,9 +23,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -14,9 +14,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_enableBlocking=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_enableBlocking=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -24,9 +24,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -54,9 +54,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -84,9 +84,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -114,9 +114,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -24,9 +24,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -54,9 +54,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -84,9 +84,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -114,9 +114,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -8,9 +8,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -33,13 +30,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -51,9 +51,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -76,13 +73,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -94,9 +94,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -119,13 +116,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -137,9 +137,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -162,13 +159,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -180,9 +180,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -205,13 +202,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=False_expectedStatusCode=200_url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=False_expectedStatusCode=200_url=_Health_-test&[$slice].verified.txt
@@ -8,9 +8,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -33,13 +30,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -51,9 +51,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -76,13 +73,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -94,9 +94,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -119,13 +116,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -137,9 +137,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -162,13 +159,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -180,9 +180,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -205,13 +202,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -8,9 +8,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -33,13 +30,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -51,9 +51,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -76,13 +73,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -94,9 +94,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -119,13 +116,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -137,9 +137,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -162,13 +159,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -180,9 +180,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -205,13 +202,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetCore5ExternalRules._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5ExternalRules._.verified.txt
@@ -8,9 +8,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -33,13 +30,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -51,9 +51,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -76,13 +73,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -94,9 +94,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -119,13 +116,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -137,9 +137,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -162,13 +159,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -180,9 +180,6 @@
     Service: Samples.AspNetCore5,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       aspnet_core.endpoint: Samples.AspNetCore5.Controllers.HealthController.Index (Samples.AspNetCore5),
@@ -205,13 +202,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
@@ -44,9 +44,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -94,9 +94,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -194,9 +194,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -244,9 +244,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
@@ -44,9 +44,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -94,9 +94,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -194,9 +194,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -244,9 +244,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
@@ -44,9 +44,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -94,9 +94,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -194,9 +194,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -244,9 +244,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
@@ -44,9 +44,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -94,9 +94,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -194,9 +194,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -244,9 +244,9 @@
       span.kind: server
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=False.__url=_Health_-arg=[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=False.__url=_Health_-test&[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?test&[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":[0,1],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
@@ -9,7 +9,6 @@
     Type: web,
     ParentId: Id_3,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -20,7 +19,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -32,9 +32,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -51,13 +48,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -70,7 +70,6 @@
     Type: web,
     ParentId: Id_6,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -81,7 +80,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -93,9 +93,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -112,13 +109,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -131,7 +131,6 @@
     Type: web,
     ParentId: Id_9,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -142,7 +141,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -154,9 +154,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -173,13 +170,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -192,7 +192,6 @@
     Type: web,
     ParentId: Id_12,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -203,7 +202,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -215,9 +215,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -234,13 +231,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   },
   {
@@ -253,7 +253,6 @@
     Type: web,
     ParentId: Id_15,
     Tags: {
-      _dd.origin: appsec,
       aspnet.action: index,
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
@@ -264,7 +263,8 @@
       http.url: http://localhost:00000/Health/?arg=[$slice],
       language: dotnet,
       net.peer.ip: ::1,
-      span.kind: server
+      span.kind: server,
+      _dd.origin: appsec
     }
   },
   {
@@ -276,9 +276,6 @@
     Service: sample,
     Type: web,
     Tags: {
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
-      _dd.origin: appsec,
-      _dd.runtime_family: dotnet,
       actor.ip: 86.242.244.246,
       appsec.event: true,
       deployment.environment: integration_tests,
@@ -295,13 +292,16 @@
       runtime-id: Guid_1,
       signalfx.tracing.library: dotnet-tracing,
       signalfx.tracing.version: x.y.z,
-      span.kind: server
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"type":"nosql_injection","category":"attack_attempt"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[\\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\\]))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["arg",0],"value":"[$slice]"}]}]}]},
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
     },
     Metrics: {
       _dd.appsec.enabled: 1.0,
-      _sampling_priority_v1: 2.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 2.0
     }
   }
 ]

--- a/tracer/test/snapshots/ThreadSampleNativeFormatParserTests.ParseSampleBuffer_fileName=Buffer000000.verified.txt
+++ b/tracer/test/snapshots/ThreadSampleNativeFormatParserTests.ParseSampleBuffer_fileName=Buffer000000.verified.txt
@@ -1,7 +1,7 @@
 ﻿[
   {
     Timestamp: 1642466714678000000,
-    StackTrace: 
+    StackTrace:
 "" #0 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x1 nid=0x4c38
 
 	at System.Threading.ManualResetEventSlim.Wait(unknown)
@@ -15,7 +15,7 @@
   },
   {
     Timestamp: 1642466714678000000,
-    StackTrace: 
+    StackTrace:
 "" #5 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x6 nid=0x4ddc
 
 	at System.Diagnostics.Tracing.EventPipeEventDispatcher.DispatchEventsToEventListeners(unknown)
@@ -33,7 +33,7 @@
   },
   {
     Timestamp: 1642466714678000000,
-    StackTrace: 
+    StackTrace:
 "" #8 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x9 nid=0x55c4
 
 	at System.Threading.ManualResetEventSlim.Wait(unknown)

--- a/tracer/test/snapshots/ThreadSampleNativeFormatParserTests.ParseSampleBuffer_fileName=Buffer000001.verified.txt
+++ b/tracer/test/snapshots/ThreadSampleNativeFormatParserTests.ParseSampleBuffer_fileName=Buffer000001.verified.txt
@@ -1,7 +1,7 @@
 ﻿[
   {
     Timestamp: 1642466715691000000,
-    StackTrace: 
+    StackTrace:
 "" #0 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x1 nid=0x4c38
 
 	at System.Threading.ManualResetEventSlim.Wait(unknown)
@@ -15,7 +15,7 @@
   },
   {
     Timestamp: 1642466715691000000,
-    StackTrace: 
+    StackTrace:
 "" #3 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x4 nid=0x247c
 
 	at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(unknown)
@@ -32,7 +32,7 @@
   },
   {
     Timestamp: 1642466715691000000,
-    StackTrace: 
+    StackTrace:
 "" #5 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x6 nid=0x4ddc
 
 	at System.Diagnostics.Tracing.EventPipeEventDispatcher.DispatchEventsToEventListeners(unknown)
@@ -50,7 +50,7 @@
   },
   {
     Timestamp: 1642466715691000000,
-    StackTrace: 
+    StackTrace:
 "" #8 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x9 nid=0x55c4
 
 	at Datadog.Trace.ThreadSampling.ThreadSampler.SampleReadingThread(unknown)

--- a/tracer/test/snapshots/ThreadSampleNativeFormatParserTests.ParseSampleBuffer_fileName=Buffer000002.verified.txt
+++ b/tracer/test/snapshots/ThreadSampleNativeFormatParserTests.ParseSampleBuffer_fileName=Buffer000002.verified.txt
@@ -1,7 +1,7 @@
 ﻿[
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 "" #0 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x1244
 
 	at System.Threading.WaitHandle.WaitOneNoCheck(unknown)
@@ -19,7 +19,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #3 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x4 nid=0x5370
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -32,7 +32,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Gate" #4 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x317c
 
 	at System.Threading.WaitHandle.WaitOneNoCheck(unknown)
@@ -43,7 +43,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #5 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x6 nid=0x94c
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -56,7 +56,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET Long Running Task" #7 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x84b8
 
 	at System.Threading.WaitHandle.WaitOneNoCheck(unknown)
@@ -73,7 +73,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #8 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0x9 nid=0x75e8
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -86,7 +86,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #9 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x5ebc
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -99,7 +99,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 "" #10 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x63c8
 
 	at System.Threading.Thread.Sleep(unknown)
@@ -110,7 +110,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET Long Running Task" #12 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xd nid=0x60a8
 
 	at System.Threading.WaitHandle.WaitOneNoCheck(unknown)
@@ -128,7 +128,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET Long Running Task" #13 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0xb68
 
 	at System.Threading.WaitHandle.WaitOneNoCheck(unknown)
@@ -146,7 +146,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET Long Running Task" #14 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xf nid=0x808
 
 	at System.Threading.WaitHandle.WaitOneNoCheck(unknown)
@@ -164,7 +164,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET Long Running Task" #15 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x272c
 
 	at System.Threading.WaitHandle.WaitOneNoCheck(unknown)
@@ -182,7 +182,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #16 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x6f08
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -195,7 +195,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #17 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x4914
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -208,7 +208,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 "In-proc Node (Default)" #18 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x7dbc
 
 	at System.Threading.WaitHandle.WaitMultiple(unknown)
@@ -222,7 +222,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 "RequestBuilder thread" #19 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x1f2c
 
 	at System.Threading.Monitor.Wait(unknown)
@@ -239,7 +239,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Wait" #20 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x5398
 
 	at System.Threading.WaitHandle.WaitAnyMultiple(unknown)
@@ -250,7 +250,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 "RequestBuilder thread" #21 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x19fc
 
 	at System.Threading.Monitor.Wait(unknown)
@@ -267,7 +267,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #22 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x4008
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -280,7 +280,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 ".NET ThreadPool Worker" #23 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x105c
 
 	at Kernel32.GetQueuedCompletionStatus(unknown)
@@ -293,7 +293,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 "RequestBuilder thread" #24 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x79b8
 
 	at System.Threading.Monitor.Wait(unknown)
@@ -310,7 +310,7 @@
   },
   {
     Timestamp: 1642466727710000000,
-    StackTrace: 
+    StackTrace:
 "In-proc Node (Default)" #25 prio=0 os_prio=0 cpu=0 elapsed=0 tid=0xffffffff nid=0x67c4
 
 	at System.Threading.WaitHandle.WaitMultiple(unknown)

--- a/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=False.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -78,9 +78,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -106,9 +106,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -134,9 +134,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -162,9 +162,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=True.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -78,9 +78,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -106,9 +106,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -134,9 +134,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -162,9 +162,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=False.verified.txt
@@ -19,9 +19,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -69,9 +69,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -94,9 +94,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -119,9 +119,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=True.verified.txt
@@ -19,9 +19,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -44,9 +44,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -69,9 +69,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -94,9 +94,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -119,9 +119,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -144,9 +144,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=False.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -78,9 +78,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -106,9 +106,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -134,9 +134,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -162,9 +162,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]

--- a/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=True.verified.txt
@@ -22,9 +22,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -50,9 +50,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -78,9 +78,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -106,9 +106,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -134,9 +134,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   },
   {
@@ -162,9 +162,9 @@
       version: 1.0.0
     },
     Metrics: {
-      _sampling_priority_v1: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
-      _dd.top_level: 1.0
+      _sampling_priority_v1: 1.0
     }
   }
 ]


### PR DESCRIPTION
## Why

Version 13.2.0 brings `DisableRequireUniquePrefix` which will be useful for Thread Sampling tests.

## What

Bump Verify.XUnit from 11.12.1 to 15.1.1

## Tests

CI
