### PR TITLE
Skip CosmosDB tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,13 +307,14 @@ jobs:
           3.1.x
           5.0.x
           6.0.x
-    - name: Start CosmosDB Emulator
-      if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
-      shell: powershell
-      run: |
-        Write-Host "Starting CosmosDB Emulator"
-        Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
-        Start-CosmosDbEmulator -Timeout 300
+    # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
+    # - name: Start CosmosDB Emulator
+    #   if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
+    #   shell: powershell
+    #   run: |
+    #     Write-Host "Starting CosmosDB Emulator"
+    #     Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
+    #     Start-CosmosDbEmulator -Timeout 300
     # Workaround around long name being hit in MultiDomainHostTests.WorksOutsideTheGAC tests
     - name: Subst for shorter path and Run Tests
       run: |

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        [SkippableTheory]
+        [SkippableTheory(Skip = "Cosmos emulator is too flaky at the moment")]
         [MemberData(nameof(PackageVersions.CosmosDb), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]


### PR DESCRIPTION
## Why

https://github.com/DataDog/dd-trace-dotnet/pull/2364

## What

Skip CosmosDB tests as in our upstream. It's to flaky.

