### PR TITLE
pin .NET to 6.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -127,7 +127,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - name: Build Docker image
       run: |
         docker build \
@@ -170,7 +170,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - run: ./tracer/build.cmd BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v2
       with:
@@ -195,7 +195,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - name: Build Docker image
       run: |
         docker build \
@@ -238,7 +238,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -260,7 +260,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - name: Build Docker image
       run: |
         docker build \
@@ -306,7 +306,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
     #   if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
@@ -345,7 +345,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - name: Build Docker image
       run: |
         docker build \
@@ -398,7 +398,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
     - run: ./tracer/build.cmd BuildTracerHome PackageTracerHome BuildWindowsIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose build IIS containers
       run: docker-compose build --build-arg dotnet_tracer_msi=.$relativeArtifacts/{{ matrix.platform }}/en-us/*.msi --build-arg ENABLE_32_BIT=${{ env.enable32bit }} IntegrationTests.IIS

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -54,7 +54,7 @@ jobs:
             2.1.x
             3.1.x
             5.0.x
-            6.0.x
+            6.0.100
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Upload Windows MSI

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.100'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 BuildTracerHome


### PR DESCRIPTION
## Why

To avoid fails in integration tests

## What

pin .NET to 6.0.1

## Tests

CI

## Notes

Jira item created to bump to 6.0.2. It fails locally if you have .NET 6.0.2/VS 2022 v 17.1