### PR TITLE
Fix zip artifact name

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/upload-artifact@v3.0.0
         with:
           name: zip
-          path: tracer/bin/artifacts/windows-tracer-home.zip
+          path: tracer/bin/artifacts/signalfx-dotnet-tracing-*.zip
 
   create-release:
     name: Create GH release
@@ -89,6 +89,6 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v}
       - name: Create Release
-        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi zip/windows-tracer-home.zip nuget/SignalFx.NET.Tracing.Azure.Site.Extension.*.nupkg
+        run: gh release create v${{ steps.get_version.outputs.VERSION }} --draft artifacts/signalfx* artifacts/x64/en-us/*.msi  artifacts/x86/en-us/*.msi zip/signalfx-dotnet-tracing-*.zip nuget/SignalFx.NET.Tracing.Azure.Site.Extension.*.nupkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -45,7 +45,6 @@ partial class Build
     AbsolutePath SymbolsDirectory => TracerHome ?? (OutputDirectory / "symbols");
     AbsolutePath DDTracerHomeDirectory => DDTracerHome ?? (OutputDirectory / "dd-tracer-home");
     AbsolutePath ArtifactsDirectory => Artifacts ?? (OutputDirectory / "artifacts");
-    AbsolutePath WindowsTracerHomeZip => ArtifactsDirectory / "windows-tracer-home.zip";
     AbsolutePath WindowsSymbolsZip => ArtifactsDirectory / "windows-native-symbols.zip";
     AbsolutePath BuildDataDirectory => TracerDirectory / "build_data";
     AbsolutePath ToolSourceDirectory => ToolSource ?? (OutputDirectory / "runnerTool");
@@ -597,15 +596,17 @@ partial class Build
         .Requires(() => Version)
         .Executes(() =>
         {
+            const string packageName = "signalfx-dotnet-tracing";
+
             if (IsWin)
             {
-                CompressZip(TracerHomeDirectory, WindowsTracerHomeZip, fileMode: FileMode.Create);
+                var zipPath = ArtifactsDirectory / $"{packageName}-{Version}.zip";
+                CompressZip(TracerHomeDirectory, zipPath, fileMode: FileMode.Create);
             }
             else if (IsLinux)
             {
                 var fpm = Fpm.Value;
                 var gzip = GZip.Value;
-                var packageName = "signalfx-dotnet-tracing";
 
                 var workingDirectory = ArtifactsDirectory / $"linux-{LinuxArchitectureIdentifier}";
                 EnsureCleanDirectory(workingDirectory);

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -125,7 +125,6 @@ partial class Build : NukeBuild
             EnsureCleanDirectory(NativeProfilerProject.Directory / "deps");
             EnsureCleanDirectory(BuildDataDirectory);
             EnsureCleanDirectory(ExplorationTestsDirectory);
-            DeleteFile(WindowsTracerHomeZip);
 
             void DeleteReparsePoints(string path)
             {


### PR DESCRIPTION
## What

Changes `windows-tracer-home.zip` to `signalfx-dotnet-tracing-{Version}.zip`, so the naming style matches with other artifacts.