### PR TITLE
[AlwaysOn Profiler] Document lack of support for passing pointers as parameters

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -127,8 +127,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             expectedLogRecord += "\tat Unknown_Native_Function(unknown)\n";
 #endif
             expectedLogRecord += "\tat My.Custom.Test.Namespace.ClassA.InternalClassB`2.DoubleInternalClassB.TripleInternalClassB`1.MethodB[TB](System.Int32, TC[], TB, TD, System.Collections.Generic.IList`1[TA], System.Collections.Generic.IList`1[System.String])\n" +
-                                 "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|7_0[T](System.Int32)\n" +
+                                 "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|8_0[T](System.Int32)\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodAOthers[T](System.String, System.Object, My.Custom.Test.Namespace.CustomClass, My.Custom.Test.Namespace.CustomStruct, My.Custom.Test.Namespace.CustomClass[], My.Custom.Test.Namespace.CustomStruct[], System.Collections.Generic.List`1[T])\n" +
+                                 "\tat My.Custom.Test.Namespace.ClassA.MethodAPointer(unknown)\n" + // TODO Splunk: FunctionMethodSignature::TryParse should be fixed to support pointers
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodAFloats(System.Single, System.Double)\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodAInts(System.UInt16, System.Int16, System.UInt32, System.Int32, System.UInt64, System.Int64, System.IntPtr, System.UIntPtr)\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodABytes(System.Boolean, System.Char, System.SByte, System.Byte)\n" +

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Program.cs
@@ -64,17 +64,24 @@ namespace My.Custom.Test.Namespace
             MethodAFloats(float.MaxValue, double.MaxValue);
         }
 
-        public static void MethodAFloats(
+        public static unsafe void MethodAFloats(
             float fl,
             double db)
         {
+            int a = 1;
+            int* pointer = &a;
+            MethodAPointer(pointer);
+        }
+
+        public static unsafe void MethodAPointer(int* pointer)
+        {
             MethodAOthers(string.Empty,
-                          new object(),
-                          new CustomClass(),
-                          new CustomStruct(),
-                          Array.Empty<CustomClass>(),
-                          Array.Empty<CustomStruct>(),
-                          new List<string>());
+                new object(),
+                new CustomClass(),
+                new CustomStruct(),
+                Array.Empty<CustomClass>(),
+                Array.Empty<CustomStruct>(),
+                new List<string>());
         }
 
         public static void MethodAOthers<T>(

--- a/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Samples.AlwaysOnProfiler.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AlwaysOnProfiler/Samples.AlwaysOnProfiler.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

To be able to reproduce issue on any machine. Not only on linux-CI.

## What

Document lack of support for pointer parameters in AlwaysOn Profiling.

## Tests

CI
