### PR TITLE
Improve Serilog log injection doc

### DIFF
--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -26,22 +26,30 @@ optional_dir() {
     fi
 }
 
-SUFIX=$(native_sufix)
+current_dir() {
+    os=$(uname_os)
+    case "$os" in
+        windows*) pwd -W ;;
+        *) pwd ;;
+    esac
+}
 
+SUFIX=$(native_sufix)
 OPT_DIR=$(optional_dir)
+CURDIR=$(current_dir)
 
 # Enable .NET Framework Profiling API
 export COR_ENABLE_PROFILING="1"
 export COR_PROFILER="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
-export COR_PROFILER_PATH="${PWD}/tracer/bin/tracer-home/${OPT_DIR}SignalFx.Tracing.ClrProfiler.Native.${SUFIX}"
+export COR_PROFILER_PATH="${CURDIR}/tracer/bin/tracer-home/${OPT_DIR}SignalFx.Tracing.ClrProfiler.Native.${SUFIX}"
 
 # Enable .NET Core Profiling API
 export CORECLR_ENABLE_PROFILING="1"
 export CORECLR_PROFILER="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}"
-export CORECLR_PROFILER_PATH="${PWD}/tracer/bin/tracer-home/${OPT_DIR}SignalFx.Tracing.ClrProfiler.Native.${SUFIX}"
+export CORECLR_PROFILER_PATH="${CURDIR}/tracer/bin/tracer-home/${OPT_DIR}SignalFx.Tracing.ClrProfiler.Native.${SUFIX}"
 
 # Configure SFx .NET Tracer 
-export SIGNALFX_DOTNET_TRACER_HOME="${PWD}/tracer/bin/tracer-home"
+export SIGNALFX_DOTNET_TRACER_HOME="${CURDIR}/tracer/bin/tracer-home"
 export SIGNALFX_VERSION="1.0.0"
 export SIGNALFX_TRACE_DEBUG="1"
 export SIGNALFX_DUMP_ILREWRITE_ENABLED="0"

--- a/docs/correlating-traces-with-logs.md
+++ b/docs/correlating-traces-with-logs.md
@@ -80,8 +80,13 @@ to print out all contextual properties.
 
 Alternatively, for more fine-grained control,
 you can use the trace context fields explicitly.
-However, the values must be surrounded with a quotation mark
-(e.g. `service.name=\"{service_name}\"`).
+However, the values must be surrounded with a quotation mark.
+For instance, you can use following output template,
+which also transforms the field names:
+
+```csharp
+"{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] trace_id=\"{trace_id}\" span_id=\"{span_id}\" service.name=\"{service_name}\" service.version=\"{service_version}\" deployment.environment=\"{deployment_environment}\"{NewLine}{Message:lj}{NewLine}{Exception}"
+```
 
 The log transformation rules must be configured as Serilog does not support
 property names with '`.`'. Find more information about the log processing rules

--- a/docs/correlating-traces-with-logs.md
+++ b/docs/correlating-traces-with-logs.md
@@ -80,7 +80,7 @@ to print out all contextual properties.
 
 Alternatively, for more fine-grained control,
 you can use the trace context fields explicitly.
-The values MUST be surrounded with a quotation mark.
+The values MUST be wrapped in quotation marks.
 For instance, you can use following output template,
 which also transforms the field name
 (the log transformation step would not be required):

--- a/docs/correlating-traces-with-logs.md
+++ b/docs/correlating-traces-with-logs.md
@@ -8,12 +8,12 @@ To inject trace context fields in logs,
 enable log correlation by setting the environment variable
 `SIGNALFX_LOGS_INJECTION=true` before running your instrumented application.
 
-If your logger uses JSON logging format,
-then SignalFx Instrumentation for .NET automatically adds
+If your logger uses JSON as the logging format,
+the SignalFx Instrumentation for .NET automatically adds
 span context to the logs.
 
 If your logger uses a different format,
-you may have to manually configure your
+you might have to manually configure your
 logger to include the trace context fields.
 
 ## Fields injected into log context
@@ -61,7 +61,7 @@ Find samples here:
 
 Regardless of the output layout, your `LoggerConfiguration` must be
 enriched from the LogContext to extract the trace context
-that is automatically injected.
+that is automatically injected. For example:
 
 ```csharp
 var loggerConfiguration = new LoggerConfiguration()
@@ -76,14 +76,11 @@ Supported layouts:
 - Raw format: output template (requires manual configuration)
 
 When using the output template you can either use `{Properties}`
-to print out all contextual properties.
+to print out all contextual properties or add context fields explicitly.
 
-Alternatively, for more fine-grained control,
-you can use the trace context fields explicitly.
-The values MUST be wrapped in quotation marks.
-For instance, you can use following output template,
-which also transforms the field name
-(the log transformation step would not be required):
+When adding context fields manually, values must be wrapped in 
+quotation marks. For instance, you can use the following output template,
+which also transforms the field name (the log transformation step would not be required):
 
 ```csharp
 "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] trace_id=\"{trace_id}\" span_id=\"{span_id}\" service.name=\"{service_name}\" service.version=\"{service_version}\" deployment.environment=\"{deployment_environment}\"{NewLine}{Message:lj}{NewLine}{Exception}"

--- a/docs/correlating-traces-with-logs.md
+++ b/docs/correlating-traces-with-logs.md
@@ -78,9 +78,10 @@ Supported layouts:
 When using the output template you can either use `{Properties}`
 to print out all contextual properties.
 
-Alternativly, for more fine-grained control,
+Alternatively, for more fine-grained control,
 you can use the trace context fields explicitly.
-However the values must be surrounded by quotation mark (e.g. `service.name=\"{service_name}\"`).
+However, the values must be surrounded with a quotation mark
+(e.g. `service.name=\"{service_name}\"`).
 
 The log transformation rules must be configured as Serilog does not support
 property names with '`.`'. Find more information about the log processing rules

--- a/docs/correlating-traces-with-logs.md
+++ b/docs/correlating-traces-with-logs.md
@@ -80,9 +80,10 @@ to print out all contextual properties.
 
 Alternatively, for more fine-grained control,
 you can use the trace context fields explicitly.
-However, the values must be surrounded with a quotation mark.
+The values MUST be surrounded with a quotation mark.
 For instance, you can use following output template,
-which also transforms the field names:
+which also transforms the field name
+(the log transformation step would not be required):
 
 ```csharp
 "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] trace_id=\"{trace_id}\" span_id=\"{span_id}\" service.name=\"{service_name}\" service.version=\"{service_version}\" deployment.environment=\"{deployment_environment}\"{NewLine}{Message:lj}{NewLine}{Exception}"

--- a/docs/correlating-traces-with-logs.md
+++ b/docs/correlating-traces-with-logs.md
@@ -5,8 +5,8 @@ you can configure log correlation to
 include trace context in your application's logs.
 
 To inject trace context fields in logs,
-enable log correlation by setting the environment variable
-`SIGNALFX_LOGS_INJECTION=true` before running your instrumented application.
+enable log correlation by setting the `SIGNALFX_LOGS_INJECTION` 
+environment variable to `true` before running your instrumented application.
 
 If your logger uses JSON as the logging format,
 the SignalFx Instrumentation for .NET automatically adds

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -40,4 +40,4 @@ needs any adjustments. Contact @signalfx/gdi-docs team if needed.
    and publish the release.
 
 1. [Publish](https://docs.microsoft.com/en-us/nuget/nuget-org/publish-a-package)
-   the NuGet packages to the offical [nuget.org feed](https://www.nuget.org/).
+   the NuGet packages to the official [nuget.org feed](https://www.nuget.org/).


### PR DESCRIPTION
## Why

The current doc is not very straightforward.

## What

- Improve Serilog log injection doc
- Fix `dev/envvars.sh` to make it working on Windows 

## Tests

I was changing the Serilog example and playing with different configurations. I was testing it also against the Console sink and I was trying different output templates.

## Next PRs

Improve description for other logging libraries.
