### PR TITLE
AlwaysOn Profiller - shared generic classes and internal classes

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -319,6 +319,8 @@ private:
 
         if (function_info.type.parent_type != nullptr)
         {
+            // parent class is available only for internal classes.
+            // See the class in the test application:  My.Custom.Test.Namespace.ClassA.InternalClassB.DoubleInternalClassB.TripleInternalClassB
             std::shared_ptr<TypeInfo> parent_type = function_info.type.parent_type;
             WSTRING prefix = parent_type->name;
             while (parent_type->parent_type != nullptr)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -105,8 +105,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return logRecord.Body.StringValue.Contains(
                 "\tat System.Threading.Thread.Sleep(System.TimeSpan)\n" +
                 "\tat My.Custom.Test.Namespace.ClassD`1.GenericMethodDFromGenericClass(!0, !!0)\n" +
-                "\tat SharedGenericFunction.GenericMethodCFromGenericClass(!0)\n" +
-                "\tat TripleInternalClassB.MethodB(System.String)\n" +
+                "\tat My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass(!0)\n" +
+                "\tat My.Custom.Test.Namespace.ClassA.InternalClassB.DoubleInternalClassB.TripleInternalClassB.MethodB(System.String)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|4_0(System.String)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodAOthers(System.String, System.Object, My.Custom.Test.Namespace.CustomClass, My.Custom.Test.Namespace.CustomStruct, My.Custom.Test.Namespace.CustomClass[], My.Custom.Test.Namespace.CustomStruct[], System.Collections.Generic.List`1[!!0])\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodAFloats(System.Single, System.Double)\n" +


### PR DESCRIPTION
## Why

Extend the AlwaysOn Profiler.

## What

Support for internal classed and shared generic functions.
Cache for class names is removed. Full function names extended about the class name size.

## Tests

CI

## TODO
You can expect more PRs for handling generic parameters.