### PR TITLE
Fix null headers enumerable

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -7,9 +7,9 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Net;
 using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                 // We may have already set headers
                 var propagator = SpanContextPropagator.Instance;
-                var requestContext = propagator.Extract(request.Headers, (headers, key) => headers.GetValues(key));
+                var requestContext = propagator.Extract(request.Headers, (headers, headerName) => headers.GetValues(headerName) ?? Enumerable.Empty<string>());
                 if (requestContext is null || requestContext.TraceId == TraceId.Zero)
                 {
                     var span = ScopeFactory.CreateInactiveOutboundHttpSpan(tracer, request.Method, request.RequestUri, WebRequestCommon.IntegrationId, out _, traceId: null, spanId: null, startTime: null, addToTraceContext: false);

--- a/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
@@ -134,10 +134,6 @@ namespace Datadog.Trace.Propagators
             static bool TryParse(IEnumerable<string?> headerValues, ref bool hasValue, out int result)
             {
                 result = 0;
-                if (headerValues == null)
-                {
-                    return false;
-                }
 
                 foreach (string? headerValue in headerValues)
                 {
@@ -216,11 +212,6 @@ namespace Datadog.Trace.Propagators
             // IEnumerable version (different method to avoid try/finally in the caller)
             static string? ParseStringIEnumerable(IEnumerable<string?> headerValues)
             {
-                if (headerValues == null)
-                {
-                    return null;
-                }
-
                 foreach (string? headerValue in headerValues)
                 {
                     if (!string.IsNullOrEmpty(headerValue))


### PR DESCRIPTION
## Why

We have changed ParseUtility in https://github.com/signalfx/signalfx-dotnet-tracing/pull/538, but the root cause of the bug was elsewhere.

## What

Fix null headers enumerable being passed to span propagators. Revert ParseUtility to previous state.

## Tests

Manual tests using Sample.WebRequest
CI passes
