### PR TITLE
[AlwaysOn Profiler] two layers cache - fixes

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -671,13 +671,13 @@ void ThreadSampler::ThreadNameChanged(ThreadID thread_id, ULONG cch_name, WCHAR 
     state->thread_name_.append(name, cch_name);
 }
 
-template <typename TFunctionIdentifier>
-NameCache<TFunctionIdentifier>::NameCache(const size_t maximum_size) : max_size_(maximum_size)
+template <typename TKey>
+NameCache<TKey>::NameCache(const size_t maximum_size) : max_size_(maximum_size)
 {
 }
 
-template <typename TFunctionIdentifier>
-shared::WSTRING* NameCache<TFunctionIdentifier>::Get(TFunctionIdentifier key)
+template <typename TKey>
+shared::WSTRING* NameCache<TKey>::Get(TKey key)
 {
     const auto found = map_.find(key);
     if (found == map_.end())
@@ -690,8 +690,8 @@ shared::WSTRING* NameCache<TFunctionIdentifier>::Get(TFunctionIdentifier key)
     return found->second->second;
 }
 
-template <typename TFunctionIdentifier>
-shared::WSTRING* NameCache<TFunctionIdentifier>::Put(TFunctionIdentifier key, shared::WSTRING* val)
+template <typename TKey>
+shared::WSTRING* NameCache<TKey>::Put(TKey key, shared::WSTRING* val)
 {
     const auto pair = std::pair(key, val);
     list_.push_front(pair);
@@ -708,8 +708,8 @@ shared::WSTRING* NameCache<TFunctionIdentifier>::Put(TFunctionIdentifier key, sh
     return nullptr;
 }
 
-template <typename TFunctionIdentifier>
-void NameCache<TFunctionIdentifier>::Clear()
+template <typename TKey>
+void NameCache<TKey>::Clear()
 {
     map_.clear();
     list_.clear();

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -244,8 +244,8 @@ class SamplingHelper
 public:
     // These are permanent parts of the helper object
     ICorProfilerInfo10* info10_ = nullptr;
-    NameCache<FunctionIdentifier> function_name_cache_;
-    NameCache<FunctionID> volatile_function_name_cache_;
+    NameCache<FunctionIdentifier, shared::WSTRING*> function_name_cache_;
+    NameCache<FunctionID, shared::WSTRING*> volatile_function_name_cache_;
     // These cycle every sample and/or are owned externally
     ThreadSamplesBuffer* cur_writer_ = nullptr;
     std::vector<unsigned char>* cur_buffer_ = nullptr;
@@ -671,13 +671,14 @@ void ThreadSampler::ThreadNameChanged(ThreadID thread_id, ULONG cch_name, WCHAR 
     state->thread_name_.append(name, cch_name);
 }
 
-template <typename TKey>
-NameCache<TKey>::NameCache(const size_t maximum_size) : max_size_(maximum_size)
+
+template <typename TKey, typename TValue>
+NameCache<TKey, TValue>::NameCache(const size_t maximum_size) : max_size_(maximum_size)
 {
 }
 
-template <typename TKey>
-shared::WSTRING* NameCache<TKey>::Get(TKey key)
+template <typename TKey, typename TValue>
+TValue NameCache<TKey, TValue>::Get(TKey key)
 {
     const auto found = map_.find(key);
     if (found == map_.end())
@@ -690,8 +691,8 @@ shared::WSTRING* NameCache<TKey>::Get(TKey key)
     return found->second->second;
 }
 
-template <typename TKey>
-shared::WSTRING* NameCache<TKey>::Put(TKey key, shared::WSTRING* val)
+template <typename TKey, typename TValue>
+TValue NameCache<TKey, TValue>::Put(TKey key, TValue val)
 {
     const auto pair = std::pair(key, val);
     list_.push_front(pair);
@@ -708,8 +709,8 @@ shared::WSTRING* NameCache<TKey>::Put(TKey key, shared::WSTRING* val)
     return nullptr;
 }
 
-template <typename TKey>
-void NameCache<TKey>::Clear()
+template <typename TKey, typename TValue>
+void NameCache<TKey, TValue>::Clear()
 {
     map_.clear();
     list_.clear();

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -147,22 +147,22 @@ struct std::hash<always_on_profiler::FunctionIdentifier>
 
 namespace always_on_profiler
 {
-template <typename TKey>
+template <typename TKey, typename TValue>
 class NameCache
 {
 // ModuleID is volatile but it is unlikely to have exactly same pair of Function Token and ModuleId after changes.
 // If fails we should end up we Unknown(unknown) as a result
 public:
     explicit NameCache(size_t maximum_size);
-    shared::WSTRING* Get(TKey key);
+    TValue Get(TKey key);
     // if max cache size is exceeded it return value which should be disposed
-    shared::WSTRING* Put(TKey key, shared::WSTRING* val);
+    TValue Put(TKey key, TValue val);
     void Clear();
 
 private:
     size_t max_size_;
-    std::list<std::pair<TKey, shared::WSTRING*>> list_;
-    std::unordered_map<TKey, typename std::list<std::pair<TKey, shared::WSTRING*>>::iterator> map_;
+    std::list<std::pair<TKey, TValue>> list_;
+    std::unordered_map<TKey, typename std::list<std::pair<TKey, TValue>>::iterator> map_;
 };
 } // namespace always_on_profiler
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -153,13 +153,15 @@ class NameCache
 // ModuleID is volatile but it is unlikely to have exactly same pair of Function Token and ModuleId after changes.
 // If fails we should end up we Unknown(unknown) as a result
 public:
-    explicit NameCache(size_t maximum_size);
+    explicit NameCache(size_t maximum_size, TValue default_value);
     TValue Get(TKey key);
+    void Refresh(TKey key);
     // if max cache size is exceeded it return value which should be disposed
     TValue Put(TKey key, TValue val);
     void Clear();
 
 private:
+    TValue default_value_;
     size_t max_size_;
     std::list<std::pair<TKey, TValue>> list_;
     std::unordered_map<TKey, typename std::list<std::pair<TKey, TValue>>::iterator> map_;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -147,22 +147,22 @@ struct std::hash<always_on_profiler::FunctionIdentifier>
 
 namespace always_on_profiler
 {
-template <typename TFunctionIdentifier>
+template <typename TKey>
 class NameCache
 {
 // ModuleID is volatile but it is unlikely to have exactly same pair of Function Token and ModuleId after changes.
 // If fails we should end up we Unknown(unknown) as a result
 public:
     explicit NameCache(size_t maximum_size);
-    shared::WSTRING* Get(TFunctionIdentifier key);
+    shared::WSTRING* Get(TKey key);
     // if max cache size is exceeded it return value which should be disposed
-    shared::WSTRING* Put(TFunctionIdentifier key, shared::WSTRING* val);
+    shared::WSTRING* Put(TKey key, shared::WSTRING* val);
     void Clear();
 
 private:
     size_t max_size_;
-    std::list<std::pair<TFunctionIdentifier, shared::WSTRING*>> list_;
-    std::unordered_map<TFunctionIdentifier, typename std::list<std::pair<TFunctionIdentifier, shared::WSTRING*>>::iterator> map_;
+    std::list<std::pair<TKey, shared::WSTRING*>> list_;
+    std::unordered_map<TKey, typename std::list<std::pair<TKey, shared::WSTRING*>>::iterator> map_;
 };
 } // namespace always_on_profiler
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -155,7 +155,8 @@ class NameCache
 public:
     explicit NameCache(size_t maximum_size);
     shared::WSTRING* Get(TFunctionIdentifier key);
-    void Put(TFunctionIdentifier key, shared::WSTRING* val);
+    // if max cache size is exceeded it return value which should be disposed
+    shared::WSTRING* Put(TFunctionIdentifier key, shared::WSTRING* val);
     void Clear();
 
 private:

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
@@ -132,7 +132,7 @@ TEST(ThreadSamplerTest, StaticBufferManagement)
 TEST(ThreadSamplerTest, LRUCache)
 {
     constexpr int max = 10000;
-    NameCache<FunctionID> cache(max);
+    NameCache<FunctionID, shared::WSTRING*> cache(max);
     for (int i = 1; i <= max; i++)
     {
         ASSERT_EQ(NULL, cache.Get(i));

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
@@ -132,36 +132,37 @@ TEST(ThreadSamplerTest, StaticBufferManagement)
 TEST(ThreadSamplerTest, LRUCache)
 {
     constexpr int max = 10000;
-    NameCache<FunctionID, shared::WSTRING*> cache(max);
+    NameCache<FunctionID, std::pair<shared::WSTRING*, FunctionIdentifier>> cache(max, std::pair<shared::WSTRING*, FunctionIdentifier>(nullptr, {}));
     for (int i = 1; i <= max; i++)
     {
-        ASSERT_EQ(NULL, cache.Get(i));
+        ASSERT_EQ(NULL, cache.Get(i).first);
         auto val = new shared::WSTRING(L"Function ");
         val->append(std::to_wstring(i));
-        cache.Put(i, val);
-        ASSERT_EQ(val, cache.Get(i));
+        cache.Put(i, std::pair<shared::WSTRING*, FunctionIdentifier>(val, {}));
+        ASSERT_EQ(val, cache.Get(i).first);
     }
+
     // Now cache is full; add another and item 1 gets kicked out
     auto* func_max_plus1 = new shared::WSTRING(L"Function max+1");
-    ASSERT_EQ(NULL, cache.Get(max + 1));
-    cache.Put(max + 1, func_max_plus1);
-    ASSERT_EQ(NULL, cache.Get(1));
-    ASSERT_EQ(func_max_plus1, cache.Get(max + 1));
-
+    ASSERT_EQ(NULL, cache.Get(max + 1).first);
+    cache.Put(max + 1, std::pair<shared::WSTRING*, FunctionIdentifier>(func_max_plus1, {}));
+    ASSERT_EQ(NULL, cache.Get(1).first);
+    ASSERT_EQ(func_max_plus1, cache.Get(max + 1).first);
+    
     // Put 1 back, 2 falls off and everything else is there
     const auto func1 = new shared::WSTRING(L"Function 1");
-    cache.Put(1, func1);
-    ASSERT_EQ(NULL, cache.Get(2));
-    ASSERT_EQ(func1, cache.Get(1));
-    ASSERT_EQ(func_max_plus1, cache.Get(max + 1));
+    cache.Put(1, std::pair<shared::WSTRING*, FunctionIdentifier>(func1, {}));
+    ASSERT_EQ(NULL, cache.Get(2).first);
+    ASSERT_EQ(func1, cache.Get(1).first);
+    ASSERT_EQ(func_max_plus1, cache.Get(max + 1).first);
     for (int i = 3; i <= max; i++) {
-        ASSERT_EQ(true, cache.Get(i) != NULL);
+        ASSERT_EQ(true, cache.Get(i).first != NULL);
     }
 
     // test clear cache
     cache.Clear();
     for (int i = 1; i <= max; i++)
     {
-        ASSERT_EQ(NULL, cache.Get(i));
+        ASSERT_EQ(NULL, cache.Get(i).first);
     }
 }


### PR DESCRIPTION
## Why

Fixes to #501

## What

Fix issues when the volatile cache or stable cache could remove memory used by another layer cache.

## Tests

Change settings to make the increase chance for bug occurence to

```cpp
constexpr auto kMaxFunctionNameCacheSize = 1000;
constexpr auto kMaxVolatileFunctionNameCacheSize = 5;
```

Execute 
```powershell
nuke BuildTracerHome BuildAndRunWindowsIntegrationTests  -Framework net6.0 -TargetPlatform x64 --Filter Datadog.Trace.ClrProfiler.IntegrationTests.AlwaysOnProfilerTests
```

Fail on current main. Passed on branch.

## Notes

Kudos to @lachmatt for making really good code review, even when the PR was merge.