### PR TITLE
Add checksums.txt

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,8 @@ verify-artifacts:
     - cd /project
     - rm -rd /project/tracer/bin/artifacts/temp
     - tracer/build.sh ChecksumArtifacts --artifacts /project/tracer/bin/artifacts
+  dependencies: 
+    - linux-build
   artifacts:
     paths:
       - tracer/bin/artifacts/checksums.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,14 +53,7 @@ verify-artifacts:
   before_script:
     - apt-get update && apt-get install -y --fix-missing curl unzip
   script:
-    - mkdir -p /project/tracer/bin/artifacts/temp
-    - cd /project/tracer/bin/artifacts/temp
-    - 'curl --location --output artifacts.zip "https://cd.splunkdev.com/o11y-gdi/dotnet-maintainers/signalfx-dotnet-tracing-releaser/-/jobs/$CI_JOB_ID/artifacts/download?job_token=$CI_JOB_TOKEN"'
-    - unzip artifacts.zip
-    - mv -v ./dist/* ./../
-    - cd /project
-    - rm -rd /project/tracer/bin/artifacts/temp
-    - tracer/build.sh ChecksumArtifacts --artifacts /project/tracer/bin/artifacts
+    - tracer/build.sh ChecksumArtifacts --artifacts /project/dist/
   dependencies: 
     - linux-build
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ workflow:
 
 stages:
   - build
+  - verify
 
 linux-build:
   stage: build
@@ -46,3 +47,21 @@ linux-build:
 #     paths:
 #       - tracer/bin/artifacts/nuget/SignalFx.NET.Tracing.Azure.Site.Extension.*.nupkg
 #       - tracer/bin/artifacts/*/en-us
+
+verify-artifacts:
+  stage: verify
+  before_script:
+    - apk update && apk add curl unzip
+  script:
+    - mkdir /project/tracer/bin/artifacts/temp
+    - cd /project/tracer/bin/artifacts/temp
+    - 'curl --location --output artifacts.zip "https://cd.splunkdev.com/o11y-gdi/dotnet-maintainers/signalfx-dotnet-tracing-releaser/-/jobs/$CI_JOB_ID/artifacts/download?job_token=$CI_JOB_TOKEN"'
+    - unzip artifacts.zip
+    - mv -v ./dist/* ./../
+    - cd /project
+    - rm -rd /project/tracer/bin/artifacts/temp
+    - tracer/build.sh ChecksumArtifacts --artifacts /project/tracer/bin/artifacts
+  artifacts:
+    paths:
+      - tracer/bin/artifacts/checksums.txt
+    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,5 +73,5 @@ verify-artifacts:
     - linux-build
   artifacts:
     paths:
-      - /project/dist/checksums.txt
+      - dist/checksums.txt
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,13 @@ linux-build:
 verify-artifacts:
   stage: verify
   before_script:
-    - apt-get update && apt-get install -y --fix-missing curl unzip
+    - apt-get update && apt-get install -y --fix-missing curl unzip wget
+    - wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+    - sudo dpkg -i packages-microsoft-prod.deb
+    - sudo apt-get update; \
+      sudo apt-get install -y apt-transport-https && \
+      sudo apt-get update && \
+      sudo apt-get install -y dotnet-sdk-6.0
   script:
     - tracer/build.sh ChecksumArtifacts --artifacts /project/dist/
   dependencies: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,8 @@ linux-build:
 verify-artifacts:
   stage: verify
   script:
-    - docker build \
+    - | 
+      docker build \
         --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
         --tag splunk-trace-dotnet/checksums \
         --file "./tracer/build/_build/docker/dotnet.dockerfile" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,16 +50,20 @@ linux-build:
 
 verify-artifacts:
   stage: verify
-  before_script:
-    - apt-get update && apt-get install -y --fix-missing curl unzip wget
-    - wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-    - sudo dpkg -i packages-microsoft-prod.deb
-    - sudo apt-get update; \
-      sudo apt-get install -y apt-transport-https && \
-      sudo apt-get update && \
-      sudo apt-get install -y dotnet-sdk-6.0
   script:
-    - tracer/build.sh ChecksumArtifacts --artifacts /project/dist/
+    - docker build \
+        --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
+        --tag splunk-trace-dotnet/checksums \
+        --file "./tracer/build/_build/docker/dotnet.dockerfile" \
+        .
+    - |
+      docker run \
+        --env artifacts=/project/dist \
+        --name checksums \
+        splunk-trace-dotnet/checksums \
+        tracer/build.sh ChecksumArtifacts
+    - |
+      docker cp checksums:/project/dist/checksums.txt dist/checksums.txt
   dependencies: 
     - linux-build
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,8 @@ verify-artifacts:
   variables:
     dotnetSdkVersion: 6.0.200
   script:
+    - |
+      rm .dockerignore
     - | 
       docker build \
         --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,8 @@ linux-build:
 
 verify-artifacts:
   stage: verify
+  variables:
+    dotnetSdkVersion: 6.0.200
   script:
     - | 
       docker build \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,9 +51,9 @@ linux-build:
 verify-artifacts:
   stage: verify
   before_script:
-    - apk update && apk add curl unzip
+    - apt-get update && apt-get install -y --fix-missing curl unzip
   script:
-    - mkdir /project/tracer/bin/artifacts/temp
+    - mkdir -p /project/tracer/bin/artifacts/temp
     - cd /project/tracer/bin/artifacts/temp
     - 'curl --location --output artifacts.zip "https://cd.splunkdev.com/o11y-gdi/dotnet-maintainers/signalfx-dotnet-tracing-releaser/-/jobs/$CI_JOB_ID/artifacts/download?job_token=$CI_JOB_TOKEN"'
     - unzip artifacts.zip

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,5 +58,5 @@ verify-artifacts:
     - linux-build
   artifacts:
     paths:
-      - tracer/bin/artifacts/checksums.txt
+      - /project/dist/checksums.txt
     

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -588,17 +588,22 @@ partial class Build
 
             foreach (var artifact in artifacts)
             {
+                Logger.Info($"Found artifact '{artifact}'");
+
                 using (var sha256 = SHA256.Create())
                 using (var stream = File.OpenRead(artifact))
                 {
-                    var hash = BitConverter.ToString(sha256.ComputeHash(stream)).Replace("-", string.Empty);
                     var fileName = Path.GetFileName(artifact);
+                    var hash = BitConverter.ToString(sha256.ComputeHash(stream)).Replace("-", string.Empty);
 
                     checksums.AppendLine($"{hash}  {fileName}");
                 }
             }
 
-            File.WriteAllText(Path.Combine(Artifacts, "checksums.txt"), checksums.ToString());
+            var checksumsPath = Path.Combine(Artifacts, "checksums.txt");
+
+            Logger.Info($"Generating checksums file: '{checksumsPath}'");
+            File.WriteAllText(checksumsPath, checksums.ToString());
         });
 
     Target CompileManagedTestHelpers => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Nuke.Common;
@@ -575,6 +577,28 @@ partial class Build
                     workingDirectory / $"{packageName}.tar.gz",
                     workingDirectory / versionedName);
             }
+        });
+
+    Target ChecksumArtifacts => _ => _
+        .Requires(() => Artifacts)
+        .Executes(() =>
+        {
+            var artifacts = Directory.GetFiles(Artifacts);
+            var checksums = new StringBuilder();
+
+            foreach (var artifact in artifacts)
+            {
+                using (var sha256 = SHA256.Create())
+                using (var stream = File.OpenRead(artifact))
+                {
+                    var hash = BitConverter.ToString(sha256.ComputeHash(stream)).Replace("-", string.Empty);
+                    var fileName = Path.GetFileName(artifact);
+
+                    checksums.AppendLine($"{hash}  {fileName}");
+                }
+            }
+
+            File.WriteAllText(Path.Combine(Artifacts, "checksums.txt"), checksums.ToString());
         });
 
     Target CompileManagedTestHelpers => _ => _

--- a/tracer/build/_build/docker/dotnet.dockerfile
+++ b/tracer/build/_build/docker/dotnet.dockerfile
@@ -1,0 +1,5 @@
+﻿ARG DOTNETSDK_VERSION
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION
+
+COPY . /project
+WORKDIR /project


### PR DESCRIPTION
## Why

Security is requiring checksums.txt for all published artifacts. 

## What

* Adds a Nuke target to calculate checksums in artifacts directory
* CI invokes target and uploads checksums.txt
