### PR TITLE
Adjust naming convention

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -47,14 +47,14 @@ static ICorProfilerInfo* profilerInfo; // After feature sets settle down, perhap
 bool ThreadSampling_ShouldProduceThreadSample()
 {
     std::lock_guard<std::mutex> guard(bufferLock);
-    return bufferA == NULL || bufferB == NULL;
+    return bufferA == nullptr || bufferB == nullptr;
 }
 void ThreadSampling_RecordProducedThreadSample(std::vector<unsigned char>* buf)
 {
     std::lock_guard<std::mutex> guard(bufferLock);
-    if (bufferA == NULL) {
+    if (bufferA == nullptr) {
         bufferA = buf;
-    } else if (bufferB == NULL) {
+    } else if (bufferB == nullptr) {
         bufferB = buf;
     } else {
         trace::Logger::Warn("Unexpected buffer drop in ThreadSampling_RecordProducedThreadSample");
@@ -64,26 +64,26 @@ void ThreadSampling_RecordProducedThreadSample(std::vector<unsigned char>* buf)
 // Can return 0 if none are pending
 int32_t ThreadSampling_ConsumeOneThreadSample(int32_t len, unsigned char* buf)
 {
-    if (len <= 0 || buf == NULL)
+    if (len <= 0 || buf == nullptr)
     {
         trace::Logger::Warn("Unexpected 0/null buffer to ThreadSampling_ConsumeOneThreadSample");
         return 0;
     }
-    std::vector<unsigned char>* toUse = NULL;
+    std::vector<unsigned char>* toUse = nullptr;
     {
         std::lock_guard<std::mutex> guard(bufferLock);
-        if (bufferA != NULL)
+        if (bufferA != nullptr)
         {
             toUse = bufferA;
-            bufferA = NULL;
+            bufferA = nullptr;
         }
-        else if (bufferB != NULL)
+        else if (bufferB != nullptr)
         {
             toUse = bufferB;
-            bufferB = NULL;
+            bufferB = nullptr;
         }
     }
-    if (toUse == NULL)
+    if (toUse == nullptr)
     {
         return 0;
     }
@@ -107,7 +107,7 @@ public:
 
     COMPtrHolder(MetaInterface* ptr)
     {
-        if (ptr != NULL)
+        if (ptr != nullptr)
         {
             ptr->AddRef();
         }
@@ -116,7 +116,7 @@ public:
 
     ~COMPtrHolder()
     {
-        if (m_ptr != NULL)
+        if (m_ptr != nullptr)
         {
             m_ptr->Release();
             m_ptr = NULL;
@@ -175,7 +175,7 @@ ThreadSamplesBuffer::ThreadSamplesBuffer(std::vector<unsigned char>* buf) : buff
 }
 ThreadSamplesBuffer ::~ThreadSamplesBuffer()
 {
-    buffer = NULL; // specifically don't delete as this is done by RecordProduced/ConsumeOneThreadSample
+    buffer = nullptr; // specifically don't delete as this is done by RecordProduced/ConsumeOneThreadSample
 }
 
 #define CHECK_SAMPLES_BUFFER_LENGTH() {  if (buffer->size() >= SAMPLES_BUFFER_MAXIMUM_SIZE) { return; } }
@@ -287,12 +287,12 @@ class SamplingHelper
 {
 public:
     // These are permanent parts of the helper object
-    ICorProfilerInfo10* info10 = NULL;
+    ICorProfilerInfo10* info10 = nullptr;
     NameCache functionNameCache;
     NameCache classNameCache;
     // These cycle every sample and/or are owned externally
-    ThreadSamplesBuffer* curWriter = NULL;
-    std::vector<unsigned char>* curBuffer = NULL;
+    ThreadSamplesBuffer* curWriter = nullptr;
+    std::vector<unsigned char>* curBuffer = nullptr;
     SamplingStatistics stats;
 
     SamplingHelper() : functionNameCache(MAX_FUNCTION_NAME_CACHE_SIZE), classNameCache(MAX_CLASS_NAME_CACHE_SIZE), stats()
@@ -316,8 +316,8 @@ public:
     {
         ThreadSampling_RecordProducedThreadSample(curBuffer);
         delete curWriter;
-        curWriter = NULL;
-        curBuffer = NULL;
+        curWriter = nullptr;
+        curBuffer = nullptr;
         stats = SamplingStatistics();
     }
 
@@ -336,7 +336,7 @@ private:
             return;
         }
 
-        hr = info10->GetClassIDInfo2(classId, &modId, &classToken, &parentClassID, 0, NULL, NULL);
+        hr = info10->GetClassIDInfo2(classId, &modId, &classToken, &parentClassID, 0, nullptr, nullptr);
         if (CORPROF_E_CLASSID_IS_ARRAY == hr)
         {
             // We have a ClassID of an array.
@@ -373,7 +373,7 @@ private:
 
         WCHAR wName[MAX_CLASS_NAME_LEN];
         DWORD dwTypeDefFlags = 0;
-        hr = pMDImport->GetTypeDefProps(classToken, wName, MAX_CLASS_NAME_LEN, NULL, &dwTypeDefFlags, NULL);
+        hr = pMDImport->GetTypeDefProps(classToken, wName, MAX_CLASS_NAME_LEN, nullptr, &dwTypeDefFlags, nullptr);
         if (FAILED(hr))
         {
             Logger::Debug("GetTypeDefProps failed: ", hr);
@@ -396,7 +396,7 @@ private:
         ModuleID moduleId = 0;
         mdToken token = 0;
 
-        HRESULT hr = info10->GetFunctionInfo2(funcID, frameInfo, &classId, &moduleId, &token, 0, NULL, NULL);
+        HRESULT hr = info10->GetFunctionInfo2(funcID, frameInfo, &classId, &moduleId, &token, 0, nullptr, nullptr);
         if (FAILED(hr))
         {
             Logger::Debug("GetFunctionInfo2 failed: ", hr);
@@ -415,7 +415,7 @@ private:
 
         WCHAR funcName[MAX_FUNC_NAME_LEN];
         funcName[0] = 0;
-        hr = pIMDImport->GetMethodProps(token, NULL, funcName, MAX_FUNC_NAME_LEN, 0, 0, NULL, NULL, NULL, NULL);
+        hr = pIMDImport->GetMethodProps(token, nullptr, funcName, MAX_FUNC_NAME_LEN, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
         if (FAILED(hr))
         {
             Logger::Debug("GetMethodProps failed: ", hr);
@@ -445,7 +445,7 @@ public:
     WSTRING* Lookup(FunctionID fid, COR_PRF_FRAME_INFO frame)
     {
         WSTRING* answer = functionNameCache.get(fid);
-        if (answer != NULL)
+        if (answer != nullptr)
         {
             return answer;
         }
@@ -459,7 +459,7 @@ public:
     void LookupClassName(ClassID cid, WSTRING& result)
     {
         WSTRING* answer = functionNameCache.get(cid);
-        if (answer != NULL)
+        if (answer != nullptr)
         {
             result.append(*answer);
             return;
@@ -485,7 +485,7 @@ HRESULT __stdcall FrameCallback(_In_ FunctionID funcId, _In_ UINT_PTR ip, _In_ C
 // Factored out from the loop to a separate function for easier auditing and control of the threadstate lock
 void CaptureSamples(ThreadSampler* ts, ICorProfilerInfo10* info10, SamplingHelper& helper)
 {
-    ICorProfilerThreadEnum* threadEnum = NULL;
+    ICorProfilerThreadEnum* threadEnum = nullptr;
     HRESULT hr = info10->EnumThreads(&threadEnum);
     if (FAILED(hr))
     {
@@ -502,7 +502,7 @@ void CaptureSamples(ThreadSampler* ts, ICorProfilerInfo10* info10, SamplingHelpe
         helper.stats.numThreads++;
         ThreadSpanContext spanContext = threadSpanContextMap[threadID];
         auto found = ts->managedTid2state.find(threadID);
-        if (found != ts->managedTid2state.end() && found->second != NULL)
+        if (found != ts->managedTid2state.end() && found->second != nullptr)
         {
             helper.curWriter->StartSample(threadID, found->second, spanContext);
         }
@@ -513,7 +513,7 @@ void CaptureSamples(ThreadSampler* ts, ICorProfilerInfo10* info10, SamplingHelpe
         }
 
         // Don't reuse the hr being used for the thread enum, especially since a failed snapshot isn't fatal
-        HRESULT snapshotHr = info10->DoStackSnapshot(threadID, &FrameCallback, COR_PRF_SNAPSHOT_DEFAULT, &helper, NULL, 0);
+        HRESULT snapshotHr = info10->DoStackSnapshot(threadID, &FrameCallback, COR_PRF_SNAPSHOT_DEFAULT, &helper, nullptr, 0);
         if (FAILED(snapshotHr))
         {
             Logger::Debug("DoStackSnapshot failed: ", snapshotHr);
@@ -651,7 +651,7 @@ void ThreadSampler::StartSampling(ICorProfilerInfo10* info10)
     profilerInfo = info10;
     this->info10 = info10;
 #ifdef _WIN32
-    HANDLE bgThread = CreateThread(NULL, 0, &SamplingThreadMain, this, 0, NULL);
+    HANDLE bgThread = CreateThread(nullptr, 0, &SamplingThreadMain, this, 0, nullptr);
 #else
     pthread_t thr;
     pthread_create(&thr, NULL, (void *(*)(void *)) &SamplingThreadMain, this);
@@ -672,7 +672,7 @@ void ThreadSampler::ThreadDestroyed(ThreadID threadId)
         std::lock_guard<std::mutex> guard(threadStateLock);
 
         ThreadState* state = managedTid2state[threadId];
-        if (state != NULL)
+        if (state != nullptr)
         {
             delete state;
         }
@@ -689,7 +689,7 @@ void ThreadSampler::ThreadAssignedToOSThread(ThreadID threadId, DWORD osThreadId
     std::lock_guard<std::mutex> guard(threadStateLock);
 
     ThreadState* state = managedTid2state[threadId];
-    if (state == NULL)
+    if (state == nullptr)
     {
         state = new ThreadState();
         managedTid2state[threadId] = state;
@@ -701,7 +701,7 @@ void ThreadSampler::ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR _n
     std::lock_guard<std::mutex> guard(threadStateLock);
 
     ThreadState* state = managedTid2state[threadId];
-    if (state == NULL)
+    if (state == nullptr)
     {
         state = new ThreadState();
         managedTid2state[threadId] = state;
@@ -719,7 +719,7 @@ WSTRING* NameCache::get(UINT_PTR key)
     auto found = map.find(key);
     if (found == map.end())
     {
-        return NULL;
+        return nullptr;
     }
     // This voodoo moves the single item in the iterator to the front of the list
     // (as it is now the most-recently-used)

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporter.cs
@@ -45,9 +45,9 @@ namespace Datadog.Trace.AlwaysOnProfiler
             // The same _logsData instance is used on all export messages. With the exception of the list of
             // LogRecords, the Logs property, all other fields are prepopulated. At this point the code just
             // need to create a LogRecord for each thread sample and add it to the Logs list.
-            List<LogRecord> logRecords = _logsData.ResourceLogs[0].InstrumentationLibraryLogs[0].Logs;
+            var logRecords = _logsData.ResourceLogs[0].InstrumentationLibraryLogs[0].Logs;
 
-            for (int i = 0; i < threadSamples.Count; i++)
+            for (var i = 0; i < threadSamples.Count; i++)
             {
                 var threadSample = threadSamples[i];
                 var logRecord = new LogRecord
@@ -63,7 +63,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
                 if (threadSample.SpanId != 0 || threadSample.TraceIdHigh != 0 || threadSample.TraceIdLow != 0)
                 {
-                    // TODO: Add tests and validate.
+                    // TODO Splunk: Add tests and validate.
                     logRecord.SpanId = BitConverter.GetBytes(threadSample.SpanId);
                     logRecord.TraceId = BitConverter.GetBytes(threadSample.TraceIdHigh).Concat(BitConverter.GetBytes(threadSample.TraceIdLow));
                 }
@@ -85,11 +85,9 @@ namespace Datadog.Trace.AlwaysOnProfiler
                 httpWebRequest.Method = "POST";
                 httpWebRequest.Headers.Add(CommonHttpHeaderNames.TracingEnabled, "false");
 
-                using (var stream = httpWebRequest.GetRequestStream())
-                {
-                    Vendors.ProtoBuf.Serializer.Serialize(stream, _logsData);
-                    stream.Flush();
-                }
+                using var stream = httpWebRequest.GetRequestStream();
+                Vendors.ProtoBuf.Serializer.Serialize(stream, _logsData);
+                stream.Flush();
             }
             catch (Exception ex)
             {
@@ -126,8 +124,8 @@ namespace Datadog.Trace.AlwaysOnProfiler
         /// </summary>
         private static class GdiProfilingConventions
         {
-            public const string OpenTelemetryProfiling = "otel.profiling";
-            public const string Version = "0.1.0";
+            private const string OpenTelemetryProfiling = "otel.profiling";
+            private const string Version = "0.1.0";
 
             public static LogsData CreateLogsData(IEnumerable<KeyValuePair<string, string>> additionalResources)
             {
@@ -158,13 +156,13 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
             private static class OpenTelemetry
             {
-                public static readonly InstrumentationLibrary InstrumentationLibrary = new InstrumentationLibrary
+                public static readonly InstrumentationLibrary InstrumentationLibrary = new()
                 {
                     Name = OpenTelemetryProfiling,
                     Version = Version
                 };
 
-                public static readonly Resource Resource = new Resource
+                public static readonly Resource Resource = new()
                 {
                     Attributes =
                     {
@@ -182,7 +180,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
             {
                 public static class Attributes
                 {
-                    public static readonly KeyValue Source = new KeyValue
+                    public static readonly KeyValue Source = new()
                     {
                         Key = "com.splunk.sourcetype",
                         Value = new AnyValue { StringValue = OpenTelemetryProfiling }

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
@@ -17,22 +17,22 @@ namespace Datadog.Trace.AlwaysOnProfiler
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ThreadSampleNativeFormatParser>();
         private static readonly bool IsLogLevelDebugEnabled = Log.IsEnabled(LogEventLevel.Debug);
 
-        private readonly byte[] buf;
-        private readonly int len;
-        private readonly Dictionary<int, string> codes;
-        private int pos;
+        private readonly byte[] _buffer;
+        private readonly int _length;
+        private readonly Dictionary<int, string> _codes;
+        private int _position;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ThreadSampleNativeFormatParser"/> class.
         /// </summary>
-        /// <param name="buf">byte array containing native thread samples format data</param>
-        /// <param name="len">how much of the buffer is actually used</param>
-        internal ThreadSampleNativeFormatParser(byte[] buf, int len)
+        /// <param name="buffer">byte array containing native thread samples format data</param>
+        /// <param name="length">how much of the buffer is actually used</param>
+        internal ThreadSampleNativeFormatParser(byte[] buffer, int length)
         {
-            this.buf = buf;
-            this.len = len;
-            this.pos = 0;
-            codes = new Dictionary<int, string>();
+            _buffer = buffer;
+            _length = length;
+            _position = 0;
+            _codes = new Dictionary<int, string>();
         }
 
         /// <summary>
@@ -42,23 +42,23 @@ namespace Datadog.Trace.AlwaysOnProfiler
         {
             uint batchThreadIndex = 0;
             var samples = new List<ThreadSample>();
-            ulong batchTimestampNanos = 0;
+            ulong batchTimestampNanoseconds = 0;
 
             // FIXME actually have this go somewhere in the future
-            while (pos < len)
+            while (_position < _length)
             {
-                byte op = buf[pos];
-                pos++;
-                if (op == OpCodes.StartBatch)
+                var operationCode = _buffer[_position];
+                _position++;
+                if (operationCode == OpCodes.StartBatch)
                 {
-                    int version = ReadInt();
+                    var version = ReadInt();
                     if (version != 1)
                     {
                         return null; // not able to parse
                     }
 
-                    long sampleStartMillis = ReadInt64();
-                    batchTimestampNanos = (ulong)sampleStartMillis * 1_000_000u;
+                    var sampleStartMillis = ReadInt64();
+                    batchTimestampNanoseconds = (ulong)sampleStartMillis * 1_000_000u;
 
                     if (IsLogLevelDebugEnabled)
                     {
@@ -70,14 +70,14 @@ namespace Datadog.Trace.AlwaysOnProfiler
                             sampleStart.ToLongTimeString());
                     }
                 }
-                else if (op == OpCodes.StartSample)
+                else if (operationCode == OpCodes.StartSample)
                 {
-                    int managedId = ReadInt();
-                    int nativeId = ReadInt();
-                    string threadName = ReadString();
-                    long traceIdHigh = ReadInt64();
-                    long traceIdLow = ReadInt64();
-                    long spanId = ReadInt64();
+                    var managedId = ReadInt();
+                    var nativeId = ReadInt();
+                    var threadName = ReadString();
+                    var traceIdHigh = ReadInt64();
+                    var traceIdLow = ReadInt64();
+                    var spanId = ReadInt64();
 
                     var threadIndex = batchThreadIndex++;
 
@@ -90,7 +90,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
                     var threadSample = new ThreadSample
                     {
-                        Timestamp = batchTimestampNanos,
+                        Timestamp = batchTimestampNanoseconds,
                         TraceIdHigh = traceIdHigh,
                         TraceIdLow = traceIdLow,
                         SpanId = spanId,
@@ -112,22 +112,22 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
                     while (code != 0)
                     {
-                        string value = null;
+                        string value;
                         if (code < 0)
                         {
                             value = ReadString();
-                            codes[-code] = value;
+                            _codes[-code] = value;
                         }
-                        else if (code > 0)
+                        else
                         {
-                            value = codes[code];
+                            value = _codes[code];
                         }
 
                         if (value != null)
                         {
                             stackTraceBuilder.Append("\tat ");
                             stackTraceBuilder.Append(value);
-                            stackTraceBuilder.Append("(unknown)\n"); // TODO placeholder for file name and lines numbers
+                            stackTraceBuilder.Append("(unknown)\n"); // TODO Splunk: placeholder for file name and lines numbers
                         }
 
                         code = ReadShort();
@@ -135,23 +135,23 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
                     if (threadName == ThreadSampler.BackgroundThreadName)
                     {
-                        // TODO: add configuration option to include the sampler thread. By default remove it.
+                        // TODO Splunk: add configuration option to include the sampler thread. By default remove it.
                         continue;
                     }
 
                     threadSample.StackTrace = stackTraceBuilder.ToString();
                     samples.Add(threadSample);
                 }
-                else if (op == OpCodes.EndBatch)
+                else if (operationCode == OpCodes.EndBatch)
                 {
                     // end batch, nothing here
                 }
-                else if (op == OpCodes.BatchStats)
+                else if (operationCode == OpCodes.BatchStats)
                 {
-                    int microsSuspended = ReadInt();
-                    int numThreads = ReadInt();
-                    int totalFrames = ReadInt();
-                    int numCacheMisses = ReadInt();
+                    var microsSuspended = ReadInt();
+                    var numThreads = ReadInt();
+                    var totalFrames = ReadInt();
+                    var numCacheMisses = ReadInt();
 
                     if (IsLogLevelDebugEnabled)
                     {
@@ -162,7 +162,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
                 }
                 else
                 {
-                    pos = len + 1; // FIXME improve error handling here
+                    _position = _length + 1; // FIXME improve error handling here
                 }
             }
 
@@ -171,52 +171,52 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
         private string ReadString()
         {
-            short len = ReadShort();
-            string s = new UnicodeEncoding().GetString(buf, pos, len * 2);
-            pos += 2 * len;
+            var length = ReadShort();
+            var s = new UnicodeEncoding().GetString(_buffer, _position, length * 2);
+            _position += 2 * length;
             return s;
         }
 
         private short ReadShort()
         {
-            short s1 = (short)(buf[pos] & 0xFF);
+            var s1 = (short)(_buffer[_position] & 0xFF);
             s1 <<= 8;
-            short s2 = (short)(buf[pos + 1] & 0xFF);
-            pos += 2;
+            var s2 = (short)(_buffer[_position + 1] & 0xFF);
+            _position += 2;
             return (short)(s1 + s2);
         }
 
         private int ReadInt()
         {
-            int i1 = buf[pos] & 0xFF;
+            var i1 = _buffer[_position] & 0xFF;
             i1 <<= 24;
-            int i2 = buf[pos + 1] & 0xFF;
+            var i2 = _buffer[_position + 1] & 0xFF;
             i2 <<= 16;
-            int i3 = buf[pos + 2] & 0xFF;
+            var i3 = _buffer[_position + 2] & 0xFF;
             i3 <<= 8;
-            int i4 = buf[pos + 3] & 0xFF;
-            pos += 4;
+            var i4 = _buffer[_position + 3] & 0xFF;
+            _position += 4;
             return i1 + i2 + i3 + i4;
         }
 
         private long ReadInt64()
         {
-            long l1 = buf[pos] & 0xFF;
+            long l1 = _buffer[_position] & 0xFF;
             l1 <<= 56;
-            long l2 = buf[pos + 1] & 0xFF;
+            long l2 = _buffer[_position + 1] & 0xFF;
             l2 <<= 48;
-            long l3 = buf[pos + 2] & 0xFF;
+            long l3 = _buffer[_position + 2] & 0xFF;
             l3 <<= 40;
-            long l4 = buf[pos + 3] & 0xFF;
+            long l4 = _buffer[_position + 3] & 0xFF;
             l4 <<= 32;
-            long l5 = buf[pos + 4] & 0xFF;
+            long l5 = _buffer[_position + 4] & 0xFF;
             l5 <<= 24;
-            long l6 = buf[pos + 5] & 0xFF;
+            long l6 = _buffer[_position + 5] & 0xFF;
             l6 <<= 16;
-            long l7 = buf[pos + 6] & 0xFF;
+            long l7 = _buffer[_position + 6] & 0xFF;
             l7 <<= 8;
-            long l8 = buf[pos + 7] & 0xFF;
-            pos += 8;
+            long l8 = _buffer[_position + 7] & 0xFF;
+            _position += 8;
             return l1 + l2 + l3 + l4 + l5 + l6 + l7 + l8;
         }
 

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
@@ -25,16 +25,16 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
         private static ImmutableTracerSettings _tracerSettings;
 
-        private static void ReadAndExportThreadSampleBatch(byte[] buf, ThreadSampleExporter exporter)
+        private static void ReadAndExportThreadSampleBatch(byte[] buffer, ThreadSampleExporter exporter)
         {
-            int read = NativeMethods.SignalFxReadThreadSamples(buf.Length, buf);
+            var read = NativeMethods.SignalFxReadThreadSamples(buffer.Length, buffer);
             if (read <= 0)
             {
                 // No data just return.
                 return;
             }
 
-            var parser = new ThreadSampleNativeFormatParser(buf, read);
+            var parser = new ThreadSampleNativeFormatParser(buffer, read);
             var threadSamples = parser.Parse();
 
             exporter.ExportThreadSamples(threadSamples);
@@ -42,7 +42,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
         private static void SampleReadingThread()
         {
-            var buf = new byte[BufferSize];
+            var buffer = new byte[BufferSize];
             var exporter = new ThreadSampleExporter(_tracerSettings);
 
             while (true)
@@ -51,8 +51,8 @@ namespace Datadog.Trace.AlwaysOnProfiler
                 try
                 {
                     // Call twice in quick succession to catch up any blips; the second will likely return 0 (no buffer)
-                    ReadAndExportThreadSampleBatch(buf, exporter);
-                    ReadAndExportThreadSampleBatch(buf, exporter);
+                    ReadAndExportThreadSampleBatch(buffer, exporter);
+                    ReadAndExportThreadSampleBatch(buffer, exporter);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Why

Cleanup POC.

## What

Adjust C# naming convention to the common standard together with some semi-auto r# fixes.
NULL->nullptr where possible for thread sampler.

## Tests

CI
