### PR TITLE
Capture more details in allocation sampling prototype

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -81,7 +81,7 @@ public:
 class ThreadSampler
 {
 public:
-    void StartSampling(ICorProfilerInfo10* cor_profiler_info10);
+    void StartThreadSampling();
     void StartAllocationSampling(ICorProfilerInfo12* info12);
     void AllocationTick(ULONG dataLen, LPCBYTE data);
     ICorProfilerInfo10* info10;
@@ -89,6 +89,9 @@ public:
     void ThreadDestroyed(ThreadID thread_id);
     void ThreadAssignedToOsThread(ThreadID managedThreadId, DWORD os_thread_id);
     void ThreadNameChanged(ThreadID thread_id, ULONG cch_name, WCHAR name[]);
+
+    void SetGlobalInfo10(ICorProfilerInfo10* info10);
+    ThreadState* GetCurrentThreadState(ThreadID tid);
 
     std::unordered_map<ThreadID, ThreadState*> managed_tid_to_state_;
     std::mutex thread_state_lock_;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -254,12 +254,16 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         return E_FAIL;
     }
 
+    if (IsThreadSamplingEnabled() || IsAllocationSamplingEnabled())
+    {
+        this->threadSampler = new always_on_profiler::ThreadSampler();
+        this->threadSampler->SetGlobalInfo10(info10);
+    }
     if (IsThreadSamplingEnabled())
     {
         if (metThreadSamplingRequirements)
         {
-            this->threadSampler = new always_on_profiler::ThreadSampler();
-            this->threadSampler->StartSampling(info10);
+            this->threadSampler->StartThreadSampling();
         }
         else
         {
@@ -272,11 +276,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         HRESULT hr = info_->QueryInterface(__uuidof(ICorProfilerInfo12), (void**) &info12);
         if (!FAILED(hr) && info12 != nullptr)
         {
-            if (this->threadSampler == nullptr)
-            {
-                // TODO Splunk: may want to combine precheck logic to ensure only one allocation site
-                this->threadSampler = new always_on_profiler::ThreadSampler();
-            }
             this->threadSampler->StartAllocationSampling(info12);
         }
         else


### PR DESCRIPTION
Rework initialization sequence so that thread or allocation sampling can be started independently; use new access to ThreadSampler state to capture (but not yet print/do anything with) span and thread context.  