### PR TITLE
StartupLogger exceptions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,38 @@ to receive telemetry data.
 
 ### Installation
 
+### Automated download and installation for Windows
+
+Run in PowerShell as administrator:
+
+```powershell
+# signalfx-dotnet-tracing github repository API
+$api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/latest"
+
+# determine OS architecture
+$os_bits = (Get-CimInstance Win32_OperatingSystem).OSArchitecture
+$os_arch = (&{If($os_bits -eq "64-bit") {"x64"} Else {"x86"}})
+
+# File pattern to search for
+$pattern = "signalfx-dotnet-tracing-*-$os_arch.msi"
+
+# Find latest MSI to download
+$download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -like $pattern } | Select-Object -Property browser_download_url,name
+
+# Download installer MSI to Temp
+$msi = Join-Path $env:temp $download.name
+Invoke-WebRequest -Uri $download.browser_download_url -OutFile $msi
+
+# Install downloaded MSI
+Start-Process msiexec.exe -Wait -ArgumentList "/I $msi /quiet"
+
+# Cleanup
+Remove-Item $msi
+
+```
+
+### Manual installation
+
 You can find the latest installation packages on the
 [Releases](https://github.com/signalfx/signalfx-dotnet-tracing/releases/latest)
 page.
@@ -68,7 +100,7 @@ On Linux, after the installation, you can optionally create the log directory:
 /opt/signalfx/createLogPath.sh
 ```
 
-### Instrument a .NET application on Windows
+## Instrument a .NET application on Windows
 
 Before running the application, set the following environment variables:
 
@@ -93,7 +125,7 @@ $Env:SIGNALFX_ENV = "production"                                  # Set the envi
 dotnet run                                                        # Run your application                                                     
 ```
 
-### Instrument a .NET application on Linux
+## Instrument a .NET application on Linux
 
 Before running the application, set the following environment variables:
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -70,9 +70,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             {
                 StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
                 var loadedAssembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
-                LoadedAssemblies[args.Name] = loadedAssembly;
-
-                return loadedAssembly;
+                return LoadedAssemblies.GetOrAdd(args.Name, loadedAssembly);
             }
 
             return null;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -43,37 +43,48 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 return LoadedAssemblies[args.Name];
             }
 
-            var assemblyName = new AssemblyName(args.Name);
-
-            // On .NET Framework, having a non-US locale can cause mscorlib
-            // to enter the AssemblyResolve event when searching for resources
-            // in its satellite assemblies. This seems to have been fixed in
-            // .NET Core in the 2.0 servicing branch, so we should not see this
-            // occur, but guard against it anyways. If we do see it, exit early
-            // so we don't cause infinite recursion.
-            if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
+            lock (Lock)
             {
+                if (LoadedAssemblies.ContainsKey(args.Name))
+                {
+                    StartupLogger.Debug("{0} has already been loaded.", args.Name);
+                    return LoadedAssemblies[args.Name];
+                }
+
+                var assemblyName = new AssemblyName(args.Name);
+
+                // On .NET Framework, having a non-US locale can cause mscorlib
+                // to enter the AssemblyResolve event when searching for resources
+                // in its satellite assemblies. This seems to have been fixed in
+                // .NET Core in the 2.0 servicing branch, so we should not see this
+                // occur, but guard against it anyways. If we do see it, exit early
+                // so we don't cause infinite recursion.
+                if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
+
+                // Only load the main profiler into the default Assembly Load Context.
+                // If Datadog.Trace or other libraries are provided by the NuGet package their loads are handled in the following two ways.
+                // 1) The AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
+                //    will load successfully and will not invoke this resolve event.
+                // 2) The AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
+                //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
+                //    load the originally referenced version
+                if (File.Exists(path))
+                {
+                    StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
+                    var loadedAssembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
+                    LoadedAssemblies[args.Name] = loadedAssembly;
+
+                    return loadedAssembly;
+                }
+
                 return null;
             }
-
-            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
-
-            // Only load the main profiler into the default Assembly Load Context.
-            // If Datadog.Trace or other libraries are provided by the NuGet package their loads are handled in the following two ways.
-            // 1) The AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
-            //    will load successfully and will not invoke this resolve event.
-            // 2) The AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
-            //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
-            //    load the originally referenced version
-            if (File.Exists(path))
-            {
-                StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
-                var loadedAssembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
-                return LoadedAssemblies.GetOrAdd(args.Name, loadedAssembly);
-            }
-
-            return null;
         }
     }
 }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -26,6 +26,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
         private static Assembly AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
         {
+            if (LoadedAssemblies.ContainsKey(args.Name))
+            {
+                StartupLogger.Debug("{0} has already been loaded.", args.Name);
+                return LoadedAssemblies[args.Name];
+            }
+
             var assemblyName = new AssemblyName(args.Name).Name;
 
             // On .NET Framework, having a non-US locale can cause mscorlib
@@ -49,7 +55,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 }
 
                 StartupLogger.Debug("Resolving {0}, loading {1}", args.Name, path);
-                return Assembly.LoadFrom(path);
+                var loadedAssembly = Assembly.LoadFrom(path);
+                LoadedAssemblies[args.Name] = loadedAssembly;
+
+                return loadedAssembly;
             }
 
             return null;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -56,9 +56,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
                 StartupLogger.Debug("Resolving {0}, loading {1}", args.Name, path);
                 var loadedAssembly = Assembly.LoadFrom(path);
-                LoadedAssemblies[args.Name] = loadedAssembly;
-
-                return loadedAssembly;
+                return LoadedAssemblies.GetOrAdd(args.Name, loadedAssembly);
             }
 
             return null;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -6,6 +6,8 @@
 // Modified by Splunk Inc.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Loader
@@ -36,6 +38,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             TryLoadManagedAssembly();
         }
+
+        private static IDictionary<string, Assembly> LoadedAssemblies { get; } = new ConcurrentDictionary<string, Assembly>();
 
         internal static string ManagedProfilerDirectory { get; }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             TryLoadManagedAssembly();
         }
 
-        private static IDictionary<string, Assembly> LoadedAssemblies { get; } = new ConcurrentDictionary<string, Assembly>();
+        private static ConcurrentDictionary<string, Assembly> LoadedAssemblies { get; } = new();
 
         internal static string ManagedProfilerDirectory { get; }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     public partial class Startup
     {
         private const string AssemblyName = "SignalFx.Tracing, Version=0.2.2.0, Culture=neutral, PublicKeyToken=e43a27c2023d388a";
+        private static readonly object Lock = new();
 
         /// <summary>
         /// Initializes static members of the <see cref="Startup"/> class.
@@ -39,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             TryLoadManagedAssembly();
         }
 
-        private static ConcurrentDictionary<string, Assembly> LoadedAssemblies { get; } = new();
+        private static Dictionary<string, Assembly> LoadedAssemblies { get; } = new();
 
         internal static string ManagedProfilerDirectory { get; }
 


### PR DESCRIPTION
## Why

StartupLogger logs the dll loading more than once, and we don't wanna bloat the logs, we also want to know why this happens.

## What

We are using AssemblyResolve event for loading our tracer dlls, when they are not in the default context (on failed loading we search for them in the tracer home directory). This event is triggered multiple times for the same dll for some reason (and it seems to be working as intended, as I was able to find some best practices on using the event and it actually mentions that), but we don't have to load the file again. It is enough to return previously loaded assembly and this is what has been done in this PR.

## Tests

CI tests passing
