### PR TITLE
Extract type parameter names

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -104,11 +104,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             return logRecord.Body.StringValue.Contains(
                 "\tat System.Threading.Thread.Sleep(System.TimeSpan)\n" +
-                "\tat My.Custom.Test.Namespace.ClassD`1.GenericMethodDFromGenericClass(!0, !!0)\n" +
-                "\tat My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass(!0)\n" +
-                "\tat My.Custom.Test.Namespace.ClassA.InternalClassB.DoubleInternalClassB.TripleInternalClassB.MethodB(System.String)\n" +
+                "\tat My.Custom.Test.Namespace.ClassD`1.GenericMethodDFromGenericClass(TClass, TMethod, TMethod2)\n" +
+                "\tat My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass(T)\n" +
+                "\tat My.Custom.Test.Namespace.ClassA.InternalClassB`2.DoubleInternalClassB.TripleInternalClassB`1.MethodB(System.String, TC[], TB, TD, System.Collections.Generic.IList`1[TA])\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|4_0(System.String)\n" +
-                "\tat My.Custom.Test.Namespace.ClassA.MethodAOthers(System.String, System.Object, My.Custom.Test.Namespace.CustomClass, My.Custom.Test.Namespace.CustomStruct, My.Custom.Test.Namespace.CustomClass[], My.Custom.Test.Namespace.CustomStruct[], System.Collections.Generic.List`1[!!0])\n" +
+                "\tat My.Custom.Test.Namespace.ClassA.MethodAOthers(System.String, System.Object, My.Custom.Test.Namespace.CustomClass, My.Custom.Test.Namespace.CustomStruct, My.Custom.Test.Namespace.CustomClass[], My.Custom.Test.Namespace.CustomStruct[], System.Collections.Generic.List`1[T])\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodAFloats(System.Single, System.Double)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodAInts(System.UInt16, System.Int16, System.UInt32, System.Int32, System.UInt64, System.Int64, System.IntPtr, System.UIntPtr)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodABytes(System.Boolean, System.Char, System.SByte, System.Byte)\n" +

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
@@ -78,17 +78,17 @@ namespace My.Custom.Test.Namespace
             CustomStruct[] structArray,
             List<T> genericList)
         {
-            void Action(string s) => InternalClassB.DoubleInternalClassB.TripleInternalClassB.MethodB(s);
+            void Action(string s) => InternalClassB<string, int>.DoubleInternalClassB.TripleInternalClassB<int>.MethodB(s, new int[] { 3 }, TimeSpan.Zero, 0, new List<string>{"a"});
             Action("test arg");
         }
 
-        internal static class InternalClassB
+        internal static class InternalClassB<TA, TD>
         {
             internal static class DoubleInternalClassB
             {
-                internal static class TripleInternalClassB
+                internal static class TripleInternalClassB<TC>
                 {
-                    public static void MethodB(string testArg)
+                    public static void MethodB<TB>(string testArg, TC[] a, TB b, TD t, IList<TA> c)
                     {
                         GenericClassC<string>.GenericMethodCFromGenericClass(testArg);
                     }
@@ -101,13 +101,13 @@ namespace My.Custom.Test.Namespace
     {
         public static void GenericMethodCFromGenericClass(T arg)
         {
-            ClassD<TimeSpan>.GenericMethodDFromGenericClass(TimeSpan.MaxValue, arg);
+            ClassD<TimeSpan>.GenericMethodDFromGenericClass(TimeSpan.MaxValue, arg, 1);
         }
     }
 
     internal static class ClassD<TClass>
     {
-        public static void GenericMethodDFromGenericClass<TMethod>(TClass classArg, TMethod methodArg)
+        public static void GenericMethodDFromGenericClass<TMethod, TMethod2>(TClass classArg, TMethod methodArg, TMethod2 additionalArg)
         {
             Console.WriteLine("Thread.Sleep - starting " + classArg + methodArg);
             Thread.Sleep(TimeSpan.FromSeconds(6));


### PR DESCRIPTION
## Why

Include type parameter names in stacktraces.

## What

Cloned and modified `GetSigTypeTokName` from `clr_helpers.cpp` to extract type parameter names.

## Tests

Existing tests for AlwaysOnProfiling.
