### PR TITLE
Add Dockerfile for building Windows release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-# this Makefile is for testing purposes. to be removed later
+# this Makefile is for testing purposes
+# to be removed when this code is moved in .gitlab-ci.yml
 
 all: build run
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# this Makefile is for testing purposes. to be removed later
+
+all: build run
+
+prepare: # run it before testing
+	rm .dockerignore
+
+build:
+	docker build --file "./tracer/build/_build/docker/windows.dockerfile" --tag win-build .
+
+run:
+	docker run --rm --name release win-build powershell -Command ".\tracer\build.ps1 Clean BuildTracerHome PackageTracerHome"

--- a/tracer/build/_build/docker/windows.dockerfile
+++ b/tracer/build/_build/docker/windows.dockerfile
@@ -1,0 +1,48 @@
+# escape=`
+
+#FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-20220215-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/sdk:3.5-20220215-windowsservercore-ltsc2019
+#FROM mcr.microsoft.com/dotnet/framework/runtime:3.5-20220208-windowsservercore-ltsc2019
+
+# ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+
+# RUN `
+#     # Install .NET Fx 3.5
+#     curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2019.zip `
+#     && tar -zxf microsoft-windows-netfx3.zip `
+#     && del /F /Q microsoft-windows-netfx3.zip `
+#     && dism /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+#     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+#     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+#     `
+#     # Apply latest patch
+#     && curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2022/02/windows10.0-kb5010351-x64_f7ba53f4c410299fc28400f7a21b7f616f635a7c.msu `
+#     && mkdir patch `
+#     && expand patch.msu patch -F:* `
+#     && del /F /Q patch.msu `
+#     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb5010351-x64.cab `
+#     && rmdir /S /Q patch `
+#     `
+#     # ngen .NET Fx
+#     && %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+#     && %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen update `
+#     && %windir%\Microsoft.NET\Framework\v2.0.50727\ngen update
+
+ENV chocolateyVersion 0.12.1
+RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))"
+
+RUN choco install visualstudio2019buildtools --version 16.11.10.0 --yes
+RUN choco install visualstudio2019-workload-nativedesktop --version 1.0.1 --yes
+
+#RUN choco install visualstudio2022professional --version 117.1.0.0 --yes --package-parameters '--add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop -add Microsoft.VisualStudio.Workload.NetWeb --add Microsoft.Net.Component.4.7.TargetingPack --includeRecommended --includeOptional --passive --locale en-US'
+
+RUN choco install visualstudio2022buildtools --version 117.1.0.0 --yes
+RUN choco install visualstudio2022-workload-vctools --version 1.0.0 --yes
+RUN choco install visualstudio2022-workload-manageddesktop --version 1.0.1 --yes
+RUN choco install visualstudio2022-workload-netweb --version 1.0.0 --yes
+RUN choco install wixtoolset --version 3.11.2 --yes
+
+ENV VSTUDIO_ROOT "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
+
+COPY . /project
+WORKDIR /project

--- a/tracer/build/_build/docker/windows.dockerfile
+++ b/tracer/build/_build/docker/windows.dockerfile
@@ -1,48 +1,23 @@
 # escape=`
 
-#FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-20220215-windowsservercore-ltsc2019
 FROM mcr.microsoft.com/dotnet/framework/sdk:3.5-20220215-windowsservercore-ltsc2019
-#FROM mcr.microsoft.com/dotnet/framework/runtime:3.5-20220208-windowsservercore-ltsc2019
 
-# ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+# it would be good to not use choco. however it can be used to create "image templates" or for sake of POC
+# reference: https://github.com/DataDog/datadog-agent-buildimages/pull/91
 
-# RUN `
-#     # Install .NET Fx 3.5
-#     curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2019.zip `
-#     && tar -zxf microsoft-windows-netfx3.zip `
-#     && del /F /Q microsoft-windows-netfx3.zip `
-#     && dism /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-#     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-#     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
-#     `
-#     # Apply latest patch
-#     && curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2022/02/windows10.0-kb5010351-x64_f7ba53f4c410299fc28400f7a21b7f616f635a7c.msu `
-#     && mkdir patch `
-#     && expand patch.msu patch -F:* `
-#     && del /F /Q patch.msu `
-#     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb5010351-x64.cab `
-#     && rmdir /S /Q patch `
-#     `
-#     # ngen .NET Fx
-#     && %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
-#     && %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen update `
-#     && %windir%\Microsoft.NET\Framework\v2.0.50727\ngen update
-
+# install choco
 ENV chocolateyVersion 0.12.1
-RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))"
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
-RUN choco install visualstudio2019buildtools --version 16.11.10.0 --yes
-RUN choco install visualstudio2019-workload-nativedesktop --version 1.0.1 --yes
+# install Visual Studio with needed workloads
+RUN choco install visualstudio2022professional --version 117.1.0.0 --yes --params "'--add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.NetWeb --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --includeRecommended'"
 
-#RUN choco install visualstudio2022professional --version 117.1.0.0 --yes --package-parameters '--add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop -add Microsoft.VisualStudio.Workload.NetWeb --add Microsoft.Net.Component.4.7.TargetingPack --includeRecommended --includeOptional --passive --locale en-US'
+# workaround for MSBuild auto-detection to not detect 'BuildTools' instead of 'Professional'
+RUN Remove-Item -Recurse 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
 
-RUN choco install visualstudio2022buildtools --version 117.1.0.0 --yes
-RUN choco install visualstudio2022-workload-vctools --version 1.0.0 --yes
-RUN choco install visualstudio2022-workload-manageddesktop --version 1.0.1 --yes
-RUN choco install visualstudio2022-workload-netweb --version 1.0.0 --yes
+# install WiX Toolset
 RUN choco install wixtoolset --version 3.11.2 --yes
 
-ENV VSTUDIO_ROOT "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
-
+# copy the repository
 COPY . /project
 WORKDIR /project

--- a/tracer/build/_build/docker/windows.dockerfile
+++ b/tracer/build/_build/docker/windows.dockerfile
@@ -10,7 +10,7 @@ ENV chocolateyVersion 0.12.1
 RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 # install Visual Studio with needed workloads
-RUN choco install visualstudio2022professional --version 117.1.0.0 --yes --params "'--add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.NetWeb --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --includeRecommended'"
+RUN choco install visualstudio2022professional --version 117.1.0.0 --yes --params "'--add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --includeRecommended'"
 
 # workaround for MSBuild auto-detection to not detect 'BuildTools' instead of 'Professional'
 RUN Remove-Item -Recurse 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'


### PR DESCRIPTION
## Why

Baby step to make the release process compliant to our standards.

## What

1. Prepare dockerfile that can be used to execute the build on a "versioned" environment
2. Add `Makefile` for testing purposes before the release is moved to GitLab CI/CD

## Tests

```
Build succeeded on 3/1/2022 1:48:56 PM. ＼（＾ᴗ＾）／
```
