### PR TITLE
Document how to verify file integrity

### DIFF
--- a/docs/internal/verify-file-integrity.md
+++ b/docs/internal/verify-file-integrity.md
@@ -1,0 +1,43 @@
+# Verify file integrity
+
+## Checksums
+
+The `checksums.txt` lists SHA-256 hash of all published artifacts.
+You can use `checksums.txt` to verify the integrity of all published artifacts
+using `shasum`.
+
+```bash
+shasum -a 256 -c checksums.txt
+```
+
+`checksums.txt.asc` is a PGP signature file `checksums.txt`.
+You can use [SplunkPGPKey.pub](https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub)
+and `checksums.txt.asc` to verify the integrity of `checksums.txt`.
+
+```bash
+curl -O https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub
+gpg --import SplunkPGPKey.pub
+gpg --verify checksums.txt.asc checksums.txt
+```
+
+## DEB package
+
+You can use [SplunkPGPKey.pub](https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub)
+to verify the integrity of the DEB packages using `dpkg-sig`.
+
+```bash
+curl -O https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub
+gpg --import SplunkPGPKey.pub
+dpkg-sig --verify signalfx-dotnet-tracing-*.deb
+```
+
+## RPM package
+
+You can use [SplunkPGPKey.pub](https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub)
+to verify the integrity of the RPM packages.
+
+```bash
+curl -O https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub
+rpm --import SplunkPGPKey.pub
+rpm -K signalfx-dotnet-tracing-*.rpm
+```


### PR DESCRIPTION
## Why

Add instructions for users if they want to check the signatures.

## What

Document how to verify file integrity

## Tests

TBH I tested only the `checksums.txt` and  `checksums.txt.asc`. I am 80% sure the DEB and RPM package verification is correct. At the same time, I estimate for 80% that nobody will use these docs. I am lazy and I don't think it is worth investing more time on testing it at the moment.
