### PR TITLE
[AlwaysOnProfiling] Tests setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,6 @@ tracer/test/test-applications/integrations/dependency-libs/Samples.AlwaysOnProfi
 
 .ionide/
 /devenv.bat
+
+# benchmark test results directory
+/dev-aop/results

--- a/dev-aop/basic.js
+++ b/dev-aop/basic.js
@@ -1,0 +1,74 @@
+import http from 'k6/http';
+import {check} from "k6";
+
+const baseUri = `http://${__ENV.app_name}:80/api`;
+// console.log(`running test against: ${baseUri}`);
+
+function randItem(list){
+    return list[rand(list.length)];
+}
+
+function rand(max){
+    return Math.floor(Math.random() * Math.floor(max))
+}
+
+function randomItem(items) {
+    const toDuplicate = randItem(items);
+    return {
+        // for now, use fixed type/brand, duplicate other values from a random item from the list
+        catalogBrandId: 1,
+        catalogTypeId: 1,
+        description: `duplicate for ${toDuplicate.id}`,
+        name: `duplicated from ${toDuplicate.name}`,
+        pictureUri: toDuplicate.pictureUri,
+        price: toDuplicate.price + 1
+    };
+}
+
+export default function () {
+    
+    const catalogItems = `${baseUri}/catalog/list`;
+    const catalogRetrieval = http.get(catalogItems);
+    check(catalogRetrieval, { "retrieve catalog status 200": r => r.status === 200 });
+    
+    const catalog = JSON.parse(catalogRetrieval.body);
+        
+    // Add new items to the list
+    const newItem1 = randomItem(catalog.catalogItems);
+    const newItem2 = randomItem(catalog.catalogItems);
+    const newItem3 = randomItem(catalog.catalogItems);
+
+    const itemUrl = `${baseUri}/catalog-items`;
+    
+    const itemAdditions = http.batch([
+        ["POST", itemUrl, JSON.stringify(newItem1), { headers: { 'Content-Type': 'application/json' } } ],
+        ["POST", itemUrl, JSON.stringify(newItem2), { headers: { 'Content-Type': 'application/json' } } ],
+        ["POST", itemUrl, JSON.stringify(newItem3), { headers: { 'Content-Type': 'application/json' } } ],
+    ]);
+
+    check(itemAdditions[0], { "add item status 200": r => r.status === 200});
+    check(itemAdditions[1], { "add item status 200": r => r.status === 200});
+    check(itemAdditions[2], { "add item status 200": r => r.status === 200});
+
+    // Verify they can be retrieved
+    const itemRetrievals = http.batch([
+        ["GET", `${itemUrl}/${JSON.parse(itemAdditions[0].body).catalogItem.id}`],
+        ["GET", `${itemUrl}/${JSON.parse(itemAdditions[1].body).catalogItem.id}`],
+        ["GET", `${itemUrl}/${JSON.parse(itemAdditions[2].body).catalogItem.id}`]
+    ]);
+    
+    check(itemRetrievals[0], { "retrieve item status 200": r => r.status === 200});
+    check(itemRetrievals[1], { "retrieve item status 200": r => r.status === 200});
+    check(itemRetrievals[2], { "retrieve item status 200": r => r.status === 200});
+
+    // Clean up
+    const itemDeletions = http.batch([
+        ["DELETE", `${itemUrl}/${JSON.parse(itemAdditions[0].body).catalogItem.id}`],
+        ["DELETE", `${itemUrl}/${JSON.parse(itemAdditions[1].body).catalogItem.id}`],
+        ["DELETE", `${itemUrl}/${JSON.parse(itemAdditions[2].body).catalogItem.id}`]
+    ]);
+
+    check(itemDeletions[0], { "delete item status 200": r => r.status === 200});
+    check(itemDeletions[1], { "delete item status 200": r => r.status === 200});
+    check(itemDeletions[2], { "delete item status 200": r => r.status === 200});
+}

--- a/dev-aop/docker-compose.yml
+++ b/dev-aop/docker-compose.yml
@@ -1,0 +1,84 @@
+version: '3.4'
+
+services:
+  eshop-app-instrumented:
+    #TODO: local image used for now
+    image: eshop-instrumented
+    container_name: eshop-app-instrumented
+    profiles:
+      - "eshop-app-instrumented"
+    depends_on:
+      - "sqlserver"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - SIGNALFX_ENDPOINT_URL=http://otel-collector:9411/api/v2/spans
+      - SIGNALFX_PROFILER_LOGS_ENDPOINT=http://otel-collector:4318/v1/logs
+    volumes:
+      - type: volume
+        source: tmp
+        target: /tmp
+  eshop-app:
+    #TODO: local image used for now
+    image: eshop
+    container_name: eshop-app
+    profiles:
+      - "eshop-app"
+    depends_on:
+      - "sqlserver"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    volumes:
+      - type: volume
+        source: tmp
+        target: /tmp
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:latest
+    environment:
+    - ACCEPT_EULA=Y
+    # needs to be in sync with whats in connection string in sample app's appsettings file
+    - SA_PASSWORD=@someThingComplicated1234
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.50.0
+    volumes:
+      - ./otel-config.yaml:/etc/otel/config.yaml
+    command: --config /etc/otel/config.yaml
+  dotnet-counters:
+    build:
+      context: .
+      dockerfile: dotnet-counters-in-sdk.dockerfile
+    container_name: dotnet-counters
+    working_dir: /app
+    volumes:
+      # /tmp directory needs to be shared between target app and this sidecar container
+      - type: volume
+        source: tmp
+        target: /tmp
+      - ./results:/app
+    # target app and sidecar need to share the process namespace
+    pid: "container:${app_name}"
+    command: dotnet counters collect --process-id 1 --refresh-interval 1 --format json --output ${app_name}/counters.json
+      
+  StartDependencies:
+    image: andrewlock/wait-for-dependencies
+    depends_on:
+      - otel-collector
+      - sqlserver
+      - ${app_name}
+    environment:
+      - TIMEOUT_LENGTH=120
+    command: otel-collector:13133 sqlserver:1433 ${app_name}:80
+  RunWarmup:
+    image: grafana/k6
+    volumes:
+      - ./basic.js:/app/basic.js
+    command: run -e app_name=${app_name} -u 10 -i 500 /app/basic.js
+  RunTest:
+    image: grafana/k6
+    depends_on: 
+      - dotnet-counters
+    volumes:
+      - ./basic.js:/app/basic.js
+      - ./results:/results
+    command: run -e app_name=${app_name} -u 30 -i 8500 /app/basic.js --summary-export /results/${app_name}/k6-test-summary.json
+volumes:
+  tmp:

--- a/dev-aop/dotnet-counters-in-sdk.dockerfile
+++ b/dev-aop/dotnet-counters-in-sdk.dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/dotnet/sdk:3.1
+
+RUN dotnet tool install dotnet-counters --tool-path /usr/bin

--- a/dev-aop/instrumented-app.dockerfile
+++ b/dev-aop/instrumented-app.dockerfile
@@ -1,0 +1,24 @@
+# TODO: local base image, to be replaced
+FROM eshop
+
+# Set up SignalFx APM
+# TODO: update with release
+ARG TRACER_VERSION=0.2.4
+RUN mkdir -p /var/log/signalfx
+RUN mkdir -p /opt/signalfx
+
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
+    curl
+
+RUN curl -LO https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
+RUN dpkg -i ./signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
+
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}
+ENV CORECLR_PROFILER_PATH=/opt/signalfx/SignalFx.Tracing.ClrProfiler.Native.so
+ENV SIGNALFX_DOTNET_TRACER_HOME=/opt/signalfx
+
+# Enable AlwaysOnProfiling
+ENV SIGNALFX_PROFILER_ENABLED=1

--- a/dev-aop/otel-config.yaml
+++ b/dev-aop/otel-config.yaml
@@ -1,0 +1,29 @@
+extensions:
+  health_check:
+
+receivers:
+  zipkin:
+  otlp:
+    protocols:
+      grpc:
+      http:
+  
+processors:
+  batch:
+
+exporters:
+  logging:
+    logLevel: info
+
+service:
+  pipelines:
+    traces:
+      receivers: [ zipkin ]
+      processors: [ batch ]
+      exporters: [ logging ]
+    logs:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ logging ]
+
+  extensions: [ health_check ]

--- a/dev-aop/run-test.sh
+++ b/dev-aop/run-test.sh
@@ -1,0 +1,20 @@
+﻿#!/usr/bin/env bash
+set -euox pipefail
+
+for profile in "eshop-app" "eshop-app-instrumented"; do
+  #TODO: cleanup profile usage
+  
+  mkdir -p ./results/$profile
+  
+  # start dependencies and an app from specified profile
+  app_name=$profile docker-compose --profile $profile up StartDependencies
+  
+  # run warmup (similar to load test, but with limited iterations/users, not exporting the results)
+  app_name=$profile docker-compose run RunWarmup
+  
+  # run test
+  app_name=$profile docker-compose run RunTest
+  
+  # cleanup
+  app_name=$profile docker-compose --profile $profile down
+done


### PR DESCRIPTION
## Why

Capture metrics from local app running and without instrumentation/profiling.

## What

`Docker-compose` configuration for running:
- eShopOnWeb `netcore 3.1` [app](https://github.com/dotnet-architecture/eShopOnWeb/tree/e5e9868003b2e940c731cdf34a3b8fa2a89d272c/src/Web)
- `sqlserver` used by the app
- `dotnet-counters` running in sidecar container to capture runtime metrics
- `k6` for driving the load on the app

Simple script for running different `compose` profiles and saving `k6` summary and events captured by `dotnet-counters` in json format for analysis.

## TODO:

- replace usage of locally built images
- expand script used by `k6`
- use `testcontainers`
- run `otel-collector` and `sqlserver` separately
## Tests

n/a
