### PR TITLE
[AlwaysOn Profiling] Don't set timestamp on LogRecord for pprof

### DIFF
--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/PlainTextThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/PlainTextThreadSampleExporter.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
         {
             foreach (var threadSample in samples)
             {
-                var logRecord = AddLogRecord(threadSample.Timestamp.Nanoseconds, BuildStackTrace(threadSample));
+                var logRecord = AddLogRecord(BuildStackTrace(threadSample));
                 DecorateLogRecord(logRecord, threadSample);
             }
         }
@@ -86,6 +86,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
                 logRecord.TraceId = ToBigEndianBytes(threadSample.TraceIdHigh, threadSample.TraceIdLow);
             }
 
+            logRecord.TimeUnixNano = threadSample.Timestamp.Nanoseconds;
             logRecord.Attributes.Add(_samplingPeriodAttribute);
         }
     }

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/PprofThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/PprofThreadSampleExporter.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
         {
             var profile = BuildProfile(samples);
             // all of the samples in the batch have the same timestamp, pick from the first sample
-            AddLogRecord(samples[0].Timestamp.Nanoseconds, Serialize(profile));
+            AddLogRecord(Serialize(profile));
         }
 
         private static string Serialize(Profile profile)

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleExporter.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
         protected abstract void ProcessThreadSamples(List<ThreadSample> samples);
 
-        protected LogRecord AddLogRecord(ulong timeUnixNanoseconds, string body)
+        protected LogRecord AddLogRecord(string body)
         {
             // The stack follows the experimental GDI conventions described at
             // https://github.com/signalfx/gdi-specification/blob/29cbcbc969531d50ccfd0b6a4198bb8a89cedebb/specification/semantic_conventions.md#logrecord-message-fields
@@ -69,7 +69,6 @@ namespace Datadog.Trace.AlwaysOnProfiler
                     FixedLogRecordAttributes[1],
                     FixedLogRecordAttributes[2]
                 },
-                TimeUnixNano = timeUnixNanoseconds,
                 Body = new AnyValue { StringValue = body }
             };
 

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PlainTextThreadSampleExporterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PlainTextThreadSampleExporterTests.cs
@@ -40,6 +40,26 @@ public class PlainTextThreadSampleExporterTests
     }
 
     [Fact]
+    public void Timestamp_is_set_on_log_record()
+    {
+        var settings = DefaultSettings();
+        var testSender = new TestSender();
+        var exporter = new PlainTextThreadSampleExporter(settings, testSender);
+
+        exporter.ExportThreadSamples(new List<ThreadSample>
+        {
+            new ThreadSample()
+            {
+                Timestamp = new ThreadSample.Time(milliseconds: 1000)
+            }
+        });
+
+        var sentLog = testSender.SentLogs[0];
+
+        sentLog.TimeUnixNano.Should().Be(1000 * 1_000_000u);
+    }
+
+    [Fact]
     public void Event_period_is_added_to_log_record_attributes()
     {
         const long expectedPeriod = 1000;

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofThreadSampleExporterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofThreadSampleExporterTests.cs
@@ -104,6 +104,33 @@ public class PprofThreadSampleExporterTests
     }
 
     [Fact]
+    public void Timestamp_is_exported_inside_labels()
+    {
+        var sender = new TestSender();
+        var exporter = new PprofThreadSampleExporter(
+            DefaultSettings(),
+            sender);
+
+        exporter.ExportThreadSamples(new List<ThreadSample>
+        {
+            new ThreadSample()
+            {
+                Timestamp = new ThreadSample.Time(milliseconds: 1000)
+            }
+        });
+
+        var sentLog = sender.SentLogs[0];
+
+        sentLog.TimeUnixNano.Should().Be(0, "for pprof exporter, timestamp for an event is exported as a label.");
+
+        var profile = Deserialize(sentLog.Body.StringValue);
+
+        var timestamp = GetLabelNum("source.event.time", profile);
+
+        timestamp.Should().Be(1000);
+    }
+
+    [Fact]
     public void Format_is_added_to_log_record_attributes()
     {
         var sender = new TestSender();


### PR DESCRIPTION
## Why

Adjust to updated spec.

## What

Don't set `timestamp` on `LogRecord` for `pprof` exporter.

## Tests

Included in PR.
