### PR TITLE
fix condition in thread sampling test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ThreadSamplingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ThreadSamplingTests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     using (new AssertionScope())
                     {
-                        if (index == 0 || index == logsData.Length - 1)
+                        if (index != 0 && index != logsData.Length - 1)
                         {
                             // skip verification for the first and the last logs. Depending on env., the expected method may not have started or is already in a finished state
                             logRecords.Should().ContainSingle(x => ContainStackTraceForClassHierarchy(x));


### PR DESCRIPTION
## Why

Fix mistake from previous PR

## What

Avoid checking stack traces for the first and the last sample.

## Tests

CI
