### PR TITLE
Filter out startup from profiling

### DIFF
--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
@@ -120,7 +120,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
                         code = ReadShort();
                     }
 
-                    if (threadName == ThreadSampler.BackgroundThreadName)
+                    if (threadName is ThreadSampler.BackgroundThreadName or ThreadSampler.StartupThreadName)
                     {
                         // TODO Splunk: add configuration option to include the sampler thread. By default remove it.
                         continue;

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
@@ -18,6 +18,11 @@ namespace Datadog.Trace.AlwaysOnProfiler
         /// </summary>
         public const string BackgroundThreadName = "SignalFx Profiling Sampler Thread";
 
+        /// <summary>
+        /// Name of the thread initializing SignalFx profiling.
+        /// </summary>
+        public const string StartupThreadName = "SignalFx Startup Thread";
+
         // If you change any of these constants, check with always_on_profiler.cpp first
         private const int BufferSize = 200 * 1024;
 


### PR DESCRIPTION
## Why

SFx code stacks are visible in the profiling data.

## What

Filter out SFx initialization thread from the profiling.

## Tests

CI and manual tests using app0 and our sample app.
