### PR TITLE
Validate env input values

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -154,7 +154,7 @@ namespace Datadog.Trace.Configuration
         {
             return IsDefaultIngestRealm(ingestRealm) ?
                        // local collector
-                       new Uri("http://127.0.0.1:9943/v2/datapoint") :
+                       new Uri("http://localhost:9943/v2/datapoint") :
                        // direct ingest
                        new Uri($"https://ingest.{ingestRealm}.signalfx.com/v2/datapoint");
         }
@@ -163,7 +163,7 @@ namespace Datadog.Trace.Configuration
         {
             return IsDefaultIngestRealm(ingestRealm) ?
                        // local collector
-                       new Uri($"http://127.0.0.1:{agentPort}/api/v2/spans", UriKind.Absolute) :
+                       new Uri($"http://localhost:{agentPort}/api/v2/spans", UriKind.Absolute) :
                        // direct ingest
                        new Uri($"https://ingest.{ingestRealm}.signalfx.com/v2/trace", UriKind.Absolute);
         }
@@ -206,7 +206,7 @@ namespace Datadog.Trace.Configuration
         {
             var logsEndpointUrl = source?.GetString(ConfigurationKeys.LogsEndpointUrl) ??
                                   // default value
-                                  "http://127.0.0.1:4318/v1/logs";
+                                  "http://localhost:4318/v1/logs";
             LogsEndpointUrl = new Uri(logsEndpointUrl);
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/Helpers/SafeReadHelper.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Helpers/SafeReadHelper.cs
@@ -1,0 +1,77 @@
+using System;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Configuration.Helpers
+{
+    internal static class SafeReadHelper
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SafeReadHelper));
+
+        /// <summary>
+        /// Tries to read String from congiguration source as Uri. In case of:
+        /// Null source default is retuned,
+        /// Empty configuration default is returned,
+        /// Invalid configuraion error is logged and default is returned.
+        /// </summary>
+        /// <param name="source">Configuration source.</param>
+        /// <param name="key">Configuration key.</param>
+        /// <param name="defaultTo">In case of failure, default to this value.</param>
+        /// <returns>Config uri or default.</returns>
+        public static Uri SafeReadUri(this IConfigurationSource source, string key, Uri defaultTo)
+        {
+            string csValue = source?.GetString(key);
+
+            if (string.IsNullOrWhiteSpace(csValue))
+            {
+                return defaultTo;
+            }
+
+            try
+            {
+                return new Uri(csValue, UriKind.Absolute);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"[{key}]: Invalid configuration value '{csValue}'. Defaulting to '{defaultTo}'");
+            }
+
+            return defaultTo;
+        }
+
+        /// <summary>
+        /// Tries to read Int32 from configuration source. In case of:
+        /// Null source default is retuned,
+        /// Empty configuration default is returned,
+        /// Invalid configuraion error is logged and default is returned.
+        /// </summary>
+        /// <param name="source">Configuration source.</param>
+        /// <param name="key">Configuration key.</param>
+        /// <param name="defaultTo">In case of failure, default to this value.</param>
+        /// <param name="validators">Value validators.</param>
+        /// <returns>Config value or default.</returns>
+        public static int SafeReadInt32(this IConfigurationSource source, string key, int defaultTo, params Predicate<int>[] validators)
+        {
+            int? csValue = source?.GetInt32(key);
+
+            if (!csValue.HasValue)
+            {
+                return defaultTo;
+            }
+
+            if (validators.Length > 0)
+            {
+                foreach (var validator in validators)
+                {
+                    if (!validator(csValue.Value))
+                    {
+                        Log.Error($"[{key}]: Invalid configuration value '{csValue}'. Defaulting to '{defaultTo}'");
+
+                        return defaultTo;
+                    }
+                }
+            }
+
+            return csValue.Value;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/Helpers/SafeReadHelper.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Helpers/SafeReadHelper.cs
@@ -8,10 +8,10 @@ namespace Datadog.Trace.Configuration.Helpers
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SafeReadHelper));
 
         /// <summary>
-        /// Tries to read String from congiguration source as Uri. In case of:
-        /// Null source default is retuned,
+        /// Tries to read String from configuration source as Uri. In case of:
+        /// Null source default is returned,
         /// Empty configuration default is returned,
-        /// Invalid configuraion error is logged and default is returned.
+        /// Invalid configuration error is logged and default is returned.
         /// </summary>
         /// <param name="source">Configuration source.</param>
         /// <param name="key">Configuration key.</param>
@@ -40,9 +40,9 @@ namespace Datadog.Trace.Configuration.Helpers
 
         /// <summary>
         /// Tries to read Int32 from configuration source. In case of:
-        /// Null source default is retuned,
+        /// Null source default is returned,
         /// Empty configuration default is returned,
-        /// Invalid configuraion error is logged and default is returned.
+        /// Invalid configuration error is logged and default is returned.
         /// </summary>
         /// <param name="source">Configuration source.</param>
         /// <param name="key">Configuration key.</param>

--- a/tracer/src/Datadog.Trace/Configuration/Helpers/SafeReadHelper.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Helpers/SafeReadHelper.cs
@@ -1,3 +1,5 @@
+// Modified by Splunk Inc.
+
 using System;
 using Datadog.Trace.Logging;
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Datadog.Trace.Configuration.Helpers;
 using Datadog.Trace.Configuration.Types;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.PlatformHelpers;
@@ -164,11 +165,10 @@ namespace Datadog.Trace.Configuration
             TraceBatchInterval = source?.GetInt32(ConfigurationKeys.SerializationBatchInterval)
                         ?? 100;
 
-            RecordedValueMaxLength = source?.GetInt32(ConfigurationKeys.RecordedValueMaxLength) ?? DefaultRecordedValueMaxLength;
-            if (RecordedValueMaxLength < 0)
-            {
-                RecordedValueMaxLength = DefaultRecordedValueMaxLength;
-            }
+            RecordedValueMaxLength = source.SafeReadInt32(
+                key: ConfigurationKeys.RecordedValueMaxLength,
+                defaultTo: DefaultRecordedValueMaxLength,
+                validators: (value) => value >= 0);
 
             RouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
                                                    ?? true;
@@ -633,16 +633,12 @@ namespace Datadog.Trace.Configuration
         private static TimeSpan GetThreadSamplingPeriod(IConfigurationSource source)
         {
             // If you change any of these constants, check with thread_sampler.cpp first
-            var defaultSamplePeriod = TimeSpan.FromMilliseconds(value: 10000);
-            const int minimumSamplePeriod = 1000;
+            int period = source.SafeReadInt32(
+                key: ConfigurationKeys.ThreadSampling.Period,
+                defaultTo: 10_000,
+                validators: (value) => value >= 1_000);
 
-            var period = source?.GetInt32(ConfigurationKeys.ThreadSampling.Period);
-            if (!period.HasValue || period.Value < minimumSamplePeriod)
-            {
-                return defaultSamplePeriod;
-            }
-
-            return TimeSpan.FromMilliseconds(period.Value);
+            return TimeSpan.FromMilliseconds(period);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -28,7 +28,7 @@ public class ExporterSettingsTests
 
         var settings = new ExporterSettings(configuration);
 
-        settings.MetricsEndpointUrl.Should().Be("http://127.0.0.1:9943/v2/datapoint");
+        settings.MetricsEndpointUrl.Should().Be("http://localhost:9943/v2/datapoint");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ExporterSettingsTests
 
         var settings = new ExporterSettings(configuration);
 
-        settings.MetricsEndpointUrl.Should().Be("http://127.0.0.1:9943/v2/datapoint");
+        settings.MetricsEndpointUrl.Should().Be("http://localhost:9943/v2/datapoint");
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿// Modified by Splunk Inc.
+// Modified by Splunk Inc.
 
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
@@ -28,7 +28,7 @@ public class ExporterSettingsTests
 
         var settings = new ExporterSettings(configuration);
 
-        settings.MetricsEndpointUrl.Should().Be("http://localhost:9943/v2/datapoint");
+        settings.MetricsEndpointUrl.Should().Be("http://127.0.0.1:9943/v2/datapoint");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ExporterSettingsTests
 
         var settings = new ExporterSettings(configuration);
 
-        settings.MetricsEndpointUrl.Should().Be("http://localhost:9943/v2/datapoint");
+        settings.MetricsEndpointUrl.Should().Be("http://127.0.0.1:9943/v2/datapoint");
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/SafeReadHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/SafeReadHelperTests.cs
@@ -21,9 +21,9 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("SIGNALFX_FOO_URI", "", "http://www.temp.org", false)]
         public void SafeReadUri(string settingName, string settingValue, string expected, bool log)
         {
-            bool waslogged = false;
+            bool wasLogged = false;
 
-            SetupLogger(settingName, value => waslogged = value);
+            SetupLogger(settingName, value => wasLogged = value);
 
             var source = new NameValueConfigurationSource(new NameValueCollection
             {
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Tests.Configuration
             Uri value = source.SafeReadUri(settingName, new Uri("http://www.temp.org", UriKind.Absolute));
 
             Assert.Equal(new Uri(expected, UriKind.Absolute), value);
-            Assert.Equal(log, waslogged);
+            Assert.Equal(log, wasLogged);
         }
 
         [Theory]
@@ -42,20 +42,20 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("SIGNALFX_FOO_VALUE", "abc", 1, 0, false)]
         public void SafeReadInt32(string settingName, string settingValue, int expected, int condition, bool log)
         {
-            bool waslogged = false;
+            bool wasLogged = false;
 
-            SetupLogger(settingName, value => waslogged = value);
+            SetupLogger(settingName, value => wasLogged = value);
 
             var source = new NameValueConfigurationSource(new NameValueCollection
             {
                 { settingName, settingValue }
             });
 
-            // using foo validator setting > condtion
+            // using foo validator setting > condition
             int value = source.SafeReadInt32(settingName, expected, (val) => val > condition);
 
             Assert.Equal(expected, value);
-            Assert.Equal(log, waslogged);
+            Assert.Equal(log, wasLogged);
         }
 
         private void SetupLogger(string key, Action<bool> wasCalled)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/SafeReadHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/SafeReadHelperTests.cs
@@ -2,11 +2,16 @@
 
 using System;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+#if NETFRAMEWORK
 using System.Reflection;
+#endif
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Helpers;
+#if NETFRAMEWORK
 using Datadog.Trace.Logging;
 using Moq;
+#endif
 using Xunit;
 
 namespace Datadog.Trace.Tests.Configuration
@@ -19,11 +24,14 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("SIGNALFX_FOO_URI", "temp.org", "http://www.temp.org", true)]
         [InlineData("SIGNALFX_FOO_URI", "http//invalid.org", "http://www.temp.org", true)]
         [InlineData("SIGNALFX_FOO_URI", "", "http://www.temp.org", false)]
+        [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Supporting Test Exploit")]
         public void SafeReadUri(string settingName, string settingValue, string expected, bool log)
         {
+#if NETFRAMEWORK
             bool wasLogged = false;
 
             SetupLogger(settingName, value => wasLogged = value);
+#endif
 
             var source = new NameValueConfigurationSource(new NameValueCollection
             {
@@ -33,18 +41,24 @@ namespace Datadog.Trace.Tests.Configuration
             Uri value = source.SafeReadUri(settingName, new Uri("http://www.temp.org", UriKind.Absolute));
 
             Assert.Equal(new Uri(expected, UriKind.Absolute), value);
+
+#if NETFRAMEWORK
             Assert.Equal(log, wasLogged);
+#endif
         }
 
         [Theory]
         [InlineData("SIGNALFX_FOO_VALUE", "1", 1, 0, false)]
         [InlineData("SIGNALFX_FOO_VALUE", "-1", 1, 0, true)]
         [InlineData("SIGNALFX_FOO_VALUE", "abc", 1, 0, false)]
+        [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Supporting Test Exploit")]
         public void SafeReadInt32(string settingName, string settingValue, int expected, int condition, bool log)
         {
+#if NETFRAMEWORK
             bool wasLogged = false;
 
             SetupLogger(settingName, value => wasLogged = value);
+#endif
 
             var source = new NameValueConfigurationSource(new NameValueCollection
             {
@@ -55,9 +69,15 @@ namespace Datadog.Trace.Tests.Configuration
             int value = source.SafeReadInt32(settingName, expected, (val) => val > condition);
 
             Assert.Equal(expected, value);
+
+#if NETFRAMEWORK
             Assert.Equal(log, wasLogged);
+#endif
         }
 
+#if NETFRAMEWORK
+        // This test is exploiting .NET Framework issue, where static readonly variables could be overwritten using reflection.
+        // It is assumed that the NET FX test result is reflecting the same result for NET Core.
         private void SetupLogger(string key, Action<bool> wasCalled)
         {
             var log = typeof(SafeReadHelper).GetField("Log", BindingFlags.NonPublic | BindingFlags.Static);
@@ -83,5 +103,6 @@ namespace Datadog.Trace.Tests.Configuration
 
             log.SetValue(null, mock.Object);
         }
+#endif
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/SafeReadHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/SafeReadHelperTests.cs
@@ -1,0 +1,87 @@
+// Modified by Splunk Inc.
+
+using System;
+using System.Collections.Specialized;
+using System.Reflection;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Helpers;
+using Datadog.Trace.Logging;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class SafeReadHelperTests
+    {
+        [Theory]
+        [InlineData("SIGNALFX_FOO_URI", "http://www.temp.org", "http://www.temp.org", false)]
+        [InlineData("SIGNALFX_FOO_URI", "www.temp.org", "http://www.temp.org", true)]
+        [InlineData("SIGNALFX_FOO_URI", "temp.org", "http://www.temp.org", true)]
+        [InlineData("SIGNALFX_FOO_URI", "http//invalid.org", "http://www.temp.org", true)]
+        [InlineData("SIGNALFX_FOO_URI", "", "http://www.temp.org", false)]
+        public void SafeReadUri(string settingName, string settingValue, string expected, bool log)
+        {
+            bool waslogged = false;
+
+            SetupLogger(settingName, value => waslogged = value);
+
+            var source = new NameValueConfigurationSource(new NameValueCollection
+            {
+                { settingName, settingValue }
+            });
+
+            Uri value = source.SafeReadUri(settingName, new Uri("http://www.temp.org", UriKind.Absolute));
+
+            Assert.Equal(new Uri(expected, UriKind.Absolute), value);
+            Assert.Equal(log, waslogged);
+        }
+
+        [Theory]
+        [InlineData("SIGNALFX_FOO_VALUE", "1", 1, 0, false)]
+        [InlineData("SIGNALFX_FOO_VALUE", "-1", 1, 0, true)]
+        [InlineData("SIGNALFX_FOO_VALUE", "abc", 1, 0, false)]
+        public void SafeReadInt32(string settingName, string settingValue, int expected, int condition, bool log)
+        {
+            bool waslogged = false;
+
+            SetupLogger(settingName, value => waslogged = value);
+
+            var source = new NameValueConfigurationSource(new NameValueCollection
+            {
+                { settingName, settingValue }
+            });
+
+            // using foo validator setting > condtion
+            int value = source.SafeReadInt32(settingName, expected, (val) => val > condition);
+
+            Assert.Equal(expected, value);
+            Assert.Equal(log, waslogged);
+        }
+
+        private void SetupLogger(string key, Action<bool> wasCalled)
+        {
+            var log = typeof(SafeReadHelper).GetField("Log", BindingFlags.NonPublic | BindingFlags.Static);
+            var mock = new Mock<IDatadogLogger>();
+
+            mock.Setup(x => x.Error(It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+                .Callback<Exception, string, int, string>((ex, message, line, file) =>
+                {
+                    if (message.Contains(key))
+                    {
+                        wasCalled(true);
+                    }
+                });
+
+            mock.Setup(x => x.Error(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+                .Callback<string, int, string>((message, line, file) =>
+                {
+                    if (message.Contains(key))
+                    {
+                        wasCalled(true);
+                    }
+                });
+
+            log.SetValue(null, mock.Object);
+        }
+    }
+}


### PR DESCRIPTION
## Why

Some values need extra careful validation or parsing (eg string to Uri). 
If parsing error happened, application could enter to parse -> error -> log loop and cause instrumented app to slow down.
If validation error happened, it was just overwriting with default value, no logging. 

## What

Adds safe parsing and logs out if something was force changed in user configuration.
Adds minimal modifications to existing solution (extending).

## Tests

`SafeReadHelperTests.cs `
