### PR TITLE
Add retry to Restore Nuke task

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -135,7 +135,7 @@ partial class Build
     Target Restore => _ => _
         .After(Clean)
         .Unlisted()
-        .Executes(() =>
+        .Executes(() => ControlFlow.ExecuteWithRetry(() =>
         {
             if (IsWin)
             {
@@ -155,7 +155,7 @@ partial class Build
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
                         o.SetPackageDirectory(NugetPackageDirectory)));
             }
-        });
+        }));
 
     Target CompileNativeSrcWindows => _ => _
         .Unlisted()


### PR DESCRIPTION
## Why

Recently the NuGet restore step is falling more frequently.

## What

Restore tasks executes up to 3 times before it fails.

## Tests

CI
