### PR TITLE
use ExportLogsServiceRequest on the OTel mock collector side

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using OpenTelemetry.TestHelpers.Proto.Collector.Logs.V1;
 using OpenTelemetry.TestHelpers.Proto.Common.V1;
 using OpenTelemetry.TestHelpers.Proto.Logs.V1;
 using VerifyXunit;
@@ -138,7 +139,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return logRecord.Body.StringValue.Contains(expectedLogRecord);
         }
 
-        private async Task DumpLogRecords(LogsData[] logsData)
+        private async Task DumpLogRecords(ExportLogsServiceRequest[] logsData)
         {
             foreach (var data in logsData)
             {

--- a/tracer/test/OpenTelemetry.TestHelpers/MockOtelLogsCollector.cs
+++ b/tracer/test/OpenTelemetry.TestHelpers/MockOtelLogsCollector.cs
@@ -34,7 +34,7 @@ public class MockOtelLogsCollector : IDisposable
     /// </summary>
     public int Port { get; }
 
-    public ConcurrentQueue<LogsData> LogsData { get; } = new();
+    public ConcurrentQueue<ExportLogsServiceRequest> LogsData { get; } = new();
 
     public void Dispose()
     {
@@ -49,7 +49,7 @@ public class MockOtelLogsCollector : IDisposable
             {
                 var ctx = _listener.GetContext();
 
-                var logsData = ProtoBuf.Serializer.Deserialize<LogsData>(ctx.Request.InputStream);
+                var logsData = ProtoBuf.Serializer.Deserialize<ExportLogsServiceRequest>(ctx.Request.InputStream);
 
                 LogsData.Enqueue(logsData);
 


### PR DESCRIPTION
## Why

Fix wrongly used type on the server side.

## What

Use `ExportLogsServiceRequest` instread of `LogsData` on the OTel Mock collector side.

## Tests

CI