### PR TITLE
Lock Docker compose dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - "15672"
 
   servicestackredis_arm64:
-    image: redis:4-alpine
+    image: redis:4.0.4-alpine
     command: redis-server --bind 0.0.0.0
     ports:
     - "6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   # ARM64 dependencies
   aws_sqs_arm64:
-    image: softwaremill/elasticmq
+    image: softwaremill/elasticmq:1.3.7
     ports:
     - "9324"
 
@@ -22,7 +22,7 @@ services:
     command: mongod
 
   mysql_arm64:
-    image: mysql/mysql-server:8.0
+    image: mysql/mysql-server:8.0.29-aarch64
     environment:
     - MYSQL_DATABASE=world
     - MYSQL_ROOT_PASSWORD=mysqldb
@@ -41,7 +41,7 @@ services:
     - "5432"
 
   rabbitmq_arm64:
-    image: rabbitmq:3-management
+    image: rabbitmq:3.9.13-management
     command: rabbitmq-server
     ports:
       - "5672"
@@ -62,37 +62,37 @@ services:
     - SA_PASSWORD=Strong!Passw0rd
 
   stackexchangeredis_arm64:
-    image: redis:4-alpine
+    image: redis:4.0.4-alpine
     command: redis-server --bind 0.0.0.0
     ports:
     - "6379"
 
 # Dependencies
   aws_sqs:
-    image: softwaremill/elasticmq
+    image: softwaremill/elasticmq:1.3.7
     ports:
     - "127.0.0.1:9324:9324"
 
   aerospike:
-    image: aerospike/aerospike-server
+    image: aerospike/aerospike-server:6.0.0.0
     ports:
     - "127.0.0.1:3000:3000"
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:3.9.13-management
     command: rabbitmq-server
     ports:
       - "127.0.0.1:5672:5672"
       - "127.0.0.1:15672:15672"
 
   servicestackredis:
-    image: redis:4-alpine
+    image: redis:4.0.4-alpine
     command: redis-server --bind 0.0.0.0
     ports:
     - "127.0.0.1:6379:6379"
 
   stackexchangeredis:
-    image: redis:4-alpine
+    image: redis:4.0.4-alpine
     command: redis-server --bind 0.0.0.0
     ports:
     - "127.0.0.1:6389:6379"
@@ -166,7 +166,7 @@ services:
     - "127.0.0.1:3407:3306"
 
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:latest
+    image: mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04
     ports:
     - "127.0.0.1:1433:1433"
     environment:

--- a/docs/internal/version-bump.md
+++ b/docs/internal/version-bump.md
@@ -9,6 +9,7 @@ This section describes dependencies that require a periodical version bump.
 | NuGet | .csproj | Upstream | Test packages might need to stay on a certain version. |
 | GitHub CI | ./github/workflows/*.yml | Dependabot | Bumps GitHub step templates |
 | Docker | *.dockerfile | Dependabot | Bumps Docker image versions |
+| Docker | docker-compose.yml | Manual | Search for `image:` |
 | .NET SDK | (CI templates) | Manual | Search for `actions/setup-dotnet` or `dotnetSdkVersion:` |
 | ASP.NET Runtime | *.dockerfile | Manual | Search for `./dotnet-install.sh --runtime aspnetcore` |
 | GitHub CI OS | ./github/workflows/*.yml | Manual | Search for `runs-on:` |
@@ -22,4 +23,3 @@ This section describes dependencies tracked and verified using hardcoded checksu
 | Dependency | Files | Bumping | Checksum | Notes |
 |-|-|-|-|-|
 | dotnet-install.sh | *.dockerfile | Manual | SHA256 | |
-


### PR DESCRIPTION
## What

Follow up of https://github.com/signalfx/signalfx-dotnet-tracing/pull/478
Dependabot currently doesn't support yet updates. See https://github.com/dependabot/dependabot-core/issues/390

Issues:
* `servicestackredis_arm64` and `stackexchangeredis_arm64` seem to be duplicate. Are they both needed?
* `sqledge_arm64` only `mcr.microsoft.com/azure-sql-edge:latest` available.
* `mcr.microsoft.com/dotnet/framework/wcf:4.8` not possible to fix patch without server specification. 
* `StartDependencies` only `andrewlock/wait-for-dependencies` latest available.