### PR TITLE
[Overhead tests] Cleanup gitlab pipeline

### DIFF
--- a/overhead-test/provision/create-results-pr.sh
+++ b/overhead-test/provision/create-results-pr.sh
@@ -18,15 +18,11 @@ pinentry-mode loopback
 EOF
 
 echo ">>> Importing secret key ..."
-cat > /tmp/sk <<EOF
-${GITHUB_BOT_GPG_KEY}
-EOF
-gpg --batch --allow-secret-key-import --import /tmp/sk
-rm /tmp/sk
+gpg --batch --allow-secret-key-import --import ${GITHUB_BOT_GPG_KEY}
 
 echo ">>> Setting up git config options"
 GPG_KEY_ID=$(gpg2 -K --keyid-format SHORT | grep '^ ' | tr -d ' ')
-git config --global user.name overhead-results
+git config --global user.name srv-gh-o11y-gdi-dotnet-test
 git config --global user.email ssg-srv-gh-o11y-gdi-dotnet-test@splunk.com
 git config --global gpg.program gpg
 git config --global user.signingKey ${GPG_KEY_ID}


### PR DESCRIPTION
## Why

Simplify `create-results-pr.sh` used in `gitlab` pipeline.

## What

Modify `create-results-pr.sh` script:

- adjust name in `git` configuration
- expect `gitlab` project variable of type [`file`](https://docs.gitlab.com/ee/ci/variables/#cicd-variable-types)

## Tests

n/a
