### PR TITLE
Replace Datadog.Trace namespace by SignalFx.Tracing

### DIFF
--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
@@ -138,7 +138,8 @@ namespace Datadog.Trace.AlwaysOnProfiler
                         continue;
                     }
 
-                    threadSample.StackTrace = stackTraceBuilder.ToString();
+                    // we are replacing Datadog.Trace namespace to avoid conflicts while upstream sync
+                    threadSample.StackTrace = stackTraceBuilder.Replace("Datadog.Trace.", "SignalFx.Tracing.").ToString();
                     samples.Add(threadSample);
                 }
                 else if (operationCode == OpCodes.EndBatch)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedLogRecord = "\tat System.Threading.Thread.Sleep(System.TimeSpan)\n" +
                                     "\tat Samples.AlwaysOnProfiler.Fs.ClassFs.methodFs(System.String)\n" +
                                     "\tat Samples.AlwaysOnProfiler.Vb.ClassVb.MethodVb(System.String)\n" +
-                                    "\tat My.Custom.Test.Namespace.TestDynamicClass.TryInvoke(System.Dynamic.InvokeBinder, System.Object[], System.Object\u0026)\n" +
+                                    "\tat SignalFx.Tracing.TestDynamicClass.TryInvoke(System.Dynamic.InvokeBinder, System.Object[], System.Object\u0026)\n" +
                                     "\tat System.Dynamic.UpdateDelegates.UpdateAndExecuteVoid3[T0, T1, T2](System.Runtime.CompilerServices.CallSite, T0, T1, T2)\n";
 #if NETCOREAPP3_1
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Runtime.InteropServices;
 using My.Custom.Test.Namespace;
-using Samples.AlwaysOnProfiler.Vb;
 
 ClassA.MethodA();
 
@@ -136,17 +135,22 @@ namespace My.Custom.Test.Namespace
     {
         public static void GenericMethodDFromGenericClass<TMethod, TMethod2>(TClass classArg, TMethod methodArg, TMethod2 additionalArg)
         {
-            dynamic test = new TestDynamicClass();
+            dynamic test = new Datadog.Trace.TestDynamicClass();
 
             test("Param1", "Param2");
         }
     }
 
+
+}
+
+// Datadog.Trace namespace will be replaced by SignalFx.Tracing by the ThreadSampleNativeFormatParser
+namespace Datadog.Trace {
     internal class TestDynamicClass : DynamicObject
     {
         public override bool TryInvoke(InvokeBinder binder, object[] args, out object result)
         {
-            ClassVb.MethodVb("testParam");
+            Samples.AlwaysOnProfiler.Vb.ClassVb.MethodVb("testParam");
             result = null;
             return true;
         }

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
@@ -145,7 +145,8 @@ namespace My.Custom.Test.Namespace
 }
 
 // Datadog.Trace namespace will be replaced by SignalFx.Tracing by the ThreadSampleNativeFormatParser
-namespace Datadog.Trace {
+namespace Datadog.Trace
+{
     internal class TestDynamicClass : DynamicObject
     {
         public override bool TryInvoke(InvokeBinder binder, object[] args, out object result)


### PR DESCRIPTION
## Why

To have better stacktraces on AlwaysOn Profiler side without huge code changes. 

## What

Replace Datadog.Trace namespace by SignalFx.Tracing
in AlwaysOn Profiler parser

## Tests

CI tests extended.
