### PR TITLE
Create only one Trace instance

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -173,6 +173,8 @@ namespace Datadog.Trace.ClrProfiler
                 }
             }
 
+            InitializeThreadSampling();
+
             Log.Debug("Initialization finished.");
         }
 
@@ -266,6 +268,12 @@ namespace Datadog.Trace.ClrProfiler
                 }
             }
 #endif
+
+            Log.Debug("Initialization of non native parts finished.");
+        }
+
+        private static void InitializeThreadSampling()
+        {
             // Thread Sampling ("profiling") feature
             if (TracerManager.Instance.Settings.ThreadSamplingEnabled)
             {
@@ -287,8 +295,6 @@ namespace Datadog.Trace.ClrProfiler
                     Log.Error("Cannot initialize thread sampling. .NET version is not supported.");
                 }
             }
-
-            Log.Debug("Initialization of non native parts finished.");
         }
 
 #if !NETFRAMEWORK

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -153,6 +153,9 @@ namespace Datadog.Trace.ClrProfiler
             InitializeNoNativeParts();
             var tracer = Tracer.Instance;
 
+            // before this line you should not call anything related to TracerManager.Instance
+            // otherwise you can have multiple instances of Tracer
+
             if (tracer is null)
             {
                 Log.Debug("Skipping TraceMethods initialization because Tracer.Instance was null after InitializeNoNativeParts was invoked");
@@ -274,6 +277,8 @@ namespace Datadog.Trace.ClrProfiler
 
         private static void InitializeThreadSampling()
         {
+            // this method should be called when Tracer.Instance is initialized
+            // otherwise it can produce multiple tracer instances
             // Thread Sampling ("profiling") feature
             if (TracerManager.Instance.Settings.ThreadSamplingEnabled)
             {


### PR DESCRIPTION
## Why

Fix bug - creating two Trace instances when
metrics (core or trace) are enabled.

## What

Postpone AlwaysOn Profiler initialization
untill Trace.Instance is fully inittialized
to avoid multiple Trace instances

## Tests

CI
Local tests with extended logging to ensure that only one Trace instance is created.
