### PR TITLE
B3 and W3C as default propagators

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### General
 
+- Add `W3C` as default propagator.
+
 ### Breaking changes
 
 ### Enhancements

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,8 @@ to capture and send telemetry data (metrics, traces, and logs).
 By default:
 
 - all spans are sampled and reported,
-- [B3 headers](https://github.com/openzipkin/b3-propagation) are used for context
-  propagation,
+- [B3 headers](https://github.com/openzipkin/b3-propagation) and [W3C headers](https://docs.dapr.io/developing-applications/building-blocks/observability/w3c-tracing/w3c-tracing-overview/)
+  are used for context propagation,
 - Zipkin trace exporter is used to send spans as JSON in the [Zipkin v2 format](https://zipkin.io/zipkin-api/#/default/post_spans).
 
 The SignalFx Instrumentation for .NET registers an OpenTracing `GlobalTracer`

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -107,7 +107,7 @@ in addition to `SIGNALFX_ACCESS_TOKEN`.
 
 | Setting | Description | Default |
 |-|-|-|
-| `SIGNALFX_PROPAGATORS` | Comma-separated list of the propagators for the tracer. Available propagators are: `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3` |
+| `SIGNALFX_PROPAGATORS` | Comma-separated list of the propagators for the tracer. Available propagators are: `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `B3,W3C` |
 
 [OpenTelemetry `OTEL_PROPAGATORS`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration)
 to `SIGNALFX_PROPAGATORS` values mapping:

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -182,7 +182,7 @@ namespace Datadog.Trace.Configuration
             DelayWcfInstrumentationEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
                                             ?? false;
 
-            PropagationStyleInject = TrimSplitString(source?.GetString(ConfigurationKeys.Propagators) ?? nameof(Propagators.ContextPropagators.Names.B3), ',').ToArray();
+            PropagationStyleInject = TrimSplitString(source?.GetString(ConfigurationKeys.Propagators) ?? $"{nameof(Propagators.ContextPropagators.Names.B3)},{nameof(Propagators.ContextPropagators.Names.W3C)}", ',').ToArray();
 
             PropagationStyleExtract = PropagationStyleInject;
 

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -51,7 +51,8 @@ namespace Datadog.Trace.Propagators
 
                     var distributedContextPropagator = (IContextExtractor)new DistributedContextExtractor();
                     var b3Propagator = new B3ContextPropagator();
-                    _instance ??= new SpanContextPropagator(new[] { b3Propagator }, new[] { distributedContextPropagator, b3Propagator });
+                    var w3cPropagator = new W3CContextPropagator();
+                    _instance ??= new SpanContextPropagator(new IContextInjector[] { b3Propagator, w3cPropagator }, new[] { distributedContextPropagator, b3Propagator, w3cPropagator });
                     return _instance;
                 }
             }


### PR DESCRIPTION
## Why

Align propagator with OTel recommendation (W3C).

## What

Support by default, both B3 and W3C propagators.

## Tests

CI
