### PR TITLE
[Overhead tests] Use deb package from pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,8 +120,7 @@ checksums-sign:
 
 run-overhead-test:
   stage: run-overhead-test
-  # can start independently of other jobs
-  needs: []
+  needs: ["sign-deb"]
   rules:
     # run when version tag encountered
     - if: '$CI_COMMIT_TAG =~ /^v.*/'
@@ -166,6 +165,8 @@ run-overhead-test:
     - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
     - apt update
     - apt install -y gh
+    # rename deb package
+    - cp -vfp $(ls signed/*.deb) package.deb
   script:
     - orca --cloud aws show deployments
     # provisioning will not work if deployments already exist, so we purge here first.

--- a/overhead-test/provision/ansible/testbox-playbook.yml
+++ b/overhead-test/provision/ansible/testbox-playbook.yml
@@ -30,6 +30,10 @@
       ansible.posix.synchronize:
         src: ../../src
         dest: /home/splunk/
+    - name: copy deb package into context directory
+      ansible.posix.synchronize:
+        src: ../../../package.deb
+        dest: /home/splunk/docker-build-context/package.deb
     - name: copy run-tests script
       ansible.builtin.template:
         src: run-tests.sh.jinja
@@ -42,7 +46,7 @@
         cmd: docker build -f /home/splunk/src/Docker/eshop-app.dockerfile -t eshop-app-dc --target baseline-app .
     - name: build instrumented-app docker image
       ansible.builtin.command:
-        cmd: docker build -f /home/splunk/src/Docker/eshop-app.dockerfile -t eshop-app-instrumented-dc --target instrumented-app .
+        cmd: docker build -f /home/splunk/src/Docker/eshop-app.dockerfile -t eshop-app-instrumented-dc --target instrumented-app /home/splunk/docker-build-context
     - name: build test project
       ansible.builtin.command:
         cmd: dotnet build --configuration Release --output /home/splunk/bin /home/splunk/src/SignalFx.OverheadTest.csproj

--- a/overhead-test/src/Docker/eshop-app.dockerfile
+++ b/overhead-test/src/Docker/eshop-app.dockerfile
@@ -38,16 +38,8 @@ FROM baseline-app as instrumented-app
 RUN mkdir -p /var/log/signalfx
 RUN mkdir -p /opt/signalfx
 
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
-    curl
-
-# TODO Splunk: update with release
-ARG TRACER_VERSION=0.2.8
-
-RUN curl -LO https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
-RUN dpkg -i ./signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb
+COPY package.deb ./
+RUN dpkg -i package.deb
 
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={B4C89B0F-9908-4F73-9F59-0D77C5A06874}


### PR DESCRIPTION
## Why

Run overhead tests with current version (e.g on tag push)

## What

Use `deb` package from pipeline for overhead tests.

## Tests

n/a
