### PR TITLE
stabilize thread sampling test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ThreadSamplingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ThreadSamplingTests.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     {
                         if (index == 0 || index == logsData.Length - 1)
                         {
-                            // skip verification for the first and the last logs. Depends on env. the expected method can not start yest or is in a finished state
+                            // skip verification for the first and the last logs. Depending on env., the expected method may not have started or is already in a finished state
                             logRecords.Should().ContainSingle(x => ContainStackTraceForClassHierarchy(x));
                         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ThreadSamplingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ThreadSamplingTests.cs
@@ -41,22 +41,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var processResult = RunSampleAndWaitForExit(agent.Port, logCollectorPort: logsCollector.Port))
             {
                 var logsData = logsCollector.LogsData.ToArray();
-                // The application works for 5 seconds with debug logging enabled we expect at least 2 attempts of thread sampling in CI.
-                // On a dev box it is typical to get at least 3 but the CI machines seem slower, using 2
-                logsData.Length.Should().BeGreaterOrEqualTo(expected: 2);
+                // The application works for 6 seconds with debug logging enabled we expect at least 2 attempts of thread sampling in CI.
+                // On a dev box it is typical to get at least 4 but the CI machines seem slower, using 3
+                logsData.Length.Should().BeGreaterOrEqualTo(expected: 3);
 
                 var settings = VerifyHelper.GetThreadSamplingVerifierSettings();
                 settings.UseTextForParameters("OnlyCommonAttributes");
 
-                foreach (var data in logsData)
-                {
-                    var logRecords = data.ResourceLogs[0].InstrumentationLibraryLogs[0].Logs;
+                await DumpLogRecords(logsData);
 
-                    await DumpLogRecords(data);
+                for (var index = 0; index < logsData.Length; index++)
+                {
+                    var data = logsData[index];
+                    var logRecords = data.ResourceLogs[0].InstrumentationLibraryLogs[0].Logs;
 
                     using (new AssertionScope())
                     {
-                        logRecords.Should().ContainSingle(x => ContainStackTraceForClassHierarchy(x));
+                        if (index == 0 || index == logsData.Length - 1)
+                        {
+                            // skip verification for the first and the last logs. Depends on env. the expected method can not start yest or is in a finished state
+                            logRecords.Should().ContainSingle(x => ContainStackTraceForClassHierarchy(x));
+                        }
+
                         AllShouldHaveCorrectAttributes(logRecords);
                         AllBodiesShouldHaveCorrectFormat(logRecords);
                     }
@@ -106,15 +112,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 "\tat ClassA.MethodA(unknown)\n");
         }
 
-        private async Task DumpLogRecords(LogsData data)
+        private async Task DumpLogRecords(LogsData[] logsData)
         {
-            await using var memoryStream = new MemoryStream();
-            await System.Text.Json.JsonSerializer.SerializeAsync(memoryStream, data);
-            memoryStream.Position = 0;
-            using var sr = new StreamReader(memoryStream);
-            var readToEnd = await sr.ReadToEndAsync();
+            foreach (var data in logsData)
+            {
+                await using var memoryStream = new MemoryStream();
+                await System.Text.Json.JsonSerializer.SerializeAsync(memoryStream, data);
+                memoryStream.Position = 0;
+                using var sr = new StreamReader(memoryStream);
+                var readToEnd = await sr.ReadToEndAsync();
 
-            Output.WriteLine(readToEnd);
+                Output.WriteLine(readToEnd);
+            }
         }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.ThreadSampling/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ThreadSampling/Program.cs
@@ -29,7 +29,7 @@ internal static class ClassD
     public static void MethodD()
     {
         Console.WriteLine("Thread.Sleep - starting");
-        Thread.Sleep(TimeSpan.FromSeconds(value: 5));
+        Thread.Sleep(TimeSpan.FromSeconds(value: 6));
         Console.WriteLine("Thread.Sleep - finished");
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.ThreadSampling/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ThreadSampling/Program.cs
@@ -29,7 +29,7 @@ internal static class ClassD
     public static void MethodD()
     {
         Console.WriteLine("Thread.Sleep - starting");
-        Thread.Sleep(TimeSpan.FromSeconds(value: 6));
+        Thread.Sleep(TimeSpan.FromSeconds(6));
         Console.WriteLine("Thread.Sleep - finished");
     }
 }


### PR DESCRIPTION
## Why

Make the test more stable

## What

Thread sampling test. Based on what I see in the logs. The expected stack trace sometimes is not available for the first logs data. I expect that similar scenario can occur for the last logs (Tread.Sleep finished).

Extending Thread sleep timeout to 6 seconds to make at least 3 data logs.

## Tests

CI
