### PR TITLE
[Overhead tests] Results publishing fix

### DIFF
--- a/overhead-test/provision/create-results-pr.sh
+++ b/overhead-test/provision/create-results-pr.sh
@@ -3,7 +3,7 @@
 # Creates a PR into main branch from the results
 
 MYDIR=$(dirname $0)
-RESULTS=${MYDIR}/../web/results
+RESULTS=${MYDIR}/../web/new-results
 REV=$(ls "${RESULTS}")
 NEW_BRANCH="results_${REV}"
 
@@ -42,7 +42,7 @@ mkdir -p $RESULTS_TARGET_DIR
 rsync -avv --progress "${RESULTS}/${REV}" github-clone/${RESULTS_TARGET_DIR}
 cd github-clone
 echo "Results list: " && ls -l ${RESULTS_TARGET_DIR}
-ls -1 ${RESULTS_TARGET_DIR} | grep -v README | grep -v index.txt > ${RESULTS_TARGET_DIR}/index.txt
+ls -1 ${RESULTS_TARGET_DIR} | grep -v index.txt > ${RESULTS_TARGET_DIR}/index.txt
 echo "Adding new files to changelist"
 git add ${RESULTS_TARGET_DIR}/index.txt
 git add ${RESULTS_TARGET_DIR}/${REV}/*

--- a/overhead-test/provision/fetch-results.sh
+++ b/overhead-test/provision/fetch-results.sh
@@ -6,7 +6,7 @@ source ${MYDIR}/env.sh
 TS=$(ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" -o "LogLevel=ERROR" -i ~/.orca/id_rsa splunk@${TESTBOX_HOST} "date -r bin/results/ '+%Y%m%d_%H%M%S'")
 echo Timestamp dir will be ${TS}
 
-RESULTS=${MYDIR}/../web/results/${TS}
+RESULTS=${MYDIR}/../web/new-results/${TS}
 mkdir -p $RESULTS
 
 # fetch only csv results and json config

--- a/overhead-test/src/Configs/TestConfig.cs
+++ b/overhead-test/src/Configs/TestConfig.cs
@@ -16,7 +16,7 @@ internal class TestConfig
                 AgentConfig.Profiled,
                 AgentConfig.ProfiledHighFrequency
             },
-            8500,
+            1000,
             30,
             900);
     }


### PR DESCRIPTION
## Why

Avoid copying results into existing dir.

## What

- copy results into new dir
- temporarily decrease number of iterations in test

## Tests

n/a
