### PR TITLE
[AlwaysOnProfiling] Span context propagation fix

### DIFF
--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ILogSender.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ILogSender.cs
@@ -1,0 +1,8 @@
+﻿using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
+
+namespace Datadog.Trace.AlwaysOnProfiler;
+
+internal interface ILogSender
+{
+    void Send(LogsData logsData);
+}

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/OtlpHttpLogSender.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/OtlpHttpLogSender.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Net;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Propagation;
+using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
+
+namespace Datadog.Trace.AlwaysOnProfiler;
+
+/// <summary>
+/// Sends logs in binary-encoded protobuf format over http.
+/// </summary>
+internal class OtlpHttpLogSender : ILogSender
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(OtlpHttpLogSender));
+
+    private readonly ImmutableExporterSettings _exporterSettings;
+
+    public OtlpHttpLogSender(ImmutableExporterSettings exporterSettings)
+    {
+        _exporterSettings = exporterSettings ?? throw new ArgumentNullException(nameof(exporterSettings));
+    }
+
+    public void Send(LogsData logsData)
+    {
+        HttpWebRequest httpWebRequest;
+
+        try
+        {
+            httpWebRequest = WebRequest.CreateHttp(_exporterSettings.LogsEndpointUrl);
+            httpWebRequest.ContentType = "application/x-protobuf";
+            httpWebRequest.Method = "POST";
+            httpWebRequest.Headers.Add(CommonHttpHeaderNames.TracingEnabled, "false");
+
+            using var stream = httpWebRequest.GetRequestStream();
+            Vendors.ProtoBuf.Serializer.Serialize(stream, logsData);
+            stream.Flush();
+        }
+        catch (Exception ex)
+        {
+            Log.Error("Exception preparing request to send thread samples to {0}: {1}", _exporterSettings.LogsEndpointUrl, ex);
+            return;
+        }
+
+        try
+        {
+            using var httpWebResponse = (HttpWebResponse)httpWebRequest.GetResponse();
+
+            if (httpWebResponse.StatusCode >= HttpStatusCode.OK && httpWebResponse.StatusCode < HttpStatusCode.MultipleChoices)
+            {
+                return;
+            }
+
+            Log.Warning("HTTP error sending thread samples to {0}: {1}", _exporterSettings.LogsEndpointUrl, httpWebResponse.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            Log.Error("Exception sending thread samples to {0}: {1}", _exporterSettings.LogsEndpointUrl, ex.Message);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/PlainTextThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/PlainTextThreadSampleExporter.cs
@@ -8,8 +8,8 @@ namespace Datadog.Trace.AlwaysOnProfiler
 {
     internal class PlainTextThreadSampleExporter : ThreadSampleExporter
     {
-        internal PlainTextThreadSampleExporter(ImmutableTracerSettings tracerSettings)
-        : base(tracerSettings)
+        internal PlainTextThreadSampleExporter(ImmutableTracerSettings tracerSettings, ILogSender logSender)
+        : base(tracerSettings, logSender)
         {
         }
 

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/PprofThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/PprofThreadSampleExporter.cs
@@ -12,8 +12,8 @@ namespace Datadog.Trace.AlwaysOnProfiler
 {
     internal class PprofThreadSampleExporter : ThreadSampleExporter
     {
-        public PprofThreadSampleExporter(ImmutableTracerSettings tracerSettings)
-            : base(tracerSettings)
+        public PprofThreadSampleExporter(ImmutableTracerSettings tracerSettings, ILogSender logSender)
+            : base(tracerSettings, logSender)
         {
         }
 

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporter.cs
@@ -3,22 +3,19 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Net;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.ExtensionMethods;
-using Datadog.Trace.Logging;
-using Datadog.Trace.Propagation;
 using Datadog.Tracer.OpenTelemetry.Proto.Common.V1;
 using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
 using Datadog.Tracer.OpenTelemetry.Proto.Resource.V1;
+using BitConverter = System.BitConverter;
 
 namespace Datadog.Trace.AlwaysOnProfiler
 {
     internal abstract class ThreadSampleExporter
     {
-        protected static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ThreadSampleExporter));
+        private readonly ILogSender _logSender;
 
-        protected ThreadSampleExporter(ImmutableTracerSettings tracerSettings)
+        protected ThreadSampleExporter(ImmutableTracerSettings tracerSettings, ILogSender logSender)
         {
             FixedLogRecordAttributes = new ReadOnlyCollection<KeyValue>(new List<KeyValue>
             {
@@ -28,16 +25,13 @@ namespace Datadog.Trace.AlwaysOnProfiler
                 GdiProfilingConventions.LogRecord.Attributes.Type
             });
 
-            LogsEndpointUrl = tracerSettings.ExporterSettings.LogsEndpointUrl;
-
             LogsData = GdiProfilingConventions.CreateLogsData(tracerSettings.GlobalTags);
+            _logSender = logSender ?? throw new ArgumentNullException(nameof(logSender));
         }
 
-        protected ReadOnlyCollection<KeyValue> FixedLogRecordAttributes { get; }
+        private ReadOnlyCollection<KeyValue> FixedLogRecordAttributes { get; }
 
-        protected Uri LogsEndpointUrl { get; }
-
-        protected LogsData LogsData { get; }
+        private LogsData LogsData { get; }
 
         public void ExportThreadSamples(List<ThreadSample> threadSamples)
         {
@@ -58,62 +52,50 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
                 if (threadSample.SpanId != 0 || threadSample.TraceIdHigh != 0 || threadSample.TraceIdLow != 0)
                 {
-                    // TODO Splunk: Add tests and validate.
-                    logRecord.SpanId = BitConverter.GetBytes(threadSample.SpanId);
-                    logRecord.TraceId = BitConverter.GetBytes(threadSample.TraceIdHigh).Concat(BitConverter.GetBytes(threadSample.TraceIdLow));
+                    logRecord.SpanId = GetBigEndianBytes(threadSample.SpanId);
+                    logRecord.TraceId = GetBigEndianBytes(threadSample.TraceIdHigh, threadSample.TraceIdLow);
                 }
 
                 logRecords.Add(logRecord);
             }
 
-            SendLogsData();
-        }
-
-        protected abstract string CreateBody(ThreadSample threadSample);
-
-        private void SendLogsData()
-        {
-            HttpWebRequest httpWebRequest;
-
             try
             {
-                httpWebRequest = WebRequest.CreateHttp(LogsEndpointUrl);
-                httpWebRequest.ContentType = "application/x-protobuf";
-                httpWebRequest.Method = "POST";
-                httpWebRequest.Headers.Add(CommonHttpHeaderNames.TracingEnabled, "false");
-
-                using var stream = httpWebRequest.GetRequestStream();
-                Vendors.ProtoBuf.Serializer.Serialize(stream, LogsData);
-                stream.Flush();
-            }
-            catch (Exception ex)
-            {
-                Log.Error("Exception preparing request to send thread samples to {0}: {1}", LogsEndpointUrl, ex);
-                return;
+                _logSender.Send(LogsData);
             }
             finally
             {
-                // The exporter reuses the _logsData object, but the actual log records are not
+                // The exporter reuses the LogsData object, but the actual log records are not
                 // needed after serialization, release the log records so they can be garbage collected.
                 LogsData.ResourceLogs[0].InstrumentationLibraryLogs[0].Logs.Clear();
             }
-
-            try
-            {
-                using var httpWebResponse = (HttpWebResponse)httpWebRequest.GetResponse();
-
-                if (httpWebResponse.StatusCode >= HttpStatusCode.OK && httpWebResponse.StatusCode < HttpStatusCode.MultipleChoices)
-                {
-                    return;
-                }
-
-                Log.Warning("HTTP error sending thread samples to {0}: {1}", LogsEndpointUrl, httpWebResponse.StatusCode);
-            }
-            catch (Exception ex)
-            {
-                Log.Error("Exception sending thread samples to {0}: {1}", LogsEndpointUrl, ex.Message);
-            }
         }
+
+        private static byte[] GetBigEndianBytes(long high, long low)
+        {
+            var highBytes = GetBigEndianBytes(high);
+            var lowBytes = GetBigEndianBytes(low);
+
+            var finalBytes = new byte[16];
+
+            highBytes.CopyTo(finalBytes, 0);
+            lowBytes.CopyTo(finalBytes, 8);
+
+            return finalBytes;
+        }
+
+        private static byte[] GetBigEndianBytes(long val)
+        {
+            var bytes = BitConverter.GetBytes(val);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+
+            return bytes;
+        }
+
+        protected abstract string CreateBody(ThreadSample threadSample);
 
         private LogRecord CreateLogRecord(string body, ulong timeUnixNanoseconds)
         {

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporterFactory.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporterFactory.cs
@@ -18,11 +18,12 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
         public ThreadSampleExporter CreateThreadSampleExporter()
         {
+            var logSender = new OtlpHttpLogSender(_tracerSettings.ExporterSettings);
             return _tracerSettings.ExporterSettings.ProfilerExportFormat switch
             {
-                ProfilerExportFormat.Pprof => new PprofThreadSampleExporter(_tracerSettings),
-                ProfilerExportFormat.Text => new PlainTextThreadSampleExporter(_tracerSettings),
-                _ => throw new ArgumentOutOfRangeException(nameof(_tracerSettings.ExporterSettings.ProfilerExportFormat), _tracerSettings.ExporterSettings.ProfilerExportFormat, null)
+                ProfilerExportFormat.Pprof => new PprofThreadSampleExporter(_tracerSettings, logSender),
+                ProfilerExportFormat.Text => new PlainTextThreadSampleExporter(_tracerSettings, logSender),
+                _ => throw new ArgumentOutOfRangeException(nameof(_tracerSettings.ExporterSettings.ProfilerExportFormat), _tracerSettings.ExporterSettings.ProfilerExportFormat, "Export format not supported.")
             };
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/ThreadSampleExporterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/ThreadSampleExporterTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using Datadog.Trace.AlwaysOnProfiler;
+using Datadog.Trace.Configuration;
+using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
+using Xunit;
+
+namespace Datadog.Trace.Tests.AlwaysOnProfiler;
+
+public class ThreadSampleExporterTests
+{
+    [Fact]
+    public void Span_context_exported_with_samples_when_converted_to_bytes_has_big_endian_order()
+    {
+        var settings = new ImmutableTracerSettings(new TracerSettings
+        {
+            ExporterSettings = new ExporterSettings()
+            {
+                ProfilerExportFormat = ProfilerExportFormat.Text
+            },
+            ThreadSamplingPeriod = TimeSpan.FromSeconds(1),
+            GlobalTags = new Dictionary<string, string>()
+        });
+        var testSender = new TestSender();
+        var exporter = new PlainTextThreadSampleExporter(settings, testSender);
+
+        exporter.ExportThreadSamples(new List<ThreadSample>
+        {
+            new ThreadSample()
+            {
+                SpanId = 1234567890,
+                TraceIdLow = 1234567890,
+                TraceIdHigh = 0987654321,
+                ThreadName = "test_thread_name",
+                ThreadIndex = 1,
+                ManagedId = 1,
+                NativeId = 1,
+                Timestamp = new ThreadSample.Time(10000)
+            }
+        });
+
+        // 1234567890 in big-endian order
+        var expectedSpanBytes = new byte[8] { 0, 0, 0, 0, 73, 150, 2, 210 };
+
+        // 987654321 in big-endian order concatenated with 1234567890 in big-endian order
+        var expectedTraceBytes = new byte[16] { 0, 0, 0, 0, 58, 222, 104, 177, 0, 0, 0, 0, 73, 150, 2, 210 };
+
+        var log = testSender.SentLogs[0].ResourceLogs[0].InstrumentationLibraryLogs[0].Logs[0];
+
+        Assert.Equal(expectedSpanBytes, log.SpanId);
+        Assert.Equal(expectedTraceBytes, log.TraceId);
+    }
+
+    private class TestSender : ILogSender
+    {
+        public IList<LogsData> SentLogs { get; } = new List<LogsData>();
+
+        public void Send(LogsData logsData)
+        {
+            SentLogs.Add(logsData);
+        }
+    }
+}


### PR DESCRIPTION
## Why

Fix span context propagation.

## What

- convert to big-endian order when converting `long` to `bytes[]`
- extract exporting logic from `ThreadSampleExporter` to `OtlpHttpLogSender` for better testability

## Tests

Included in PR.
