### PR TITLE
Lock all dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
@@ -124,9 +124,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - name: Build Docker image
       run: |
@@ -167,9 +167,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - run: ./tracer/build.cmd BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v2.3.1
@@ -192,9 +192,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - name: Build Docker image
       run: |
@@ -235,9 +235,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
@@ -257,9 +257,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - name: Build Docker image
       run: |
@@ -303,9 +303,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
@@ -342,9 +342,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - name: Build Docker image
       run: |
@@ -395,9 +395,9 @@ jobs:
     - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
-          2.1.x
-          3.1.x
-          5.0.x
+          2.1.818
+          3.1.416
+          5.0.405
           6.0.200
     - run: ./tracer/build.cmd BuildTracerHome PackageTracerHome BuildWindowsIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose build IIS containers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
     runs-on: ${{ matrix.machine }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -82,31 +82,31 @@ jobs:
     - name: Build tracer home
       run: ./tracer/build.cmd BuildTracerHome PackageTracerHome
     - name: Publish tracer-home
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         path: ${{ env.tracerHome }}
         name: ${{ matrix.machine }}-tracer-home
     - name: Publish Windows x86 MSI
       if: ${{ runner.os == 'Windows' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         path: ${{ env.artifacts }}/x86/en-us
         name: windows-msi-x86
     - name: Publish Windows x64 MSI
       if: ${{ runner.os == 'Windows' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         path: ${{ env.artifacts }}/x64/en-us
         name: windows-msi-x64
     - name: Publish Linux x64 packages
       if: ${{ runner.os == 'Linux' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         path: ${{ env.artifacts }}/linux-x64
         name: linux-x64-packages
     - name: Publish NuGet packages
       if: ${{ runner.os == 'Windows' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         path: ${{ env.artifacts }}/nuget/SignalFx.NET.Tracing.Azure.Site.Extension.*.nupkg
         name: nuget-packages
@@ -120,8 +120,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -147,7 +147,7 @@ jobs:
           dd-trace-dotnet/${{ matrix.base-image }}-builder \
           dotnet /build/bin/Debug/_build.dll BuildTracerHome ZipTracerHome
     - name: Publish Linux x64-musl packages
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         path: ${{ env.artifacts }}/linux-x64
         name: linux-x64-musl-packages
@@ -163,8 +163,8 @@ jobs:
     runs-on: ${{ matrix.machine }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -172,7 +172,7 @@ jobs:
           5.0.x
           6.0.200
     - run: ./tracer/build.cmd BuildTracerHome BuildAndRunManagedUnitTests
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2.3.1
       with:
         name: ${{ matrix.machine }}-managed-unit-tests-build_data
         path: tracer/build_data
@@ -188,8 +188,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -215,7 +215,7 @@ jobs:
           dd-trace-dotnet/${{ matrix.base-image }}-tester \
           dotnet /build/bin/Debug/_build.dll BuildTracerHome BuildAndRunManagedUnitTests
     - name: Publish managed tests results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         name: ${{ matrix.base-image }}-managed-unit-tests-build_data
         path: tracer/build_data
@@ -231,8 +231,8 @@ jobs:
     runs-on: ${{ matrix.machine }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -253,8 +253,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -280,7 +280,7 @@ jobs:
           dd-trace-dotnet/${{ matrix.base-image }}-builder \
           dotnet /build/bin/Debug/_build.dll BuildTracerHome BuildAndRunNativeUnitTests
     - name: Publish native tests results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         name: ${{ matrix.base-image }}-native-unit-tests-build_data
         path: tracer/build_data
@@ -299,8 +299,8 @@ jobs:
     runs-on: ${{ matrix.machine }}
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -321,7 +321,7 @@ jobs:
         subst y: .
         y:
         ./tracer/build.cmd BuildTracerHome ${{ matrix.target }} -Framework ${{ matrix.framework }} -TargetPlatform ${{ matrix.platform }} --PrintDriveSpace
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2.3.1
       with:
         name: ${{ matrix.machine }}-integration-tests-${{ matrix.platform }}-${{ matrix.framework }}-${{ matrix.target }}-build_data
         path: tracer/build_data
@@ -338,8 +338,8 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -374,7 +374,7 @@ jobs:
           -e Verify_DisableClipboard=true \
           -e DiffEngine_Disabled=true \
           IntegrationTests
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2.3.1
       with:
         name: ${{ matrix.base-image }}-integration-tests-${{ matrix.framework }}-build_data
         path: tracer/build_data
@@ -391,8 +391,8 @@ jobs:
         framework: [ netcoreapp3.1, net461 ]
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v2.4.0
+    - uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: | 
           2.1.x
@@ -413,7 +413,7 @@ jobs:
     - name: docker-compose stop services
       run: docker-compose down
       if: (${{ job.status }} != 'cancelled')
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2.3.1
       with:
         name: windows-iis-integration-tests-${{ matrix.platform }}-build_data
         path: tracer/build_data

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -17,7 +17,7 @@ jobs:
       baseImage: ${{ matrix.baseImage }}
       dotnetSdkVersion: 6.0.200
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.4.0
     - name: Build Docker image
       run: |
         docker build \
@@ -36,7 +36,7 @@ jobs:
           dd-trace-dotnet/${baseImage}-builder \
           dotnet /build/bin/Debug/_build.dll Clean BuildTracerHome ZipTracerHome
     - name: Upload Linux x64 packages
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.3.1
       with:
         name: artifacts
         path: ./tracer/src/bin/artifacts/linux-x64
@@ -47,8 +47,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - run: git config --system core.longpaths true
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: | 
             2.1.x
@@ -58,12 +58,12 @@ jobs:
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Upload Windows MSI
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.3.1
         with:
           name: artifacts
           path: tracer/bin/artifacts/*/en-us
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.3.1
         with:
           name: nuget
           path: tracer/bin/artifacts/nuget/SignalFx.NET.Tracing.Azure.Site.Extension.*.nupkg
@@ -76,8 +76,8 @@ jobs:
       contents: write
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/download-artifact@v2.1.0
         with:
           path: .
       - name: Extract Version from Tag

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -51,9 +51,9 @@ jobs:
       - uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: | 
-            2.1.x
-            3.1.x
-            5.0.x
+            2.1.818
+            3.1.416
+            5.0.405
             6.0.200
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   verify_source_generators:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -13,9 +13,9 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.4.0
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: '6.0.200'
 

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,6 +1,8 @@
 ﻿ARG DOTNETSDK_VERSION
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.14 as base
 
+# SECURITY NOTE: Exception is made for APK packages, 
+# no need to lock versions
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache --update \

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -13,7 +13,7 @@ RUN apk update \
         ruby \
         ruby-dev \
         ruby-etc \
-    && gem install --no-document fpm
+    && gem install --no-document fpm --version 1.14.1
 
 ENV IsAlpine=true
 

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -1,5 +1,5 @@
 # We used a fixed, older version of debian for linking reasons
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-buster-slim as base
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.14-buster-slim as base
 ARG DOTNETSDK_VERSION
 
 # Based on https://github.com/dotnet/dotnet-docker/blob/34c81d5f9c8d56b36cc89da61702ccecbf00f249/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
@@ -19,20 +19,20 @@ ENV \
 RUN apt-get update \
     && apt-get -y upgrade \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
-        git=1:2.30.2-1 \
-        procps=2:3.3.17-5 \
-        wget=1.21-1+deb11u1 \
-        curl=7.74.0-1.3+deb11u1 \
-        cmake=3.18.4-2+deb11u1 \
-        make=4.3-4.1 \
-        llvm=1:11.0-51+nmu5 \
-        clang=1:11.0-51+nmu5 \
-        gcc=4:10.2.1-1 \
-        build-essential=12.9 \
-        rpm=4.16.1.2+dfsg1-3 \
-        ruby=1:2.7+2 \
-        ruby-dev=1:2.7+2 \
-        rubygems=3.2.5-2 \
+        git=1:2.20.1-2+deb10u3 \
+        procps=2:3.3.15-2 \
+        wget=1.20.1-1.1 \
+        curl=7.64.0-4+deb10u2 \
+        cmake=3.13.4-1 \
+        make=4.2.1-1.2 \
+        llvm=1:7.0-47 \
+        clang=1:7.0-47 \
+        gcc=4:8.3.0-1 \
+        build-essential=12.6 \
+        rpm=4.14.2.1+dfsg1-1 \
+        ruby=1:2.5.1 \
+        ruby-dev=1:2.5.1 \
+        rubygems-integration=1.11+deb10u1 \
     && gem install --no-document fpm --version 1.14.1 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -19,21 +19,21 @@ ENV \
 RUN apt-get update \
     && apt-get -y upgrade \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
-        git \
-        procps \
-        wget \
-        curl \
-        cmake \
-        make \
-        llvm \
-        clang \
-        gcc \
-        build-essential \
-        rpm \
-        ruby \
-        ruby-dev \
-        rubygems \
-    && gem install --no-document fpm \
+        git=1:2.30.2-1 \
+        procps=2:3.3.17-5 \
+        wget=1.21-1+deb11u1 \
+        curl=7.74.0-1.3+deb11u1 \
+        cmake=3.18.4-2+deb11u1 \
+        make=4.3-4.1 \
+        llvm=1:11.0-51+nmu5 \
+        clang=1:11.0-51+nmu5 \
+        gcc=4:10.2.1-1 \
+        build-essential=12.9 \
+        rpm=4.16.1.2+dfsg1-3 \
+        ruby=1:2.7+2 \
+        ruby-dev=1:2.7+2 \
+        rubygems=3.2.5-2 \
+    && gem install --no-document fpm --version 1.14.1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the .NET SDK


### PR DESCRIPTION
## Why

According to the security doc, all dependencies must be locked to specific version

## What

Locking:
* Github Actions base image versions
* APT repo packages for Debian
* (TODO) APK repo package for Alpine - Currently unsure what the final solution will be. Still under discussions in security doc.

