### PR TITLE
bump .NET SDK in docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   buildConfiguration: Release
-  dotnetSdkVersion: 6.0.102
+  dotnetSdkVersion: 6.0.200
   relativeTracerHome: /tracer/src/bin/windows-tracer-home
   relativeArtifacts: /tracer/src/bin/artifacts
   binDir: ${{ github.workspace }}/tracer/src/bin

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     env:
       baseImage: ${{ matrix.baseImage }}
-      dotnetSdkVersion: 6.0.102
+      dotnetSdkVersion: 6.0.200
     steps:
     - uses: actions/checkout@v2
     - name: Build Docker image


### PR DESCRIPTION
## Why

When I created previous PR the docker images was not available.

## What

Update .NET SDK to 6.0.200 also on docker images.

## Tests

CI
