### PR TITLE
[AlwaysOn Profiler] Support for pointers passed as parameters

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler_clr_helpers.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler_clr_helpers.cpp
@@ -167,6 +167,13 @@ shared::WSTRING GetSigTypeTokNameNew(PCCOR_SIGNATURE& pb_cur, const ComPtr<IMeta
         ref_flag = true;
     }
 
+    bool pointer_flag = false;
+    if (*pb_cur == ELEMENT_TYPE_PTR)
+    {
+        pb_cur++;
+        pointer_flag = true;
+    }
+
     switch (*pb_cur)
     {
         case ELEMENT_TYPE_BOOLEAN:
@@ -283,6 +290,11 @@ shared::WSTRING GetSigTypeTokNameNew(PCCOR_SIGNATURE& pb_cur, const ComPtr<IMeta
     if (ref_flag)
     {
         token_name += WStr("&");
+    }
+
+    if (pointer_flag)
+    {
+        token_name += WStr("*");
     }
     return token_name;
 }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -495,6 +495,13 @@ shared::WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaData
         ref_flag = true;
     }
 
+    bool pointer_flag = false;
+    if (*pbCur == ELEMENT_TYPE_PTR)
+    {
+        pbCur++;
+        pointer_flag = true;
+    }
+
     switch (*pbCur)
     {
         case ELEMENT_TYPE_BOOLEAN:
@@ -617,6 +624,10 @@ shared::WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaData
     if (ref_flag)
     {
         tokenName += WStr("&");
+    }
+    if (pointer_flag)
+    {
+        tokenName += WStr("*");
     }
     return tokenName;
 }
@@ -841,6 +852,8 @@ bool ParseParamOrLocal(PCCOR_SIGNATURE& pbCur, PCCOR_SIGNATURE pbEnd)
     if (*pbCur == ELEMENT_TYPE_TYPEDBYREF) return false;
 
     if (*pbCur == ELEMENT_TYPE_BYREF) pbCur++;
+
+    if (*pbCur == ELEMENT_TYPE_PTR) pbCur++;
 
     return ParseType(pbCur, pbEnd);
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -129,7 +129,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             expectedLogRecord += "\tat My.Custom.Test.Namespace.ClassA.InternalClassB`2.DoubleInternalClassB.TripleInternalClassB`1.MethodB[TB](System.Int32, TC[], TB, TD, System.Collections.Generic.IList`1[TA], System.Collections.Generic.IList`1[System.String])\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.<MethodAOthers>g__Action|8_0[T](System.Int32)\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodAOthers[T](System.String, System.Object, My.Custom.Test.Namespace.CustomClass, My.Custom.Test.Namespace.CustomStruct, My.Custom.Test.Namespace.CustomClass[], My.Custom.Test.Namespace.CustomStruct[], System.Collections.Generic.List`1[T])\n" +
-                                 "\tat My.Custom.Test.Namespace.ClassA.MethodAPointer(unknown)\n" + // TODO Splunk: FunctionMethodSignature::TryParse should be fixed to support pointers
+                                 "\tat My.Custom.Test.Namespace.ClassA.MethodAPointer(System.Int32*)\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodAFloats(System.Single, System.Double)\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodAInts(System.UInt16, System.Int16, System.UInt32, System.Int32, System.UInt64, System.Int64, System.IntPtr, System.UIntPtr)\n" +
                                  "\tat My.Custom.Test.Namespace.ClassA.MethodABytes(System.Boolean, System.Char, System.SByte, System.Byte)\n" +


### PR DESCRIPTION
## Why

Fix for the issue documented under #511

## What

There were lack of support for pointer parameters such as `public static unsafe void MethodAPointer(int* pointer)`.

## Tests

CI + extended test.