### PR TITLE
[RuntimeMetrics] Reimplement to match otel - gc

### DIFF
--- a/tracer/src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
+++ b/tracer/src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.DogStatsd
         {
         }
 
-        public void Counter(string statName, double value, double sampleRate = 1, string[] tags = null)
+        public void Counter(string statName, long value, double sampleRate = 1, string[] tags = null)
         {
         }
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/GcMetrics.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/GcMetrics.cs
@@ -1,0 +1,36 @@
+// Modified by Splunk Inc.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Datadog.Trace.Vendors.StatsdClient;
+
+namespace Datadog.Trace.RuntimeMetrics;
+
+// source originated from: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+internal static class GcMetrics
+{
+    private const int NumberOfGenerations = 3;
+
+    internal static ReadOnlyCollection<string> GenNames { get; } = new(new List<string> { "gen0", "gen1", "gen2", "loh", "poh" });
+
+    public static string GenerationTag(int i)
+    {
+        return $"generation:{GenNames[i]}";
+    }
+
+    public static void PushCollectionCounts(IDogStatsd dogStatsd)
+    {
+        long collectionsFromHigherGeneration = 0;
+
+        for (var gen = NumberOfGenerations - 1; gen >= 0; --gen)
+        {
+            long collectionsFromThisGeneration = GC.CollectionCount(gen);
+            var currentValue = collectionsFromThisGeneration - collectionsFromHigherGeneration;
+
+            dogStatsd.Counter(MetricsNames.Gc.CollectionsCount, currentValue, tags: new[] { GenerationTag(gen) });
+
+            collectionsFromHigherGeneration = collectionsFromThisGeneration;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
@@ -3,28 +3,19 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 namespace Datadog.Trace.RuntimeMetrics
 {
     internal static class MetricsNames
     {
-        public const string ExceptionsCount = "runtime.dotnet.exceptions.count";
-
-        public const string Gen0CollectionsCount = "runtime.dotnet.gc.count.gen0";
-        public const string Gen1CollectionsCount = "runtime.dotnet.gc.count.gen1";
-        public const string Gen2CollectionsCount = "runtime.dotnet.gc.count.gen2";
-
-        public const string GcPauseTime = "runtime.dotnet.gc.pause_time";
-        public const string GcMemoryLoad = "runtime.dotnet.gc.memory_load";
-
-        public const string Gen0HeapSize = "runtime.dotnet.gc.size.gen0";
-        public const string Gen1HeapSize = "runtime.dotnet.gc.size.gen1";
-        public const string Gen2HeapSize = "runtime.dotnet.gc.size.gen2";
-        public const string LohSize = "runtime.dotnet.gc.size.loh";
+        private const string MetricPrefix = "process.runtime.dotnet.";
+        public const string ExceptionsCount = $"{MetricPrefix}exceptions.count";
 
         public const string ContentionTime = "runtime.dotnet.threads.contention_time";
-        public const string ContentionCount = "runtime.dotnet.threads.contention_count";
+        public const string ContentionCount = $"{MetricPrefix}monitor.lock_contention.count";
 
-        public const string ThreadPoolWorkersCount = "runtime.dotnet.threads.workers_count";
+        public const string ThreadPoolWorkersCount = $"{MetricPrefix}thread_pool.threads.count";
 
         public const string ThreadsCount = "runtime.dotnet.threads.count";
 
@@ -42,5 +33,13 @@ namespace Datadog.Trace.RuntimeMetrics
         public const string AspNetCoreCurrentConnections = "runtime.dotnet.aspnetcore.connections.current";
         public const string AspNetCoreConnectionQueueLength = "runtime.dotnet.aspnetcore.connections.queue_length";
         public const string AspNetCoreTotalConnections = "runtime.dotnet.aspnetcore.connections.total";
+
+        internal static class Gc
+        {
+            public const string CollectionsCount = $"{MetricPrefix}gc.collections.count";
+            public const string HeapSize = $"{MetricPrefix}gc.heap.size";
+            public const string AllocatedBytes = $"{MetricPrefix}gc.allocations.size";
+            public const string HeapCommittedMemory = $"{MetricPrefix}gc.committed_memory.size";
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCounterWrapper.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCounterWrapper.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.RuntimeMetrics
             _counter?.Dispose();
         }
 
-        public double? GetValue(string instanceName)
+        public long? GetValue(string instanceName)
         {
             var counter = _counter;
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 #if NETFRAMEWORK
 using System;
 using System.Diagnostics;
@@ -18,7 +20,7 @@ namespace Datadog.Trace.RuntimeMetrics
     {
         private const string MemoryCategoryName = ".NET CLR Memory";
         private const string ThreadingCategoryName = ".NET CLR LocksAndThreads";
-        private const string GarbageCollectionMetrics = $"{MetricsNames.Gen0HeapSize}, {MetricsNames.Gen1HeapSize}, {MetricsNames.Gen2HeapSize}, {MetricsNames.LohSize}, {MetricsNames.ContentionCount}, {MetricsNames.Gen0CollectionsCount}, {MetricsNames.Gen1CollectionsCount}, {MetricsNames.Gen2CollectionsCount}";
+        private const string GarbageCollectionMetrics = $"{MetricsNames.Gc.HeapSize}, {MetricsNames.Gc.CollectionsCount}";
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<PerformanceCountersListener>();
 
@@ -35,12 +37,6 @@ namespace Datadog.Trace.RuntimeMetrics
         private PerformanceCounterWrapper _gen2Size;
         private PerformanceCounterWrapper _lohSize;
         private PerformanceCounterWrapper _contentionCount;
-
-        private int? _previousGen0Count;
-        private int? _previousGen1Count;
-        private int? _previousGen2Count;
-
-        private double? _lastContentionCount;
 
         private Task _initializationTask;
 
@@ -79,35 +75,14 @@ namespace Datadog.Trace.RuntimeMetrics
                 _instanceName = GetSimpleInstanceName();
             }
 
-            TryUpdateGauge(MetricsNames.Gen0HeapSize, _gen0Size);
-            TryUpdateGauge(MetricsNames.Gen1HeapSize, _gen1Size);
-            TryUpdateGauge(MetricsNames.Gen2HeapSize, _gen2Size);
-            TryUpdateGauge(MetricsNames.LohSize, _lohSize);
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen0Size, GcMetrics.GenerationTag(0));
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen1Size, GcMetrics.GenerationTag(1));
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen2Size, GcMetrics.GenerationTag(2));
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _lohSize, GcMetrics.GenerationTag(3));
 
-            TryUpdateCounter(MetricsNames.ContentionCount, _contentionCount, ref _lastContentionCount);
+            TryUpdateCounter(MetricsNames.ContentionCount, _contentionCount);
 
-            var gen0 = GC.CollectionCount(0);
-            var gen1 = GC.CollectionCount(1);
-            var gen2 = GC.CollectionCount(2);
-
-            if (_previousGen0Count != null)
-            {
-                _statsd.Increment(MetricsNames.Gen0CollectionsCount, gen0 - _previousGen0Count.Value);
-            }
-
-            if (_previousGen1Count != null)
-            {
-                _statsd.Increment(MetricsNames.Gen1CollectionsCount, gen1 - _previousGen1Count.Value);
-            }
-
-            if (_previousGen2Count != null)
-            {
-                _statsd.Increment(MetricsNames.Gen2CollectionsCount, gen2 - _previousGen2Count.Value);
-            }
-
-            _previousGen0Count = gen0;
-            _previousGen1Count = gen1;
-            _previousGen2Count = gen2;
+            GcMetrics.PushCollectionCounts(_statsd);
 
             Log.Debug("Sent the following metrics: {metrics}", GarbageCollectionMetrics);
         }
@@ -143,17 +118,17 @@ namespace Datadog.Trace.RuntimeMetrics
             }
         }
 
-        private void TryUpdateGauge(string path, PerformanceCounterWrapper counter)
+        private void TryUpdateGauge(string path, PerformanceCounterWrapper counter, string tag)
         {
             var value = counter.GetValue(_instanceName);
 
             if (value != null)
             {
-                _statsd.Gauge(path, value.Value);
+                _statsd.Gauge(path, value.Value, tags: new[] { tag });
             }
         }
 
-        private void TryUpdateCounter(string path, PerformanceCounterWrapper counter, ref double? lastValue)
+        private void TryUpdateCounter(string path, PerformanceCounterWrapper counter)
         {
             var value = counter.GetValue(_instanceName);
 
@@ -162,14 +137,7 @@ namespace Datadog.Trace.RuntimeMetrics
                 return;
             }
 
-            if (lastValue == null)
-            {
-                lastValue = value;
-                return;
-            }
-
-            _statsd.Counter(path, value.Value - lastValue.Value);
-            lastValue = value;
+            _statsd.Counter(path, value.Value);
         }
 
         private Tuple<string, bool> GetInstanceName()

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;

--- a/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxMetricSender.cs
+++ b/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxMetricSender.cs
@@ -34,7 +34,18 @@ namespace Datadog.Trace.SignalFx.Metrics
         /// <param name="tags">Tags added to the metric.</param>
         public void SendGaugeMetric(string name, double value, string[] tags = null)
         {
-            Send(MetricType.GAUGE, name, value, tags);
+            Send(MetricType.GAUGE, name, datum => datum.doubleValue = value, tags);
+        }
+
+        /// <summary>
+        /// Sends cumulative counter metric using configured reporter.
+        /// </summary>
+        /// <param name="name">The name of the metric.</param>
+        /// <param name="value">The value of the metric.</param>
+        /// <param name="tags">Tags added to the metric.</param>
+        public void SendCumulativeCounterMetric(string name, long value, string[] tags = null)
+        {
+            Send(MetricType.CUMULATIVE_COUNTER, name, datum => datum.intValue = value, tags);
         }
 
         /// <summary>
@@ -43,9 +54,9 @@ namespace Datadog.Trace.SignalFx.Metrics
         /// <param name="name">The name of the metric.</param>
         /// <param name="value">The value of the metric.</param>
         /// <param name="tags">Tags added to the metric.</param>
-        public void SendCounterMetric(string name, double value, string[] tags = null)
+        public void SendCounterMetric(string name, long value, string[] tags = null)
         {
-            Send(MetricType.COUNTER, name, value, tags);
+            Send(MetricType.COUNTER, name, datum => datum.intValue = value, tags);
         }
 
         public void Dispose()
@@ -63,26 +74,27 @@ namespace Datadog.Trace.SignalFx.Metrics
             };
         }
 
-        private void Send(MetricType metricType, string name, double value, string[] tags)
+        private void Send(MetricType metricType, string name, Action<Datum> valueSetter, string[] tags)
         {
-            var dataPoint = CreateDataPoint(metricType, name, value, tags);
+            var dataPoint = CreateDataPoint(metricType, name, valueSetter, tags);
             if (!_writer.TryWrite(dataPoint))
             {
                 Log.Warning("Metric upload failed, worker queue full.");
             }
         }
 
-        private DataPoint CreateDataPoint(MetricType metricType, string name, double value, string[] tags)
+        private DataPoint CreateDataPoint(MetricType metricType, string name, Action<Datum> valueSetter, string[] tags)
         {
             // TODO splunk: consider pooling data points
             var dataPoint = new DataPoint
             {
                 metricType = metricType,
                 metric = name,
-                value = new Datum { doubleValue = value },
+                value = new Datum(),
                 timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
             };
 
+            valueSetter(dataPoint.value);
             dataPoint.dimensions.AddRange(_globalDimensions);
 
             if (tags != null)

--- a/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxStats.cs
+++ b/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxStats.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.SignalFx.Metrics
         public SignalFxStats(SignalFxMetricSender metricSender)
         {
             _metricSender = metricSender ?? throw new ArgumentNullException(nameof(metricSender));
-            // splunk: consider supporting telemetry with our metric exporter
+            // TODO splunk: consider supporting telemetry with our metric exporter
             TelemetryCounters = new Vendors.StatsdClient.Telemetry();
         }
 
@@ -32,19 +32,20 @@ namespace Datadog.Trace.SignalFx.Metrics
             // nothing to configure
         }
 
-        public void Counter(string statName, double value, double sampleRate = 1, string[] tags = null)
+        public void Counter(string statName, long value, double sampleRate = 1, string[] tags = null)
         {
-            _metricSender.SendCounterMetric(statName, value, tags);
+            // we want to map to cumulative counter, leave the name to reduce required changes
+            _metricSender.SendCumulativeCounterMetric(statName, value, tags);
         }
 
         public void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null)
         {
+            // we want to map to counter, leave the name to reduce required changes
             _metricSender.SendCounterMetric(statName, value, tags);
         }
 
         public void Decrement(string statName, int value = 1, double sampleRate = 1, params string[] tags)
         {
-            _metricSender.SendCounterMetric(statName, -value, tags);
         }
 
         public void Gauge(string statName, double value, double sampleRate = 1, string[] tags = null)

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/DogStatsdService.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/DogStatsdService.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Vendors.StatsdClient
         /// <param name="value">A given delta.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null)
+        public void Counter(string statName, long value, double sampleRate = 1.0, string[] tags = null)
         {
             _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags);
         }

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/Dogstatsd.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/Dogstatsd.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.Vendors.StatsdClient
         /// <param name="value">A given delta.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
+        public static void Counter(string statName, long value, double sampleRate = 1.0, string[] tags = null) =>
             _dogStatsdService.Counter(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/IDogStatsd.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/IDogStatsd.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.Vendors.StatsdClient
         /// <param name="value">A given delta.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Counter(string statName, double value, double sampleRate = 1, string[] tags = null);
+        void Counter(string statName, long value, double sampleRate = 1, string[] tags = null);
 
         /// <summary>
         /// Decrements the specified counter.

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // - exception count is gathered using common .NET APIs
             // - contention count is gathered using platform-specific APIs
 
-            var exceptionRequestsCount = requests.Count(r => r.metric == "runtime.dotnet.exceptions.count");
+            var exceptionRequestsCount = requests.Count(r => r.metric == "process.runtime.dotnet.exceptions.count");
 
             Assert.True(exceptionRequestsCount > 0, "No exception metrics received.");
 
@@ -98,7 +98,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
              || (Environment.Version.Major == 3 && Environment.Version.Minor == 1)
              || Environment.Version.Major >= 5)
             {
-                var contentionRequestsCount = requests.Count(r => r.metric == "runtime.dotnet.threads.contention_count");
+                var contentionRequestsCount = requests.Count(r => r.metric == "process.runtime.dotnet.monitor.lock_contention.count");
 
                 Assert.True(contentionRequestsCount > 0, "No contention metrics received.");
             }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
@@ -33,25 +33,15 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
             listener.Refresh();
 
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, expectedGen0HeapSize, 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, expectedGen1HeapSize, 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, expectedGen2HeapSize, 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, expectedLohHeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedGen0HeapSize, 1, new[] { "generation:gen0" }), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedGen1HeapSize, 1, new[] { "generation:gen1" }), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedGen2HeapSize, 1, new[] { "generation:gen2" }), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedLohHeapSize, 1, new[] { "generation:loh" }), Times.Once);
 
-            statsd.VerifyNoOtherCalls();
-            statsd.Invocations.Clear();
-
-            listener.Refresh();
-
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, expectedGen0HeapSize, 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, expectedGen1HeapSize, 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, expectedGen2HeapSize, 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, expectedLohHeapSize, 1, null), Times.Once);
-
-            // Those metrics aren't pushed the first time (differential count)
-            statsd.Verify(s => s.Increment(MetricsNames.Gen0CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Increment(MetricsNames.Gen1CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Increment(MetricsNames.Gen2CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            // note: collections count no longer extracted from counters
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen0" }), Times.Once);
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen1" }), Times.Once);
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen2" }), Times.Once);
 
             statsd.VerifyNoOtherCalls();
         }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
@@ -28,26 +28,16 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
             listener.Refresh();
 
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, It.IsAny<double>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:gen0" }), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:gen1" }), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:gen2" }), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:loh" }), Times.Once);
 
-            statsd.VerifyNoOtherCalls();
-            statsd.Invocations.Clear();
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen0" }), Times.Once);
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen1" }), Times.Once);
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen2" }), Times.Once);
 
-            listener.Refresh();
-
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, It.IsAny<double>(), 1, null), Times.Once);
-
-            // Those metrics aren't pushed the first time (differential count)
-            statsd.Verify(s => s.Increment(MetricsNames.Gen0CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Increment(MetricsNames.Gen1CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Increment(MetricsNames.Gen2CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<double>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<long>(), 1, It.IsAny<string[]>()), Times.Once);
 
             statsd.VerifyNoOtherCalls();
         }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 // Disabled on .NET Core 3.1 as we were running into this issue: https://github.com/dotnet/runtime/issues/51579
+
 #if NET5_0_OR_GREATER
 using System;
 using System.Collections.Generic;
@@ -30,44 +33,55 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             listener.Refresh();
 
             statsd.Verify(s => s.Gauge(MetricsNames.ContentionTime, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<double>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<long>(), 1, null), Times.Once);
             statsd.Verify(s => s.Gauge(MetricsNames.ThreadPoolWorkersCount, It.IsAny<double>(), 1, null), Times.Once);
         }
 
         [Fact]
         public void MonitorGarbageCollections()
         {
-            string[] compactingGcTags = { "compacting_gc:true" };
-
             var statsd = new Mock<IDogStatsd>();
 
-            var mutex = new ManualResetEventSlim();
+            // number of reported heap sizes depends on the version of the runtime
+            var expectedCount = Environment.Version.Major >= 6 ? 5 : 4;
 
-            // GcPauseTime is pushed on the GcRestartEnd event, which should be the last event for any GC
-            statsd.Setup(s => s.Timer(MetricsNames.GcPauseTime, It.IsAny<double>(), It.IsAny<double>(), null))
-                .Callback(() => mutex.Set());
+            // needed for runtime version < net6
+            var countdownEvent = new CountdownEvent(expectedCount);
+
+            statsd.Setup(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), It.IsAny<string[]>()))
+                .Callback(() => countdownEvent.Signal());
 
             using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(10));
 
             statsd.Invocations.Clear();
 
-            for (int i = 0; i < 3; i++)
+            countdownEvent.Reset(); // In case a GC was triggered when creating the listener
+
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+            // refresh for collection counts metrics to be pushed
+            listener.Refresh();
+
+            // GC events are pushed asynchronously for runtime version < net6, wait for the last one to be processed
+            if (!countdownEvent.Wait(TimeSpan.FromSeconds(30)))
             {
-                mutex.Reset(); // In case a GC was triggered when creating the listener
-
-                GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
-
-                // GC events are pushed asynchronously, wait for the last one to be processed
-                mutex.Wait();
+                throw new TimeoutException("Timed-out waiting for heap sizes to be reported.");
             }
 
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, It.IsAny<double>(), It.IsAny<double>(), null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, It.IsAny<double>(), It.IsAny<double>(), null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, It.IsAny<double>(), It.IsAny<double>(), null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, It.IsAny<double>(), It.IsAny<double>(), null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Timer(MetricsNames.GcPauseTime, It.IsAny<double>(), It.IsAny<double>(), null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.GcMemoryLoad, It.IsAny<double>(), It.IsAny<double>(), null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Increment(MetricsNames.Gen2CollectionsCount, 1, It.IsAny<double>(), compactingGcTags), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:gen0" }), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:gen1" }), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:gen2" }), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:loh" }), Times.AtLeastOnce);
+
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.AllocatedBytes, It.IsAny<long>(), It.IsAny<double>(), It.IsAny<string[]>()), Times.AtLeastOnce);
+
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), It.IsAny<double>(), new[] { "generation:gen0" }), Times.AtLeastOnce);
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), It.IsAny<double>(), new[] { "generation:gen1" }), Times.AtLeastOnce);
+            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), It.IsAny<double>(), new[] { "generation:gen2" }), Times.AtLeastOnce);
+
+#if NET6_0_OR_GREATER
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapCommittedMemory, It.IsAny<double>(), It.IsAny<double>(), It.IsAny<string[]>()), Times.AtLeastOnce);
+#endif
         }
 
         [Fact]


### PR DESCRIPTION
## Why

Adjust metrics implementation to match [`otel`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs).

## What

- reimplement gc-related metrics, threadpool's thread count, contention 
- adjust metrics export

## Tests

Included in PR.
Dashboard: https://app.signalfx.com/#/dashboard/FGfk_uBAgAA?groupId=FGfk7HwAcAE&configId=FGflAd_AcAA&startTimeUTC=1662357568000&endTimeUTC=1662358037000
