### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,7 @@ updates:
 
       # Lock Microsoft.Build.Framework for widest compatibility when instrumenting builds
       - dependency-name: "Microsoft.Build.Framework"
+    open-pull-requests-limit: 0 # disable version updates
 
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.OpenTracing"
@@ -77,6 +78,7 @@ updates:
       - dependency-name: "System.Reflection.Emit.Lightweight"
       ### End Datadog.Trace.csproj ignored dependencies
     open-pull-requests-limit: 0 # disable version updates
+
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
     schedule:


### PR DESCRIPTION
We do not need to bump things that are being bumped by upstream. Example: https://github.com/signalfx/signalfx-dotnet-tracing/pull/397

