### PR TITLE
 Context propagators log errors and hit exceptions on typical case

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,13 +9,13 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
-- Fix context propagation on .NET Framework.
-
 ### General
 
 ### Breaking changes
 
 ### Bugfixes
+
+- Fix context propagation on .NET Framework.
 
 ### Enhancements
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ## Unreleased
 
+- Fix context propagation on .NET Framework.
+
 ### General
 
 ### Breaking changes

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler
                 return spanContext;
             }
 
-            return SpanContextPropagator.Instance.Extract(value, (headers, key) => new List<string> { headers[key] });
+            return SpanContextPropagator.Instance.Extract(value);
         }
 
         void IDistributedTracer.SetSpanContext(IReadOnlyDictionary<string, string> value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-// Modified by Splunk Inc.
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -72,10 +72,8 @@ namespace Datadog.Trace.ClrProfiler
             {
                 return spanContext;
             }
-            else
-            {
-                return SpanContextPropagator.Instance.Extract(values, (headers, key) => new List<string> { headers[key] });
-            }
+
+            return SpanContextPropagator.Instance.Extract(values);
         }
 
         void IDistributedTracer.SetSpanContext(IReadOnlyDictionary<string, string> value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-// Modified by Splunk Inc.
-
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.DuckTyping;
@@ -72,8 +70,10 @@ namespace Datadog.Trace.ClrProfiler
             {
                 return spanContext;
             }
-
-            return SpanContextPropagator.Instance.Extract(values);
+            else
+            {
+                return SpanContextPropagator.Instance.Extract(values);
+            }
         }
 
         void IDistributedTracer.SetSpanContext(IReadOnlyDictionary<string, string> value)

--- a/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
@@ -134,6 +134,11 @@ namespace Datadog.Trace.Propagators
             static bool TryParse(IEnumerable<string?> headerValues, ref bool hasValue, out int result)
             {
                 result = 0;
+                if (headerValues == null)
+                {
+                    return false;
+                }
+
                 foreach (string? headerValue in headerValues)
                 {
                     if (int.TryParse(headerValue, out result))
@@ -211,6 +216,11 @@ namespace Datadog.Trace.Propagators
             // IEnumerable version (different method to avoid try/finally in the caller)
             static string? ParseStringIEnumerable(IEnumerable<string?> headerValues)
             {
+                if (headerValues == null)
+                {
+                    return null;
+                }
+
                 foreach (string? headerValue in headerValues)
                 {
                     if (!string.IsNullOrEmpty(headerValue))


### PR DESCRIPTION
## Why

When incoming requests has no context propagated, the context propagators log errors and hit exceptions.

## What

Fix the bug described above. Also improve the code of B3 propagator TryExtract method.

## Tests

CI passing
Tested manually by @pjanotti 
