### PR TITLE
Update instructions to use SIGNALFX_REALM

### DIFF
--- a/docs/azure-instrumentation.md
+++ b/docs/azure-instrumentation.md
@@ -17,7 +17,7 @@
    | `SIGNALFX_SERVICE_NAME` | `my-service-name` | Name of the instrumented service. |
    | `SIGNALFX_ENV` | `production` | Deployment environment of the instrumented service. |
    | `SIGNALFX_ACCESS_TOKEN` | `[splunk-access-token]` | Access token. See [here](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html) to learn how to obtain one. |
-   | `SIGNALFX_ENDPOINT_URL` |  `https://ingest.[splunk-realm].signalfx.com/v2/trace` | In the endpoint URL, `splunk-realm` is the [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints). For example, `us0`. |
+   | `SIGNALFX_REALM` | `[splunk-realm]` | [O11y realm](https://dev.splunk.com/observability/docs/realms_in_endpoints). For example, `us0`. |
 
 6. Restart the application in App Service.
 


### PR DESCRIPTION
## Why

Less configuration when metrics is enabled and easier to set.

## What

Update Azure instrumentation instructions to use SIGNALFX_REALM instead of SIGNALFX_ENDPOINT_URL

## Tests

None