### PR TITLE
[Overhead test] revert temporary iterations count decrease

### DIFF
--- a/overhead-test/src/Configs/TestConfig.cs
+++ b/overhead-test/src/Configs/TestConfig.cs
@@ -16,7 +16,7 @@ internal class TestConfig
                 AgentConfig.Profiled,
                 AgentConfig.ProfiledHighFrequency
             },
-            1000,
+            8500,
             30,
             900);
     }


### PR DESCRIPTION
## Why

Increase iterations count in overhead test.

## What

Revert previous decrease.

## Tests

n/a
