### PR TITLE
[AlwaysOn Profiling] fix span context propagation in pprof exporter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Bugfixes
 
+- Fix span context propagation for [AlwaysOn Profiling](always-on-profiling.md)
+
 ### Enhancements
 
 ---

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/PlainTextThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/PlainTextThreadSampleExporter.cs
@@ -1,8 +1,11 @@
 // Modified by Splunk Inc.
 
+using System;
 using System.Globalization;
 using System.Text;
 using Datadog.Trace.Configuration;
+using Datadog.Tracer.OpenTelemetry.Proto.Common.V1;
+using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
 
 namespace Datadog.Trace.AlwaysOnProfiler
 {
@@ -13,7 +16,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
         {
         }
 
-        protected override string CreateBody(ThreadSample threadSample)
+        protected override void DecorateLogRecord(LogRecord logRecord, ThreadSample threadSample)
         {
             // The stack follows the experimental GDI conventions described at
             // https://github.com/signalfx/gdi-specification/blob/29cbcbc969531d50ccfd0b6a4198bb8a89cedebb/specification/semantic_conventions.md#logrecord-message-fields
@@ -38,7 +41,37 @@ namespace Datadog.Trace.AlwaysOnProfiler
                 stackTraceBuilder.Append('\n');
             }
 
-            return stackTraceBuilder.ToString();
+            logRecord.Body = new AnyValue { StringValue = stackTraceBuilder.ToString() };
+
+            if (threadSample.SpanId != 0 || threadSample.TraceIdHigh != 0 || threadSample.TraceIdLow != 0)
+            {
+                logRecord.SpanId = ToBigEndianBytes(threadSample.SpanId);
+                logRecord.TraceId = ToBigEndianBytes(threadSample.TraceIdHigh, threadSample.TraceIdLow);
+            }
+        }
+
+        private static byte[] ToBigEndianBytes(long high, long low)
+        {
+            var highBytes = ToBigEndianBytes(high);
+            var lowBytes = ToBigEndianBytes(low);
+
+            var finalBytes = new byte[16];
+
+            highBytes.CopyTo(finalBytes, 0);
+            lowBytes.CopyTo(finalBytes, 8);
+
+            return finalBytes;
+        }
+
+        private static byte[] ToBigEndianBytes(long val)
+        {
+            var bytes = BitConverter.GetBytes(val);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+
+            return bytes;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PlainTextThreadSampleExporterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PlainTextThreadSampleExporterTests.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using Datadog.Trace.AlwaysOnProfiler;
 using Datadog.Trace.Configuration;
-using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
 using Xunit;
 
 namespace Datadog.Trace.Tests.AlwaysOnProfiler;
 
-public class ThreadSampleExporterTests
+public class PlainTextThreadSampleExporterTests
 {
     [Fact]
     public void Span_context_exported_with_samples_when_converted_to_bytes_has_big_endian_order()
@@ -49,16 +48,5 @@ public class ThreadSampleExporterTests
 
         Assert.Equal(expectedSpanBytes, log.SpanId);
         Assert.Equal(expectedTraceBytes, log.TraceId);
-    }
-
-    private class TestSender : ILogSender
-    {
-        public IList<LogRecord> SentLogs { get; } = new List<LogRecord>();
-
-        public void Send(LogsData logsData)
-        {
-            var logRecord = logsData.ResourceLogs[0].InstrumentationLibraryLogs[0].Logs[0];
-            SentLogs.Add(logRecord);
-        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofThreadSampleExporterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofThreadSampleExporterTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Datadog.Trace.AlwaysOnProfiler;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Vendors.ProtoBuf;
+using Datadog.Tracer.Pprof.Proto.Profile;
+using Xunit;
+
+namespace Datadog.Trace.Tests.AlwaysOnProfiler;
+
+public class PprofThreadSampleExporterTests
+{
+    [Fact]
+    public void If_stack_sample_has_span_context_associated_then_it_is_sent_inside_labels()
+    {
+        var sender = new TestSender();
+        var exporter = new PprofThreadSampleExporter(
+            DefaultSettings(),
+            sender);
+
+        exporter.ExportThreadSamples(new List<ThreadSample>
+        {
+            new ThreadSample()
+            {
+                SpanId = 1234567890,
+                TraceIdLow = 9876543210,
+                TraceIdHigh = 1234567890,
+                Timestamp = new ThreadSample.Time(10000),
+            }
+        });
+
+        var log = sender.SentLogs[0];
+
+        // for Pprof exporter, span context SHOULD NOT be set on logRecord level
+        Assert.Null(log.TraceId);
+        Assert.Null(log.SpanId);
+
+        var profile = Deserialize(log.Body.StringValue);
+
+        var spanId = GetId("span_id", profile);
+
+        // hex representation of 1234567890
+        Assert.Equal("00000000499602d2", spanId);
+
+        var traceId = GetId("trace_id", profile);
+
+        // concatenated hex representations of 1234567890 and 9876543210
+        Assert.Equal("00000000499602d2000000024cb016ea", traceId);
+    }
+
+    private static string GetId(string id, Profile profile)
+    {
+        var stringTables = profile.StringTables;
+        var idKey = stringTables.IndexOf(id);
+        var idLabel = profile.Samples[0].Labels.Single(label => label.Key == idKey);
+        return stringTables[(int)idLabel.Str];
+    }
+
+    private static ImmutableTracerSettings DefaultSettings()
+    {
+        return new ImmutableTracerSettings(new TracerSettings
+        {
+            ExporterSettings = new ExporterSettings
+            {
+                ProfilerExportFormat = ProfilerExportFormat.Pprof
+            },
+            ThreadSamplingPeriod = TimeSpan.FromMilliseconds(1000)
+        });
+    }
+
+    private static Profile Deserialize(string body)
+    {
+        using var memoryStream = new MemoryStream(Convert.FromBase64String(body));
+        using var gzipStream = new GZipStream(memoryStream, CompressionMode.Decompress);
+        var profile = Serializer.Deserialize<Profile>(gzipStream);
+        return profile;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/TestSender.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/TestSender.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Datadog.Trace.AlwaysOnProfiler;
+using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
+
+namespace Datadog.Trace.Tests.AlwaysOnProfiler;
+
+internal class TestSender : ILogSender
+{
+    public IList<LogRecord> SentLogs { get; } = new List<LogRecord>();
+
+    public void Send(LogsData logsData)
+    {
+        var logRecord = logsData.ResourceLogs[0].InstrumentationLibraryLogs[0].Logs[0];
+        SentLogs.Add(logRecord);
+    }
+}


### PR DESCRIPTION
## Why

Fix span context propagation for `Pprof` exporter.

## What
- set `span_id` label value as a `hex` string
- set span context info on `LogRecord` only for `PlainTextThreadSampleExporter`

## Tests

Included in CI.
Stack samples with span context properly associated:
`Text` exporter: https://app.signalfx.com/#/apm/traces/39a34bba0517d79a24db86a972ec4231
`Pprof` exporter: https://app.signalfx.com/#/apm/traces/54362b8fa82f868f3033d3fee1bda6dd
