### PR TITLE
AlwaysOn Profiler - cache by function token

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -284,33 +284,50 @@ public:
     }
 
 private:
-    void GetFunctionName(FunctionID funcID, const COR_PRF_FRAME_INFO frameInfo, shared::WSTRING& result)
+    [[nodiscard]] FunctionIdentifier GetFunctionIdentifier(const FunctionID func_id, const COR_PRF_FRAME_INFO frame_info) const
+    {
+        if (func_id == 0)
+        {
+            constexpr auto zero_valid_function_identifier = FunctionIdentifier{0, 0, true};
+            return zero_valid_function_identifier;
+        }
+
+        ModuleID moduleId = 0;
+        mdToken functionToken = 0;
+        // theoretically there is a possibility to use GetFunctionInfo method, but it does not support generic methods
+        HRESULT hr = info10->GetFunctionInfo2(func_id, frame_info, nullptr, &moduleId, &functionToken, 0, nullptr, nullptr);
+        if (FAILED(hr))
+        {
+            Logger::Debug("GetFunctionInfo2 failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);
+            constexpr auto zero_invalid_function_identifier = FunctionIdentifier{0, 0, false};
+            return zero_invalid_function_identifier;
+        }
+
+        return FunctionIdentifier{functionToken, moduleId, true};
+    }
+
+    void GetFunctionName(FunctionIdentifier functionIdentifier, shared::WSTRING& result)
     {
         constexpr auto unknown_list_of_arguments = WStr("(unknown)");
         constexpr auto unknown_function_name = WStr("Unknown(unknown)");
         constexpr auto name_separator = WStr(".");
 
-        if (funcID == 0)
+        if (!functionIdentifier.is_valid)
+        {
+            result.append(unknown_function_name);
+            return;
+        }
+
+        if (functionIdentifier.function_token == 0)
         {
             constexpr auto unknown_native_function_name = WStr("Unknown_Native_Function(unknown)");
             result.append(unknown_native_function_name);
             return;
         }
 
-        ModuleID moduleId = 0;
-        mdToken functionToken = 0;
-
-        // theoretically there is a possibility to use GetFunctionInfo method, but it does not support generic methods
-        HRESULT hr = info10->GetFunctionInfo2(funcID, frameInfo, nullptr, &moduleId, &functionToken, 0, nullptr, nullptr);
-        if (FAILED(hr))
-        {
-            Logger::Debug("GetFunctionInfo2 failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);
-            result.append(unknown_function_name);
-            return;
-        }
-
         ComPtr<IMetaDataImport2> pIMDImport;
-        hr = info10->GetModuleMetaData(moduleId, ofRead, IID_IMetaDataImport2, reinterpret_cast<IUnknown**>(&pIMDImport));
+        HRESULT hr = info10->GetModuleMetaData(functionIdentifier.module_id, ofRead, IID_IMetaDataImport2,
+                                              reinterpret_cast<IUnknown**>(&pIMDImport));
         if (FAILED(hr))
         {
             Logger::Debug("GetModuleMetaData failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);
@@ -318,7 +335,7 @@ private:
             return;
         }
 
-        const auto function_info = GetFunctionInfo(pIMDImport, functionToken);
+        const auto function_info = GetFunctionInfo(pIMDImport, functionIdentifier.function_token);
 
         if (!function_info.IsValid())
         {
@@ -369,7 +386,7 @@ private:
             return;
         }
         
-        hr = pIMDImport->EnumGenericParams(&functionGenParamsIter, functionToken, functionGenericParams,
+        hr = pIMDImport->EnumGenericParams(&functionGenParamsIter, functionIdentifier.function_token, functionGenericParams,
                                      generic_params_max_len,
                                       &functionGenParamsCount);
         pIMDImport->CloseEnum(functionGenParamsIter);
@@ -593,15 +610,17 @@ private:
 public:
     shared::WSTRING* Lookup(FunctionID fid, COR_PRF_FRAME_INFO frame)
     {
-        shared::WSTRING* answer = functionNameCache.get(fid);
+        const auto function_identifier = this->GetFunctionIdentifier(fid, frame);
+
+        shared::WSTRING* answer = functionNameCache.get(function_identifier);
         if (answer != nullptr)
         {
             return answer;
         }
         stats.nameCacheMisses++;
         answer = new shared::WSTRING();
-        this->GetFunctionName(fid, frame, *answer);
-        functionNameCache.put(fid, answer);
+        this->GetFunctionName(function_identifier, *answer);
+        functionNameCache.put(function_identifier, answer);
         return answer;
     }
 };
@@ -845,7 +864,7 @@ NameCache::NameCache(size_t maximumSize) : maxSize(maximumSize)
 {
 }
 
-shared::WSTRING* NameCache::get(UINT_PTR key)
+shared::WSTRING* NameCache::get(FunctionIdentifier key)
 {
     const auto found = map.find(key);
     if (found == map.end())
@@ -858,9 +877,9 @@ shared::WSTRING* NameCache::get(UINT_PTR key)
     return found->second->second;
 }
 
-void NameCache::put(UINT_PTR key, shared::WSTRING* val)
+void NameCache::put(FunctionIdentifier key, shared::WSTRING* val)
 {
-    const auto pair = std::pair<FunctionID, shared::WSTRING*>(key, val);
+    const auto pair = std::pair(key, val);
     list.push_front(pair);
     map[key] = list.begin();
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -612,6 +612,8 @@ public:
     {
         const auto function_identifier = this->GetFunctionIdentifier(fid, frame);
 
+        // TODO Splunk: consider two layers cache. Based on FunctionID while CLR is suspended.
+        // The second one based on Function token (mdToken) and ModuleID - it can susrvive multiple CLR suspensions.
         shared::WSTRING* answer = functionNameCache.get(function_identifier);
         if (answer != nullptr)
         {

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -24,7 +24,8 @@ extern "C"
 
 namespace trace
 {
-struct SamplingStatistics {
+struct SamplingStatistics
+{
     int microsSuspended;
     int numThreads;
     int totalFrames;
@@ -113,21 +114,48 @@ private:
     void writeUInt64(uint64_t val) const;
 };
 
+struct FunctionIdentifier
+{
+    mdToken function_token;
+    ModuleID module_id;
+    bool is_valid;
+
+    bool operator==(const FunctionIdentifier& p) const
+    {
+        return function_token == p.function_token && module_id == p.module_id && is_valid == p.is_valid;
+    }
+};
+} // namespace trace
+
+template <>
+struct std::hash<trace::FunctionIdentifier>
+{
+    std::size_t operator()(const trace::FunctionIdentifier& k) const
+    {
+        using std::hash;
+        using std::size_t;
+        using std::string;
+
+        std::size_t h1 = std::hash<mdToken>()(k.function_token);
+        std::size_t h2 = std::hash<ModuleID>()(k.module_id);
+
+        return h1 ^ h2;
+    }
+};
+
+namespace trace {
 class NameCache
 {
 public:
     NameCache(size_t maximumSize);
-    shared::WSTRING* get(UINT_PTR key);
-    void put(UINT_PTR key, shared::WSTRING* val);
+    shared::WSTRING* get(FunctionIdentifier key);
+    void put(FunctionIdentifier key, shared::WSTRING* val);
 
 private:
     size_t maxSize;
-    std::list<std::pair<FunctionID, shared::WSTRING*>> list;
-    std::unordered_map<FunctionID, std::list<std::pair<FunctionID, shared::WSTRING*>>::iterator> map;
+    std::list<std::pair<FunctionIdentifier, shared::WSTRING*>> list;
+    std::unordered_map<FunctionIdentifier, std::list<std::pair<FunctionIdentifier, shared::WSTRING*>>::iterator> map;
 };
-
-
-
 } // namespace trace
 
 bool ThreadSampling_ShouldProduceThreadSample();

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -146,6 +146,9 @@ struct std::hash<trace::FunctionIdentifier>
 namespace trace {
 class NameCache
 {
+// TODO Splunk: cache based on mdToken (Function token) and ModuleID
+// ModuleID is volatile but it is unlikely to have exactly same pair of Function Token and ModuleId after changes.
+// If fails we should end up we Unknown(unknown) as a result
 public:
     NameCache(size_t maximumSize);
     shared::WSTRING* get(FunctionIdentifier key);

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
@@ -135,26 +135,26 @@ TEST(ThreadSamplerTest, LRUCache)
     NameCache cache(max);
     for (int i = 1; i <= max; i++)
     {
-        ASSERT_EQ(NULL, cache.get(i));
+        ASSERT_EQ(NULL, cache.get(FunctionIdentifier{static_cast<unsigned>(i), 0, true}));
         auto val = new shared::WSTRING(L"Function ");
         val->append(std::to_wstring(i));
-        cache.put(i, val);
-        ASSERT_EQ(val, cache.get(i));
+        cache.put(FunctionIdentifier{static_cast<unsigned>(i), 0, true}, val);
+        ASSERT_EQ(val, cache.get(FunctionIdentifier{static_cast<unsigned>(i), 0, true}));
     }
     // Now cache is full; add another and item 1 gets kicked out
     auto* funcMaxPlus1 = new shared::WSTRING(L"Function max+1");
-    ASSERT_EQ(NULL, cache.get(max+1));
-    cache.put(max + 1, funcMaxPlus1);
-    ASSERT_EQ(NULL, cache.get(1));
-    ASSERT_EQ(funcMaxPlus1, cache.get(max+1));
+    ASSERT_EQ(NULL, cache.get(FunctionIdentifier{static_cast<unsigned>(max + 1), 0, true}));
+    cache.put(FunctionIdentifier{static_cast<unsigned>(max + 1), 0, true}, funcMaxPlus1);
+    ASSERT_EQ(NULL, cache.get(FunctionIdentifier{static_cast<unsigned>(1), 0, true}));
+    ASSERT_EQ(funcMaxPlus1, cache.get(FunctionIdentifier{static_cast<unsigned>(max + 1), 0, true}));
 
     // Put 1 back, 2 falls off and everything else is there
     const auto func1 = new shared::WSTRING(L"Function 1");
-    cache.put(1, func1);
-    ASSERT_EQ(NULL, cache.get(2));
-    ASSERT_EQ(func1, cache.get(1));
-    ASSERT_EQ(funcMaxPlus1, cache.get(max+1));
+    cache.put(FunctionIdentifier { 1, 0, true }, func1);
+    ASSERT_EQ(NULL, cache.get(FunctionIdentifier{2, 0, true}));
+    ASSERT_EQ(func1, cache.get(FunctionIdentifier{static_cast<unsigned>(1), 0, true}));
+    ASSERT_EQ(funcMaxPlus1, cache.get(FunctionIdentifier{static_cast<unsigned>(max + 1), 0, true}));
     for (int i = 3; i <= max; i++) {
-        ASSERT_EQ(true, cache.get(i) != NULL);
+        ASSERT_EQ(true, cache.get(FunctionIdentifier{static_cast<unsigned>(i), 0, true}) != NULL);
     }
 }


### PR DESCRIPTION
## Why

FunctionId is volatile and can be changed.

## What

Cache for function name based on Function Token and Module Id.

## Tests

CI
Local tests  to verify if the cache is working correctly. For our Sample app each function name is calculated only once. Second sampling is taking data from the cache.
