### PR TITLE
Always on better format fot generic methods

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -363,11 +363,11 @@ private:
             result.append(unknown_list_of_arguments);
             return;
         }
+        
         hr = pIMDImport->EnumGenericParams(&functionGenParamsIter, functionToken, functionGenericParams,
                                      generic_params_max_len,
                                       &functionGenParamsCount);
         pIMDImport->CloseEnum(functionGenParamsIter);
-
         if (FAILED(hr))
         {
             Logger::Debug("Method generic parameters enumeration failed. HRESULT=0x", std::setfill('0'), std::setw(8),

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -415,7 +415,7 @@ private:
         WCHAR param_type_name[param_name_max_len]{};
         ULONG pch_name = 0;
         const auto hr = pImport->GetGenericParamProps(genericParameters[num], nullptr, nullptr, nullptr, nullptr,
-                                                      param_type_name, param_name_max_len - 1, &pch_name);
+                                                      param_type_name, param_name_max_len, &pch_name);
         if (FAILED(hr))
         {
             Logger::Debug("GetGenericParamProps failed. HRESULT=0x", std::setfill('0'), std::setw(8),

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -375,6 +375,34 @@ private:
             result.append(unknown_list_of_arguments);
             return;
         }
+
+        if (functionGenParamsCount > 0)
+        {
+            result.append(WStr("["));
+            for (ULONG i = 0; i < functionGenParamsCount; ++i)
+            {
+                if (i != 0)
+                {
+                    result.append(WStr(", "));
+                }
+
+                WCHAR param_type_name[param_name_max_len]{};
+                ULONG pch_name = 0;
+                const auto hr =
+                    pIMDImport->GetGenericParamProps(functionGenericParams[i], nullptr, nullptr, nullptr, nullptr,
+                                                     param_type_name, param_name_max_len, &pch_name);
+                if (FAILED(hr))
+                {
+                    Logger::Debug("GetGenericParamProps failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);
+                    result.append(unknown);
+                }
+                else
+                {
+                    result.append(param_type_name);
+                }
+            }
+            result.append(WStr("]"));
+        }
         
         // try to list arguments type
         FunctionMethodSignature functionMethodSignature = function_info.method_signature;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -105,6 +105,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return logRecord.Body.StringValue.Contains(
                 "\tat System.Threading.Thread.Sleep(System.TimeSpan)\n" +
                 "\tat My.Custom.Test.Namespace.ClassD`1.GenericMethodDFromGenericClass[TMethod, TMethod2](TClass, TMethod, TMethod2)\n" +
+                "\tat at My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass[T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, Unknown)\n" +
                 "\tat My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass(T)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.InternalClassB`2.DoubleInternalClassB.TripleInternalClassB`1.MethodB[TB](System.String, TC[], TB, TD, System.Collections.Generic.IList`1[TA], System.Collections.Generic.IList`1[System.String])\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|4_0[T](System.String)\n" +

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -104,7 +104,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             return logRecord.Body.StringValue.Contains(
                 "\tat System.Threading.Thread.Sleep(System.TimeSpan)\n" +
-                "\tat My.Custom.Test.Namespace.ClassD`1.GenericMethodDFromGenericClass[TMethod, TMethod2](TClass, TMethod, TMethod2)\n" +
+                "\tat My.Custom.Test.Namespace.ClassE`1.GenericMethodDFromGenericClass[TMethod, TMethod2](TClass, TMethod, TMethod2)\n" +
+                "\tat at My.Custom.Test.Namespace.ClassD`21.MethodD(T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, Unknown)\n" +
                 "\tat at My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass[T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, Unknown)\n" +
                 "\tat My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass(T)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.InternalClassB`2.DoubleInternalClassB.TripleInternalClassB`1.MethodB[TB](System.String, TC[], TB, TD, System.Collections.Generic.IList`1[TA], System.Collections.Generic.IList`1[System.String])\n" +

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -104,11 +104,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             return logRecord.Body.StringValue.Contains(
                 "\tat System.Threading.Thread.Sleep(System.TimeSpan)\n" +
-                "\tat My.Custom.Test.Namespace.ClassD`1.GenericMethodDFromGenericClass(TClass, TMethod, TMethod2)\n" +
+                "\tat My.Custom.Test.Namespace.ClassD`1.GenericMethodDFromGenericClass[TMethod, TMethod2](TClass, TMethod, TMethod2)\n" +
                 "\tat My.Custom.Test.Namespace.GenericClassC`1.GenericMethodCFromGenericClass(T)\n" +
-                "\tat My.Custom.Test.Namespace.ClassA.InternalClassB`2.DoubleInternalClassB.TripleInternalClassB`1.MethodB(System.String, TC[], TB, TD, System.Collections.Generic.IList`1[TA])\n" +
-                "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|4_0(System.String)\n" +
-                "\tat My.Custom.Test.Namespace.ClassA.MethodAOthers(System.String, System.Object, My.Custom.Test.Namespace.CustomClass, My.Custom.Test.Namespace.CustomStruct, My.Custom.Test.Namespace.CustomClass[], My.Custom.Test.Namespace.CustomStruct[], System.Collections.Generic.List`1[T])\n" +
+                "\tat My.Custom.Test.Namespace.ClassA.InternalClassB`2.DoubleInternalClassB.TripleInternalClassB`1.MethodB[TB](System.String, TC[], TB, TD, System.Collections.Generic.IList`1[TA], System.Collections.Generic.IList`1[System.String])\n" +
+                "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|4_0[T](System.String)\n" +
+                "\tat My.Custom.Test.Namespace.ClassA.MethodAOthers[T](System.String, System.Object, My.Custom.Test.Namespace.CustomClass, My.Custom.Test.Namespace.CustomStruct, My.Custom.Test.Namespace.CustomClass[], My.Custom.Test.Namespace.CustomStruct[], System.Collections.Generic.List`1[T])\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodAFloats(System.Single, System.Double)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodAInts(System.UInt16, System.Int16, System.UInt32, System.Int32, System.UInt64, System.Int64, System.IntPtr, System.UIntPtr)\n" +
                 "\tat My.Custom.Test.Namespace.ClassA.MethodABytes(System.Boolean, System.Char, System.SByte, System.Byte)\n" +

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
@@ -78,7 +78,7 @@ namespace My.Custom.Test.Namespace
             CustomStruct[] structArray,
             List<T> genericList)
         {
-            void Action(string s) => InternalClassB<string, int>.DoubleInternalClassB.TripleInternalClassB<int>.MethodB(s, new int[] { 3 }, TimeSpan.Zero, 0, new List<string>{"a"});
+            void Action(string s) => InternalClassB<string, int>.DoubleInternalClassB.TripleInternalClassB<int>.MethodB(s, new int[] { 3 }, TimeSpan.Zero, 0, new List<string>{"a"}, new List<string>(0));
             Action("test arg");
         }
 
@@ -88,7 +88,7 @@ namespace My.Custom.Test.Namespace
             {
                 internal static class TripleInternalClassB<TC>
                 {
-                    public static void MethodB<TB>(string testArg, TC[] a, TB b, TD t, IList<TA> c)
+                    public static void MethodB<TB>(string testArg, TC[] a, TB b, TD t, IList<TA> c, IList<string> d)
                     {
                         GenericClassC<string>.GenericMethodCFromGenericClass(testArg);
                     }

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
@@ -107,12 +107,22 @@ namespace My.Custom.Test.Namespace
         public static void GenericMethodCFromGenericClass<T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T01 p01, T02 p02, T03 p03, T04 p04, T05 p05, T06 p06, T07 p07, T08 p08, T09 p09, T10 p10, T11 p11, T12 p12, T13 p13, T14 p14, T15 p15, T16 p16, T17 p17, T18 p18, T19 p19, T20 p20, T21 p21)
         {
             // Always on profiler supports only fetching for 20 generic arguments. This method covers scenario where there is more parameters.
-            ClassD<TimeSpan>.GenericMethodDFromGenericClass(TimeSpan.MaxValue, p01, 1);
+            ClassD<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>.MethodD(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21);
         }
 
     }
 
-    internal static class ClassD<TClass>
+    internal static class ClassD<T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>
+    {
+        // Always on profiler supports only fetching for 20 generic arguments. This class covers scenario where there is more parameters.
+        public static void MethodD(T01 p01, T02 p02, T03 p03, T04 p04, T05 p05, T06 p06, T07 p07, T08 p08, T09 p09, T10 p10, T11 p11, T12 p12, T13 p13, T14 p14, T15 p15, T16 p16, T17 p17, T18 p18, T19 p19, T20 p20, T21 p21)
+        {
+            ClassE<TimeSpan>.GenericMethodDFromGenericClass(TimeSpan.MaxValue, p01, 1);
+
+        }
+    }
+
+    internal static class ClassE<TClass>
     {
         public static void GenericMethodDFromGenericClass<TMethod, TMethod2>(TClass classArg, TMethod methodArg, TMethod2 additionalArg)
         {

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
@@ -101,8 +101,15 @@ namespace My.Custom.Test.Namespace
     {
         public static void GenericMethodCFromGenericClass(T arg)
         {
-            ClassD<TimeSpan>.GenericMethodDFromGenericClass(TimeSpan.MaxValue, arg, 1);
+            GenericMethodCFromGenericClass(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21);
         }
+
+        public static void GenericMethodCFromGenericClass<T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T01 p01, T02 p02, T03 p03, T04 p04, T05 p05, T06 p06, T07 p07, T08 p08, T09 p09, T10 p10, T11 p11, T12 p12, T13 p13, T14 p14, T15 p15, T16 p16, T17 p17, T18 p18, T19 p19, T20 p20, T21 p21)
+        {
+            // Always on profiler supports only fetching for 20 generic arguments. This method covers scenario where there is more parameters.
+            ClassD<TimeSpan>.GenericMethodDFromGenericClass(TimeSpan.MaxValue, p01, 1);
+        }
+
     }
 
     internal static class ClassD<TClass>


### PR DESCRIPTION
## Why & What

 - fixes to comment form #438
 - display method generic parameters name
 - Extended test case to cover scenario where we have more than 20 generic parameter names

## Tests

CI/New test created.

## Notes

After internal conversation we have decided to do not list all generic parameters from the classes and keep only the number of it. It is same as we have in stacktraces.