### PR TITLE
Fix Kafka tests stability

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -69,10 +69,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             VerifyProducerSpanProperties(successfulProducerSpans, GetSuccessfulResourceName("Produce", topic), ExpectedSuccessProducerSpans + ExpectedTombstoneProducerSpans);
             VerifyProducerSpanProperties(errorProducerSpans, ErrorProducerResourceName, ExpectedErrorProducerSpans);
 
-            allProducerSpans.Where(span => span.Name == $"{topic} send").Should().HaveCount(ExpectedSuccessProducerSpans + ExpectedTombstoneProducerSpans);
-            allProducerSpans.Where(span => span.Name == $"INVALID-TOPIC send").Should().HaveCount(ExpectedErrorProducerSpans);
-            allConsumerSpans.Where(span => span.Name == $"{topic} receive").Should().HaveCount(ExpectedConsumerSpans);
-
             // Only successful spans with a delivery handler will have an offset
             successfulProducerSpans
                .Where(span => span.Tags.ContainsKey(Tags.KafkaOffset))


### PR DESCRIPTION
## Why

Extra assertions added by SFX causing Kafka tests to be unstable. 

## What

* removing extra tests, keeping test more similar to the upstream.