### PR TITLE
[Overhead test] Github pages - add permission required by deploy step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   pages: write
+  id-token: write
 
 # Allow one concurrent deployment
 concurrency:


### PR DESCRIPTION
## Why

Required by [deploy](https://github.com/actions/deploy-pages#security-considerations) step.

## What

Additional permission.
Set of permissions as in [starter](https://github.com/actions/starter-workflows/blob/main/pages/static.yml) workflow.

## Tests

n/a
