### PR TITLE
bump otel/opentelemetry-collector-contrib from 0.47.0 to 0.50.0

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "14250:14250"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.47.0
+    image: otel/opentelemetry-collector-contrib:0.50.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
     command: --config /etc/otel/config.yaml


### PR DESCRIPTION
## Why

To be in sync with collector releases

## What

bump otel/opentelemetry-collector-contrib from 0.47.0 to 0.50.0

## Tests

Manual tests with profiling.
