### PR TITLE
Bump .NET to 6.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   buildConfiguration: Release
-  dotnetSdkVersion: 6.0.100
+  dotnetSdkVersion: 6.0.102
   relativeTracerHome: /tracer/src/bin/windows-tracer-home
   relativeArtifacts: /tracer/src/bin/artifacts
   binDir: ${{ github.workspace }}/tracer/src/bin
@@ -72,7 +72,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -127,7 +127,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - name: Build Docker image
       run: |
         docker build \
@@ -170,7 +170,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - run: ./tracer/build.cmd BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v2
       with:
@@ -195,7 +195,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - name: Build Docker image
       run: |
         docker build \
@@ -238,7 +238,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -260,7 +260,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - name: Build Docker image
       run: |
         docker build \
@@ -306,7 +306,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
     #   if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
@@ -345,7 +345,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - name: Build Docker image
       run: |
         docker build \
@@ -398,7 +398,7 @@ jobs:
           2.1.x
           3.1.x
           5.0.x
-          6.0.100
+          6.0.200
     - run: ./tracer/build.cmd BuildTracerHome PackageTracerHome BuildWindowsIntegrationTests -Framework ${{ matrix.framework }}
     - name: docker-compose build IIS containers
       run: docker-compose build --build-arg dotnet_tracer_msi=.$relativeArtifacts/{{ matrix.platform }}/en-us/*.msi --build-arg ENABLE_32_BIT=${{ env.enable32bit }} IntegrationTests.IIS

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     env:
       baseImage: ${{ matrix.baseImage }}
-      dotnetSdkVersion: 6.0.100
+      dotnetSdkVersion: 6.0.102
     steps:
     - uses: actions/checkout@v2
     - name: Build Docker image
@@ -54,7 +54,7 @@ jobs:
             2.1.x
             3.1.x
             5.0.x
-            6.0.100
+            6.0.200
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Upload Windows MSI

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '6.0.200'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 BuildTracerHome

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,7 +291,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.200}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -348,7 +348,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.200}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -391,7 +391,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.200}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -601,7 +601,9 @@ partial class Build
                 $"src/**/bin/{BuildConfiguration}",
                 $"src/Datadog.Trace.Tools.Runner/obj/{BuildConfiguration}",
                 $"test/Datadog.Trace.TestHelpers/**/bin/{BuildConfiguration}",
+                $"test/Datadog.Trace.TestHelpers/obj/{BuildConfiguration}",
                 $"test/OpenTelemetry.TestHelpers/**/bin/{BuildConfiguration}",
+                $"test/OpenTelemetry.TestHelpers/obj/{BuildConfiguration}",
                 $"test/test-applications/integrations/dependency-libs/**/bin/{BuildConfiguration}"
             );
 

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="signalfx-dotnet-tracing/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=6.0.100 \
+   --build-arg DOTNETSDK_VERSION=6.0.200 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/debian.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
## Why

Revert downgrade from yesterday.

## What

Bump .NET SDK to 6.0.200
Fix build dependencies

## Tests

CI