### PR TITLE
Update testcontainers reference in overhead tests

### DIFF
--- a/overhead-test/src/SignalFx.OverheadTest.csproj
+++ b/overhead-test/src/SignalFx.OverheadTest.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageReference Include="Testcontainers" Version="2.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/overhead-test/web/overhead.js
+++ b/overhead-test/web/overhead.js
@@ -78,7 +78,7 @@ function addAgents(overview, config) {
             body.append(p)
             const args = document.createElement('ul');
             agent.additionalEnvVars.forEach(arg => {
-                addListItem(args, `${arg.key}=${arg.value}`, ['font-monospace', 'envvar']);
+                addListItem(args, `${arg.name}=${arg.value}`, ['font-monospace', 'envvar']);
             });
             body.append(args);
         }


### PR DESCRIPTION
## Why

Update `testcontainers` reference.

## What

- `testcontainers` reference update
- tests results visualization fix

## Tests

Tested locally with a smoke test.
