### PR TITLE
[Overhead tests] Use create-results-pr script in gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,6 +172,5 @@ run-overhead-test:
     - ./overhead-test/provision/start-remote-test.sh
     - sleep 30
     - ./overhead-test/provision/wait-for-test-complete.sh
-    # Don't create results PR yet
-#    - ./overhead-test/provision/fetch-results.sh
-#    - ./overhead-test/provision/create-results-pr.sh
+    - ./overhead-test/provision/fetch-results.sh
+    - ./overhead-test/provision/create-results-pr.sh

--- a/overhead-test/provision/create-results-pr.sh
+++ b/overhead-test/provision/create-results-pr.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Creates a PR into main branch from the results
+
+MYDIR=$(dirname $0)
+RESULTS=${MYDIR}/../web/results
+REV=$(ls "${RESULTS}")
+NEW_BRANCH="results_${REV}"
+
+set -e
+
+echo ">>> Setting GnuPG configuration ..."
+mkdir -p ~/.gnupg
+chmod 700 ~/.gnupg
+cat > ~/.gnupg/gpg.conf <<EOF
+no-tty
+pinentry-mode loopback
+EOF
+
+echo ">>> Importing secret key ..."
+cat > /tmp/sk <<EOF
+${GITHUB_BOT_GPG_KEY}
+EOF
+gpg --batch --allow-secret-key-import --import /tmp/sk
+rm /tmp/sk
+
+echo ">>> Setting up git config options"
+GPG_KEY_ID=$(gpg2 -K --keyid-format SHORT | grep '^ ' | tr -d ' ')
+git config --global user.name overhead-results
+git config --global user.email ssg-srv-gh-o11y-gdi-dotnet-test@splunk.com
+git config --global gpg.program gpg
+git config --global user.signingKey ${GPG_KEY_ID}
+
+git clone https://srv-gh-o11y-gdi-dotnet-test:"${GITHUB_TOKEN}"@github.com/signalfx/signalfx-dotnet-tracing.git github-clone
+cd github-clone
+git checkout main
+git checkout -b ${NEW_BRANCH}
+cd ..
+
+echo "Setting up a new pull request for results data: ${REV} results"
+MSG="Add test results: ${REV}"
+RESULTS_TARGET_DIR="overhead-test/web/results/"
+
+mkdir -p $RESULTS_TARGET_DIR
+
+rsync -avv --progress "${RESULTS}/${REV}" github-clone/${RESULTS_TARGET_DIR}
+cd github-clone
+echo "Results list: " && ls -l ${RESULTS_TARGET_DIR}
+ls -1 ${RESULTS_TARGET_DIR} | grep -v README | grep -v index.txt > ${RESULTS_TARGET_DIR}/index.txt
+echo "Adding new files to changelist"
+git add ${RESULTS_TARGET_DIR}/index.txt
+git add ${RESULTS_TARGET_DIR}/${REV}/*
+git diff --cached
+echo "Committing changes..."
+git commit -S -am "[automated] $MSG"
+git show HEAD
+# TODO: uncomment when verified
+#echo "Pushing results to remote branch ${NEW_BRANCH}"
+#git push https://srv-gh-o11y-gdi-dotnet-test:"${GITHUB_TOKEN}"@github.com/signalfx/signalfx-dotnet-tracing.git ${NEW_BRANCH}
+#
+#echo "Running PR create command:"
+#gh pr create \
+#  --title "$MSG" \
+#  --body "$MSG" \
+#  --label automated \
+#  --base main \
+#  --head "$NEW_BRANCH"

--- a/overhead-test/provision/create-results-pr.sh
+++ b/overhead-test/provision/create-results-pr.sh
@@ -50,7 +50,6 @@ ls -1 ${RESULTS_TARGET_DIR} | grep -v README | grep -v index.txt > ${RESULTS_TAR
 echo "Adding new files to changelist"
 git add ${RESULTS_TARGET_DIR}/index.txt
 git add ${RESULTS_TARGET_DIR}/${REV}/*
-git diff --cached
 echo "Committing changes..."
 git commit -S -am "[automated] $MSG"
 git show HEAD

--- a/overhead-test/web/index.html
+++ b/overhead-test/web/index.html
@@ -49,7 +49,7 @@
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-totalgctime">Total GC Time</a></li>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-scriptduration">Script Duration</a></li>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-scriptdurationp95">Script Duration
-                        (P95)</a></li>
+                        (p95)</a></li>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-requestavg">Request Latency</a></li>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-requestavgp95">Request Latency (p95)</a>
                     <li class="nav-item"><a class="nav-link link-dark" href="#a-maxthreadpoolthreadcount">ThreadPool thread count</a>


### PR DESCRIPTION
## Why

Publish test results automatically.

## What
Adapted [script](https://github.com/signalfx/splunk-otel-java-overhead-test/blob/main/provision/create-results-pr.sh) to create pr with test results.
- fetch test results in the pipeline using `fetch-results.sh` script
- run `create-results-pr.sh` as a part of a pipeline in `gitlab` (but don't create PR yet)

## Tests
 
 n/a
