### PR TITLE
Move SIGNALFX_PROFILER_EXPORT_FORMAT to internal docs

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -158,4 +158,3 @@ of SignalFx Instrumentation for .NET.
 | `SIGNALFX_PROFILER_LOGS_ENDPOINT` | The URL to where logs are exported using [OTLP/HTTP v1 log protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) | `http://localhost:4318/v1/logs` |
 | `SIGNALFX_PROFILER_ENABLED` | Enable to activate thread sampling. | `false` |
 | `SIGNALFX_PROFILER_CALL_STACK_INTERVAL` | Sampling period. It defines how often the threads are stopped in order to fetch all stack traces. This value cannot be lower than `1000` milliseconds. | `10000` |
-| `SIGNALFX_PROFILER_EXPORT_FORMAT` | Format in which data will be exported. Available values are: `Pprof` for pprof-gzip-base64 format, and `Text` for plain text stack trace. | `PProf` |

--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -22,6 +22,7 @@ These settings should be never used by the users.
 | `SIGNALFX_LOGS_DIRECT_SUBMISSION_MAX_BATCH_SIZE` | Configuration key for the maximum number of logs to send at one time  | `1000` |
 | `SIGNALFX_LOGS_DIRECT_SUBMISSION_MAX_QUEUE_SIZE` | Configuration key for the maximum number of logs to hold in internal queue at any one time | `100000` |
 | `SIGNALFX_LOGS_DIRECT_SUBMISSION_BATCH_PERIOD_SECONDS` | Configuration key for the time in seconds to wait between checking for batches | `2` |
+| `SIGNALFX_PROFILER_EXPORT_FORMAT` | Format in which data will be exported. Available values are: `Pprof` for pprof-gzip-base64 format, and `Text` for plain text stack trace. | `PProf` |
 
 ## Unsupported upstream settings
 


### PR DESCRIPTION
## Why

The users should use the default value of `SIGNALFX_PROFILER_EXPORT_FORMAT`. The other formats could be useful only during troubleshooting.

## What

Move `SIGNALFX_PROFILER_EXPORT_FORMAT` config description to internal docs