### PR TITLE
[AlwaysOn Profiling] Pprof exporter adjustments

### DIFF
--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/PprofThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/PprofThreadSampleExporter.cs
@@ -1,48 +1,31 @@
 // Modified by Splunk Inc.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using Datadog.Trace.AlwaysOnProfiler.Builder;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Vendors.ProtoBuf;
-using Datadog.Tracer.OpenTelemetry.Proto.Common.V1;
-using Datadog.Tracer.OpenTelemetry.Proto.Logs.V1;
 using Datadog.Tracer.Pprof.Proto.Profile;
 
 namespace Datadog.Trace.AlwaysOnProfiler
 {
     internal class PprofThreadSampleExporter : ThreadSampleExporter
     {
+        private readonly TimeSpan _threadSamplingPeriod;
+
         public PprofThreadSampleExporter(ImmutableTracerSettings tracerSettings, ILogSender logSender)
-            : base(tracerSettings, logSender)
+            : base(tracerSettings, logSender, "pprof-gzip-base64")
         {
+            _threadSamplingPeriod = tracerSettings.ThreadSamplingPeriod;
         }
 
-        protected override void DecorateLogRecord(LogRecord logRecord, ThreadSample threadSample)
+        protected override void ProcessThreadSamples(List<ThreadSample> samples)
         {
-            var pprof = new Pprof();
-            var sampleBuilder = new SampleBuilder();
-
-            pprof.AddLabel(sampleBuilder, "source.event.time", threadSample.Timestamp.Milliseconds);
-
-            if (threadSample.SpanId != 0 || threadSample.TraceIdHigh != 0 || threadSample.TraceIdLow != 0)
-            {
-                pprof.AddLabel(sampleBuilder, "span_id", threadSample.SpanId.ToString("x16"));
-                pprof.AddLabel(sampleBuilder, "trace_id", TraceIdHelper.ToString(threadSample.TraceIdHigh, threadSample.TraceIdLow));
-            }
-
-            foreach (var methodName in threadSample.Frames)
-            {
-                sampleBuilder.AddLocationId(pprof.GetLocationId(methodName));
-            }
-
-            pprof.AddLabel(sampleBuilder, "thread.id", threadSample.ManagedId);
-            pprof.AddLabel(sampleBuilder, "thread.name", threadSample.ThreadName);
-            pprof.AddLabel(sampleBuilder, "thread.os.id", threadSample.NativeId);
-
-            pprof.Profile.Samples.Add(sampleBuilder.Build());
-            logRecord.Body = new AnyValue { StringValue = Serialize(pprof.Profile) };
+            var profile = BuildProfile(samples);
+            // all of the samples in the batch have the same timestamp, pick from the first sample
+            AddLogRecord(samples[0].Timestamp.Nanoseconds, Serialize(profile));
         }
 
         private static string Serialize(Profile profile)
@@ -56,6 +39,37 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
             var byteArray = memoryStream.ToArray();
             return Convert.ToBase64String(byteArray);
+        }
+
+        private Profile BuildProfile(List<ThreadSample> threadSamples)
+        {
+            var pprof = new Pprof();
+            foreach (var threadSample in threadSamples)
+            {
+                var sampleBuilder = new SampleBuilder();
+
+                pprof.AddLabel(sampleBuilder, "source.event.time", threadSample.Timestamp.Milliseconds);
+                pprof.AddLabel(sampleBuilder, "source.event.period", (long)_threadSamplingPeriod.TotalMilliseconds);
+
+                if (threadSample.SpanId != 0 || threadSample.TraceIdHigh != 0 || threadSample.TraceIdLow != 0)
+                {
+                    pprof.AddLabel(sampleBuilder, "span_id", threadSample.SpanId.ToString("x16"));
+                    pprof.AddLabel(sampleBuilder, "trace_id", TraceIdHelper.ToString(threadSample.TraceIdHigh, threadSample.TraceIdLow));
+                }
+
+                foreach (var methodName in threadSample.Frames)
+                {
+                    sampleBuilder.AddLocationId(pprof.GetLocationId(methodName));
+                }
+
+                pprof.AddLabel(sampleBuilder, "thread.id", threadSample.ManagedId);
+                pprof.AddLabel(sampleBuilder, "thread.name", threadSample.ThreadName);
+                pprof.AddLabel(sampleBuilder, "thread.os.id", threadSample.NativeId);
+
+                pprof.Profile.Samples.Add(sampleBuilder.Build());
+            }
+
+            return pprof.Profile;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/SampleBuilder.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/SampleBuilder.cs
@@ -18,12 +18,6 @@ namespace Datadog.Trace.AlwaysOnProfiler.Builder
             return this;
         }
 
-        public SampleBuilder AddValue(long value)
-        {
-            _values.Add(value);
-            return this;
-        }
-
         public SampleBuilder AddLocationId(ulong locationId)
         {
             _locationIds.Add(locationId);

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/SampleBuilder.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/SampleBuilder.cs
@@ -9,7 +9,6 @@ namespace Datadog.Trace.AlwaysOnProfiler.Builder
     internal class SampleBuilder
     {
         private readonly Sample _sample = new();
-        private readonly IList<long> _values = new List<long>();
         private readonly IList<ulong> _locationIds = new List<ulong>();
 
         public SampleBuilder AddLabel(Label label)
@@ -26,7 +25,6 @@ namespace Datadog.Trace.AlwaysOnProfiler.Builder
 
         public Sample Build()
         {
-            _sample.Values = _values.ToArray();
             _sample.LocationIds = _locationIds.ToArray();
 
             return _sample;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPlainTextTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPlainTextTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using OpenTelemetry.TestHelpers.Proto.Common.V1;
 using OpenTelemetry.TestHelpers.Proto.Logs.V1;
 using VerifyXunit;
 using Xunit;
@@ -58,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     using (new AssertionScope())
                     {
-                        AllShouldHaveCorrectAttributes(logRecords, "text");
+                        AllShouldHaveCorrectAttributes(logRecords, ExpectedAttributes());
                         AllBodiesShouldHaveCorrectFormat(logRecords);
                     }
 
@@ -69,6 +70,33 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 Assert.True(containStackTraceForClassHierarchy, "At least one stack trace containing class hierarchy should be reported.");
             }
+        }
+
+        private static List<KeyValue> ExpectedAttributes()
+        {
+            return new List<KeyValue>
+            {
+                new KeyValue
+                {
+                    Key = "com.splunk.sourcetype",
+                    Value = new AnyValue { StringValue = "otel.profiling" }
+                },
+                new KeyValue
+                {
+                    Key = "source.event.period",
+                    Value = new AnyValue { IntValue = 1000L }
+                },
+                new KeyValue
+                {
+                    Key = "profiling.data.format",
+                    Value = new AnyValue { StringValue = "text" }
+                },
+                new KeyValue
+                {
+                    Key = "profiling.data.type",
+                    Value = new AnyValue { StringValue = "cpu" }
+                }
+            };
         }
 
         private static void AllBodiesShouldHaveCorrectFormat(List<LogRecord> logRecords)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPprofTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPprofTests.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.Vendors.ProtoBuf;
 using Datadog.Tracer.Pprof.Proto.Profile;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using OpenTelemetry.TestHelpers.Proto.Common.V1;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -70,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     using (new AssertionScope())
                     {
-                        AllShouldHaveCorrectAttributes(logRecords, "pprof-gzip-base64");
+                        AllShouldHaveCorrectAttributes(logRecords, ExpectedAttributes());
                     }
 
                     // all samples should contain the same common attributes, only stack traces are vary
@@ -80,6 +81,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 Assert.True(containStackTraceForClassHierarchy, "At least one stack trace containing class hierarchy should be reported.");
             }
+        }
+
+        private static List<KeyValue> ExpectedAttributes()
+        {
+            return new List<KeyValue>
+            {
+                new KeyValue
+                {
+                    Key = "com.splunk.sourcetype",
+                    Value = new AnyValue { StringValue = "otel.profiling" }
+                },
+                new KeyValue
+                {
+                    Key = "profiling.data.format",
+                    Value = new AnyValue { StringValue = "pprof-gzip-base64" }
+                },
+                new KeyValue
+                {
+                    Key = "profiling.data.type",
+                    Value = new AnyValue { StringValue = "cpu" }
+                }
+            };
         }
 
         private static bool ContainStackTraceForClassHierarchy(Profile profile, string expectedStackTrace)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -19,40 +19,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class AlwaysOnProfilerTests : TestHelper
     {
-        public AlwaysOnProfilerTests(ITestOutputHelper output)
+        protected AlwaysOnProfilerTests(ITestOutputHelper output)
             : base("AlwaysOnProfiler", output)
         {
             SetServiceVersion("1.0.0");
         }
 
-        protected static void AllShouldHaveCorrectAttributes(List<LogRecord> logRecords, string format)
+        protected static void AllShouldHaveCorrectAttributes(List<LogRecord> logRecords, List<KeyValue> attributes)
         {
             var expectedAttributesForLogRecord = new LogRecord();
-            expectedAttributesForLogRecord.Attributes.Add(
-                new KeyValue
-                {
-                    Key = "com.splunk.sourcetype",
-                    Value = new AnyValue { StringValue = "otel.profiling" }
-                });
-            expectedAttributesForLogRecord.Attributes.Add(
-                new KeyValue
-                {
-                    Key = "source.event.period",
-                    Value = new AnyValue { IntValue = 1000L }
-                });
-            expectedAttributesForLogRecord.Attributes.Add(
-                new KeyValue
-                {
-                    Key = "profiling.data.format",
-                    Value = new AnyValue { StringValue = format }
-                });
-            expectedAttributesForLogRecord.Attributes.Add(
-                new KeyValue
-                {
-                    Key = "profiling.data.type",
-                    Value = new AnyValue { StringValue = "cpu" }
-                });
-
+            expectedAttributesForLogRecord.Attributes.AddRange(attributes);
             logRecords.Should().AllBeEquivalentTo(expectedAttributesForLogRecord, option => option.Including(x => x.Attributes));
         }
 

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofThreadSampleExporterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofThreadSampleExporterTests.cs
@@ -7,6 +7,8 @@ using Datadog.Trace.AlwaysOnProfiler;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Vendors.ProtoBuf;
 using Datadog.Tracer.Pprof.Proto.Profile;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace Datadog.Trace.Tests.AlwaysOnProfiler;
@@ -14,7 +16,7 @@ namespace Datadog.Trace.Tests.AlwaysOnProfiler;
 public class PprofThreadSampleExporterTests
 {
     [Fact]
-    public void If_stack_sample_has_span_context_associated_then_it_is_sent_inside_labels()
+    public void If_stack_sample_has_span_context_associated_then_it_is_exported_inside_labels()
     {
         var sender = new TestSender();
         var exporter = new PprofThreadSampleExporter(
@@ -29,37 +31,157 @@ public class PprofThreadSampleExporterTests
                 TraceIdLow = 9876543210,
                 TraceIdHigh = 1234567890,
                 Timestamp = new ThreadSample.Time(10000),
-            }
+            },
+            new ThreadSample()
+            {
+                SpanId = 9876543210,
+                TraceIdLow = 1234567890,
+                TraceIdHigh = 9876543210,
+                Timestamp = new ThreadSample.Time(10000),
+            },
         });
+
+        sender.SentLogs.Count.Should().Be(1, "all of the samples should be sent inside single LogRecord.");
 
         var log = sender.SentLogs[0];
 
-        // for Pprof exporter, span context SHOULD NOT be set on logRecord level
-        Assert.Null(log.TraceId);
-        Assert.Null(log.SpanId);
+        log.TraceId.Should().BeNull("traceId should not be set on LogRecord level for pprof exporter.");
+        log.SpanId.Should().BeNull("spanId should not be set on LogRecord level for pprof exporter.");
 
         var profile = Deserialize(log.Body.StringValue);
 
-        var spanId = GetId("span_id", profile);
+        profile.Samples.Count.Should().Be(2);
 
-        // hex representation of 1234567890
-        Assert.Equal("00000000499602d2", spanId);
+        using (new AssertionScope())
+        {
+            var firstSpanId = GetLabelString("span_id", profile.StringTables, profile.Samples[0]);
 
-        var traceId = GetId("trace_id", profile);
+            // hex representation of 1234567890
+            firstSpanId.Should().Be("00000000499602d2");
 
-        // concatenated hex representations of 1234567890 and 9876543210
-        Assert.Equal("00000000499602d2000000024cb016ea", traceId);
+            var firstTraceId = GetLabelString("trace_id", profile.StringTables, profile.Samples[0]);
+
+            // concatenated hex representations of 1234567890 and 9876543210
+            firstTraceId.Should().Be("00000000499602d2000000024cb016ea");
+
+            var secondSpanId = GetLabelString("span_id", profile.StringTables, profile.Samples[1]);
+
+            // hex representation of 9876543210
+            secondSpanId.Should().Be("000000024cb016ea");
+
+            var secondTraceId = GetLabelString("trace_id", profile.StringTables, profile.Samples[1]);
+
+            // concatenated hex representations of 9876543210 and 1234567890
+            secondTraceId.Should().Be("000000024cb016ea00000000499602d2");
+        }
     }
 
-    private static string GetId(string id, Profile profile)
+    [Fact]
+    public void Event_period_is_exported_inside_labels()
     {
-        var stringTables = profile.StringTables;
-        var idKey = stringTables.IndexOf(id);
-        var idLabel = profile.Samples[0].Labels.Single(label => label.Key == idKey);
-        return stringTables[(int)idLabel.Str];
+        const long expectedPeriod = 1000;
+
+        var sender = new TestSender();
+        var exporter = new PprofThreadSampleExporter(
+            DefaultSettings(samplingPeriodMs: expectedPeriod),
+            sender);
+
+        exporter.ExportThreadSamples(new List<ThreadSample>
+        {
+            new ThreadSample()
+            {
+                Timestamp = new ThreadSample.Time(10000)
+            }
+        });
+
+        var sentLog = sender.SentLogs[0];
+
+        var profile = Deserialize(sentLog.Body.StringValue);
+
+        var eventPeriod = GetLabelNum("source.event.period", profile);
+
+        eventPeriod.Should().Be(expectedPeriod);
     }
 
-    private static ImmutableTracerSettings DefaultSettings()
+    [Fact]
+    public void Format_is_added_to_log_record_attributes()
+    {
+        var sender = new TestSender();
+        var exporter = new PprofThreadSampleExporter(
+            DefaultSettings(),
+            sender);
+
+        exporter.ExportThreadSamples(new List<ThreadSample>
+        {
+            new ThreadSample()
+            {
+                Timestamp = new ThreadSample.Time(10000)
+            }
+        });
+
+        var sentLog = sender.SentLogs[0];
+
+        var format = sentLog.Attributes.Single(kv => kv.Key == "profiling.data.format");
+        format.Value.StringValue.Should().Be("pprof-gzip-base64");
+    }
+
+    [Fact]
+    public void Thread_info_is_exported_inside_labels()
+    {
+        var sender = new TestSender();
+        var exporter = new PprofThreadSampleExporter(
+            DefaultSettings(),
+            sender);
+
+        exporter.ExportThreadSamples(new List<ThreadSample>
+        {
+            new ThreadSample()
+            {
+                Timestamp = new ThreadSample.Time(10000),
+                ThreadIndex = 0,
+                NativeId = 1,
+                ManagedId = 2,
+                ThreadName = "test_thread"
+            }
+        });
+
+        var sentLog = sender.SentLogs[0];
+
+        var profile = Deserialize(sentLog.Body.StringValue);
+
+        using (new AssertionScope())
+        {
+            var threadName = GetLabelString("thread.name", profile.StringTables, profile.Samples[0]);
+            threadName.Should().Be("test_thread");
+
+            var nativeId = GetLabelNum("thread.os.id", profile);
+            nativeId.Should().Be(1);
+
+            var managedThreadId = GetLabelNum("thread.id", profile);
+            managedThreadId.Should().Be(2);
+        }
+    }
+
+    private static long GetLabelNum(string labelName, Profile profile)
+    {
+        var label = GetLabel(labelName, profile.StringTables, profile.Samples[0]);
+        return label.Num;
+    }
+
+    private static string GetLabelString(string labelName, IList<string> profileStringTables, Sample profileSample)
+    {
+        var label = GetLabel(labelName, profileStringTables, profileSample);
+        return profileStringTables[(int)label.Str];
+    }
+
+    private static Label GetLabel(string labelName, IList<string> profileStringTables, Sample profileSample)
+    {
+        var labelKeyIndex = profileStringTables.IndexOf(labelName);
+        var label = profileSample.Labels.Single(label => label.Key == labelKeyIndex);
+        return label;
+    }
+
+    private static ImmutableTracerSettings DefaultSettings(long samplingPeriodMs = 10000)
     {
         return new ImmutableTracerSettings(new TracerSettings
         {
@@ -67,7 +189,7 @@ public class PprofThreadSampleExporterTests
             {
                 ProfilerExportFormat = ProfilerExportFormat.Pprof
             },
-            ThreadSamplingPeriod = TimeSpan.FromMilliseconds(1000)
+            ThreadSamplingPeriod = TimeSpan.FromMilliseconds(samplingPeriodMs)
         });
     }
 

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/SampleBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/SampleBuilderTests.cs
@@ -33,16 +33,5 @@ namespace Datadog.Trace.Tests.AlwaysOnProfiler.Builder
             sample.Labels.Should().HaveCount(1);
             sample.Labels[0].Should().Be(label);
         }
-
-        [Fact]
-        public void AddValue()
-        {
-            _sampleBuilder.AddValue(100);
-
-            var sample = _sampleBuilder.Build();
-
-            sample.Values.Should().HaveCount(1);
-            sample.Values[0].Should().Be(100);
-        }
     }
 }


### PR DESCRIPTION
## Why

Fix `source.event.period` export for `pprof`.
Make exporter's behavior consistent with other languages.

## What

- export `source.event.period` as a label in `pprof` exporter
- send single `LogRecord` with captured samples for `pprof` exporter
- some of the suggested enhancements to tests from https://github.com/signalfx/signalfx-dotnet-tracing/pull/560

## Tests

Automated tests included in PR.
Smoke tests with backend:

- `text` exporter: https://app.signalfx.com/#/apm/traces/163b79f0b40251ba56084a94c6e693f3
- `pprof` exporter: https://app.signalfx.com/#/apm/traces/3300b4d1502b217975920d61c6f4e439
