### PR TITLE
Fix async profiling context

### DIFF
--- a/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -8,15 +8,12 @@
 using System;
 using System.Threading;
 using Datadog.Trace.ClrProfiler;
-using Datadog.Trace.Logging;
 
 namespace Datadog.Trace
 {
     internal class AsyncLocalScopeManager : IScopeManager, IScopeRawAccess
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AsyncLocalScopeManager));
-
-        private readonly AsyncLocal<Scope> _activeScope = new();
+        private readonly AsyncLocal<Scope> _activeScope;
 
         public AsyncLocalScopeManager(bool pushScopeToNative)
         {
@@ -61,7 +58,6 @@ namespace Datadog.Trace
         public void Close(Scope scope)
         {
             var current = Active;
-            var isRootSpan = scope.Parent == null;
 
             if (current == null || current != scope)
             {

--- a/tracer/test/Datadog.Trace.Tests/ThreadSampling/AsyncLocalScopeManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ThreadSampling/AsyncLocalScopeManagerTests.cs
@@ -4,39 +4,65 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace Datadog.Trace.Tests.ThreadSampling
 {
     public class AsyncLocalScopeManagerTests
     {
-        [Fact(Timeout = 5_000)]
+        [Fact(Timeout = 500_000)]
         public void PushAsyncContextToNative()
         {
-            // For the tests use a delegate that keeps track of current context
-            var tid2ProfilingCtx = new Dictionary<int, ProfilingContext>();
-
-            // Have the whole tests running a dedicated thread so Tasks get to
+            // Have the whole test running in a dedicated thread so Tasks get to
             // run in the thread pool, causing an async thread change. This is
             // not required on dev boxes but makes the test more robust for machines
             // with a smaller number of cores.
-            var testThread = new Thread(async () =>
+            // Running the test in a dedicated thread requires any exception throw
+            // in the test, eg.: an assert, to be flowed to the original test thread.
+            Exception testException = null;
+            var testThread = new Thread(() =>
             {
-                var mockSetProfilingContext = (ulong traceIdHigher, ulong traceIdLower, ulong spanId, int managedThreadId) =>
-                    {
-                        if (traceIdHigher == 0 && traceIdLower == 0 && spanId == 0)
-                        {
-                            tid2ProfilingCtx.Remove(managedThreadId);
-                            return;
-                        }
+                try
+                {
+                    // The actual code of the test will execute in different threads
+                    // because of that the thread must wait for its completion.
+                    TestThread().GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    testException = ex;
+                }
+            });
 
-                        tid2ProfilingCtx[managedThreadId] = new ProfilingContext
-                        {
-                            TraceIdHigher = traceIdHigher,
-                            TraceIdLower = traceIdLower,
-                            SpanId = spanId,
-                        };
+            testThread.Start();
+            testThread.Join();
+
+            // Check if there wasn't any assertion/exception on the test thread.
+            testException.Should().BeNull();
+
+            async Task TestThread()
+            {
+                // For the tests use a delegate that keeps track of current context
+                // in the test thread.
+                var tid2ProfilingCtx = new Dictionary<int, ProfilingContext>();
+
+                var mockSetProfilingContext = (ulong traceIdHigher, ulong traceIdLower, ulong spanId, int managedThreadId) =>
+                {
+                    if (traceIdHigher == 0 && traceIdLower == 0 && spanId == 0)
+                    {
+                        tid2ProfilingCtx.Remove(managedThreadId);
+                        return;
+                    }
+
+                    tid2ProfilingCtx[managedThreadId] = new ProfilingContext
+                    {
+                        TraceIdHigher = traceIdHigher,
+                        TraceIdLower = traceIdLower,
+                        SpanId = spanId,
                     };
+                };
 
                 var scopeManager = new AsyncLocalScopeManager(pushScopeToNative: true)
                 {
@@ -63,24 +89,24 @@ namespace Datadog.Trace.Tests.ThreadSampling
                 AssertProfilingContextMatchesScope(activeScope, currentManagedThreadId);
 
                 // Context must have been cleaned up from old thread.
-                Assert.False(tid2ProfilingCtx.ContainsKey(initialManagedThreadId));
+                tid2ProfilingCtx.Should().NotContainKey(initialManagedThreadId);
 
                 activeScope.Close();
 
-                Assert.False(tid2ProfilingCtx.ContainsKey(currentManagedThreadId));
-            });
+                tid2ProfilingCtx.Should().NotContainKey(currentManagedThreadId);
 
-            testThread.Start();
-            testThread.Join();
+                void AssertProfilingContextMatchesScope(Scope scope, int managedThreadId)
+                {
+                    var scopeCtx = scope.Span.Context;
+                    var profilingCtx = tid2ProfilingCtx[managedThreadId];
 
-            void AssertProfilingContextMatchesScope(Scope scope, int managedThreadId)
-            {
-                var scopeCtx = scope.Span.Context;
-                var profilingCtx = tid2ProfilingCtx[managedThreadId];
-
-                Assert.Equal(scopeCtx.TraceId.Higher, profilingCtx.TraceIdHigher);
-                Assert.Equal(scopeCtx.TraceId.Lower, profilingCtx.TraceIdLower);
-                Assert.Equal(scopeCtx.SpanId, profilingCtx.SpanId);
+                    using (new AssertionScope())
+                    {
+                        scopeCtx.TraceId.Higher.Should().Be(profilingCtx.TraceIdHigher);
+                        scopeCtx.TraceId.Lower.Should().Be(profilingCtx.TraceIdLower);
+                        scopeCtx.SpanId.Should().Be(profilingCtx.SpanId);
+                    }
+                }
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/ThreadSampling/AsyncLocalScopeManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ThreadSampling/AsyncLocalScopeManagerTests.cs
@@ -1,0 +1,83 @@
+// Modified by Splunk Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ThreadSampling
+{
+    public class AsyncLocalScopeManagerTests
+    {
+        [Fact(Timeout = 5_000)]
+        public async Task PushAsyncContextToNative()
+        {
+            // For the tests use a delegate that keeps track of current context
+            var tid2ProfilingCtx = new Dictionary<int, ProfilingContext>();
+            var mockSetProfilingContext = (ulong traceIdHigher, ulong traceIdLower, ulong spanId, int managedThreadId) =>
+                {
+                    if (traceIdHigher == 0 && traceIdLower == 0 && spanId == 0)
+                    {
+                        tid2ProfilingCtx.Remove(managedThreadId);
+                        return;
+                    }
+
+                    tid2ProfilingCtx[managedThreadId] = new ProfilingContext
+                    {
+                        TraceIdHigher = traceIdHigher,
+                        TraceIdLower = traceIdLower,
+                        SpanId = spanId,
+                    };
+                };
+
+            var scopeManager = new AsyncLocalScopeManager(pushScopeToNative: true)
+            {
+                SetProfilingContext = mockSetProfilingContext
+            };
+
+            var span = new Span(new SpanContext(TraceId.CreateFromInt(42), 41), DateTimeOffset.UtcNow, null);
+            Scope activeScope = scopeManager.Activate(span, false);
+
+            var currentManagedThreadId = Thread.CurrentThread.ManagedThreadId;
+            var initialManagedThreadId = currentManagedThreadId;
+
+            AssertProfilingContextMatchesScope(activeScope, currentManagedThreadId);
+
+            while (currentManagedThreadId == initialManagedThreadId)
+            {
+                await Task.Delay(100);
+                currentManagedThreadId = Thread.CurrentThread.ManagedThreadId;
+            }
+
+            // Context must have migrated to the new thread.
+            AssertProfilingContextMatchesScope(activeScope, currentManagedThreadId);
+
+            // Context must have been cleaned up from old thread.
+            Assert.False(tid2ProfilingCtx.ContainsKey(initialManagedThreadId));
+
+            activeScope.Close();
+
+            Assert.False(tid2ProfilingCtx.ContainsKey(currentManagedThreadId));
+
+            void AssertProfilingContextMatchesScope(Scope scope, int managedThreadId)
+            {
+                var scopeCtx = scope.Span.Context;
+                var profilingCtx = tid2ProfilingCtx[managedThreadId];
+
+                Assert.Equal(scopeCtx.TraceId.Higher, profilingCtx.TraceIdHigher);
+                Assert.Equal(scopeCtx.TraceId.Lower, profilingCtx.TraceIdLower);
+                Assert.Equal(scopeCtx.SpanId, profilingCtx.SpanId);
+            }
+        }
+
+        private class ProfilingContext
+        {
+            public ulong TraceIdHigher { get; set; }
+
+            public ulong TraceIdLower { get; set; }
+
+            public ulong SpanId { get; set; }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/ThreadSampling/AsyncLocalScopeManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ThreadSampling/AsyncLocalScopeManagerTests.cs
@@ -46,7 +46,9 @@ namespace Datadog.Trace.Tests.ThreadSampling
 
             while (currentManagedThreadId == initialManagedThreadId)
             {
+                var blockingThreadTask = Task.Run(() => Thread.Sleep(200));
                 await Task.Delay(100);
+                await blockingThreadTask;
                 currentManagedThreadId = Thread.CurrentThread.ManagedThreadId;
             }
 

--- a/tracer/test/Datadog.Trace.Tests/ThreadSampling/ThreadSampleNativeFormatParserTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ThreadSampling/ThreadSampleNativeFormatParserTests.cs
@@ -1,3 +1,5 @@
+// Modified by Splunk Inc.
+
 #if NETCOREAPP3_1_OR_GREATER
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
## Why

The profiling context is not being correctly handled for async/await usage.

## What

* Leveraged the `valueChangedHandler` callback to correctly update the native profiler when the async context flows between threads. Added a unit test to validate the approach, plus did some manual tests and validation. However, the approach used to simplify the tests adds a cost to the handler, we will look at optimizing it when doing the [story to benchmark span context of profiling](https://signalfuse.atlassian.net/browse/APMI-2394).

## Tests

* Manually validated that the problem was real and used the same app to validate the change
* Added unit tests to ensure that it works as expected
