### PR TITLE
Bump otel/opentelemetry-collector-contrib to 0.47.0

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "14250:14250"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.46.0
+    image: otel/opentelemetry-collector-contrib:0.47.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
     command: --config /etc/otel/config.yaml


### PR DESCRIPTION
## Why

Keep in sync with otel releases

## What

Bump otel/opentelemetry-collector-contrib to 0.47.0

## Tests

Local test.
