### PR TITLE
Add net6.0 target to ConsoleApp

### DIFF
--- a/tracer/samples/ConsoleApp/ConsoleApp.csproj
+++ b/tracer/samples/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Why

Tracer is now targeted netcoreapp3.1 and net6.0.
It is easier to cover all cases here.

## What

Add net6.0 target for ConsoleApp

## Tests

Manual testing.