### PR TITLE
Initial work on a buffer for allocation samples

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -34,9 +34,12 @@ constexpr auto kMaxVolatileFunctionNameCacheSize = 2000;
 // https://github.com/dotnet/samples/blob/2cf486af936261b04a438ea44779cdc26c613f98/core/profiling/stacksampling/src/sampler.cpp
 // That stack sampling project is worth reading for a simpler (though higher overhead) take on thread sampling.
 
-static std::mutex buffer_lock = std::mutex();
-static std::vector<unsigned char>* buffer_a;
-static std::vector<unsigned char>* buffer_b;
+static std::mutex cpu_buffer_lock = std::mutex();
+static std::vector<unsigned char>* cpu_buffer_a;
+static std::vector<unsigned char>* cpu_buffer_b;
+
+static std::mutex allocation_buffer_lock = std::mutex();
+static std::vector<unsigned char>* allocation_buffer = new std::vector<unsigned char>();
 
 static std::mutex thread_span_context_lock;
 static std::unordered_map<ThreadID, always_on_profiler::thread_span_context> thread_span_context_map;
@@ -46,16 +49,16 @@ static ICorProfilerInfo10* profiler_info; // After feature sets settle down, per
 // Dirt-simple back pressure system to save overhead if managed code is not reading fast enough
 bool ThreadSamplingShouldProduceThreadSample()
 {
-    std::lock_guard<std::mutex> guard(buffer_lock);
-    return buffer_a == nullptr || buffer_b == nullptr;
+    std::lock_guard<std::mutex> guard(cpu_buffer_lock);
+    return cpu_buffer_a == nullptr || cpu_buffer_b == nullptr;
 }
 void ThreadSamplingRecordProducedThreadSample(std::vector<unsigned char>* buf)
 {
-    std::lock_guard<std::mutex> guard(buffer_lock);
-    if (buffer_a == nullptr) {
-        buffer_a = buf;
-    } else if (buffer_b == nullptr) {
-        buffer_b = buf;
+    std::lock_guard<std::mutex> guard(cpu_buffer_lock);
+    if (cpu_buffer_a == nullptr) {
+        cpu_buffer_a = buf;
+    } else if (cpu_buffer_b == nullptr) {
+        cpu_buffer_b = buf;
     } else {
         trace::Logger::Warn("Unexpected buffer drop in ThreadSampling_RecordProducedThreadSample");
         delete buf; // needs to be dropped now
@@ -71,17 +74,58 @@ int32_t ThreadSamplingConsumeOneThreadSample(int32_t len, unsigned char* buf)
     }
     std::vector<unsigned char>* to_use = nullptr;
     {
-        std::lock_guard<std::mutex> guard(buffer_lock);
-        if (buffer_a != nullptr)
+        std::lock_guard<std::mutex> guard(cpu_buffer_lock);
+        if (cpu_buffer_a != nullptr)
         {
-            to_use = buffer_a;
-            buffer_a = nullptr;
+            to_use = cpu_buffer_a;
+            cpu_buffer_a = nullptr;
         }
-        else if (buffer_b != nullptr)
+        else if (cpu_buffer_b != nullptr)
         {
-            to_use = buffer_b;
-            buffer_b = nullptr;
+            to_use = cpu_buffer_b;
+            cpu_buffer_b = nullptr;
         }
+    }
+    if (to_use == nullptr)
+    {
+        return 0;
+    }
+    const size_t to_use_len = static_cast<int>(std::min(to_use->size(), static_cast<size_t>(len)));
+    memcpy(buf, to_use->data(), to_use_len);
+    delete to_use;
+    return static_cast<int32_t>(to_use_len);
+}
+
+void AllocationSamplingAppendToBuffer(int32_t appendLen, unsigned char* appendBuf)
+{
+    if (appendLen <= 0 || appendBuf == NULL)
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> guard(allocation_buffer_lock);
+
+    if (allocation_buffer->size() >= kSamplesBufferMaximumSize)
+    {
+        return;
+    }
+    size_t actualLen = std::min((size_t) appendLen, kSamplesBufferMaximumSize - allocation_buffer->size());
+    allocation_buffer->insert(allocation_buffer->end(), appendBuf, &appendBuf[actualLen]);
+}
+
+// Can return 0
+int32_t AllocationSamplingConsumeAndReplaceBuffer(int32_t len, unsigned char* buf)
+{
+    if (len <= 0 || buf == nullptr)
+    {
+        trace::Logger::Warn("Unexpected 0/null buffer to SignalFxReadAllocationSamples");
+        return 0;
+    }
+    std::vector<unsigned char>* to_use = nullptr;
+    {
+        std::lock_guard<std::mutex> guard(allocation_buffer_lock);
+        to_use = allocation_buffer;
+        allocation_buffer = new std::vector<unsigned char>();
+        allocation_buffer->reserve(kSamplesBufferDefaultSize);
     }
     if (to_use == nullptr)
     {
@@ -795,6 +839,10 @@ extern "C"
     EXPORTTHIS int32_t SignalFxReadThreadSamples(int32_t len, unsigned char* buf)
     {
         return ThreadSamplingConsumeOneThreadSample(len, buf);
+    }
+    EXPORTTHIS int32_t SignalFxReadAllocationSamples(int32_t len, unsigned char* buf)
+    {
+        return AllocationSamplingConsumeAndReplaceBuffer(len, buf);
     }
     EXPORTTHIS void SignalFxSetNativeContext(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId,
                                              int32_t managedThreadId)

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -19,6 +19,7 @@ constexpr auto unknown_managed_thread_id = -1;
 extern "C"
 {
     EXPORTTHIS int32_t SignalFxReadThreadSamples(int32_t len, unsigned char* buf);
+    EXPORTTHIS int32_t SignalFxReadAllocationSamples(int32_t len, unsigned char* buf);
     // ReSharper disable CppInconsistentNaming
     EXPORTTHIS void SignalFxSetNativeContext(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId, int32_t managedThreadId);
     // ReSharper restore CppInconsistentNaming
@@ -172,6 +173,8 @@ private:
     std::unordered_map<TKey, typename std::list<std::pair<TKey, TValue>>::iterator> map_;
 };
 } // namespace always_on_profiler
+
+void AllocationSamplingAppendToBuffer(int32_t appendLen, unsigned char* appendBuf);
 
 bool ThreadSamplingShouldProduceThreadSample();
 void ThreadSamplingRecordProducedThreadSample(std::vector<unsigned char>* buf);

--- a/tracer/src/Datadog.Trace/ClrProfiler/NativeMethods.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/NativeMethods.cs
@@ -125,6 +125,11 @@ namespace Datadog.Trace.ClrProfiler
             return IsWindows ? Windows.SignalFxReadThreadSamples(len, buf) : NonWindows.SignalFxReadThreadSamples(len, buf);
         }
 
+        public static int SignalFxReadAllocationSamples(int len, byte[] buf)
+        {
+            return IsWindows ? Windows.SignalFxReadAllocationSamples(len, buf) : NonWindows.SignalFxReadAllocationSamples(len, buf);
+        }
+
         public static void SignalFxSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId, int managedThreadId)
         {
             if (IsWindows)
@@ -166,6 +171,9 @@ namespace Datadog.Trace.ClrProfiler
             public static extern int SignalFxReadThreadSamples(int len, byte[] buf);
 
             [DllImport("SignalFx.Tracing.ClrProfiler.Native.dll")]
+            public static extern int SignalFxReadAllocationSamples(int len, byte[] buf);
+
+            [DllImport("SignalFx.Tracing.ClrProfiler.Native.dll")]
             public static extern void SignalFxSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId, int managedThreadId);
         }
 
@@ -195,6 +203,9 @@ namespace Datadog.Trace.ClrProfiler
 
             [DllImport("SignalFx.Tracing.ClrProfiler.Native")]
             public static extern int SignalFxReadThreadSamples(int len, byte[] buf);
+
+            [DllImport("SignalFx.Tracing.ClrProfiler.Native")]
+            public static extern int SignalFxReadAllocationSamples(int len, byte[] buf);
 
             [DllImport("SignalFx.Tracing.ClrProfiler.Native")]
             public static extern void SignalFxSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId, int managedThreadId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
@@ -129,6 +129,26 @@ TEST(ThreadSamplerTest, StaticBufferManagement)
     ASSERT_EQ('E', read_buf[0]);
 }
 
+TEST(ThreadSamplerTest, AllocationBufferBehavior)
+{
+    unsigned char read_buf[4];
+    unsigned char write_buf[] = {5, 6, 7, 8};
+    // Invalid inputs don't blow up
+    ASSERT_EQ(0, SignalFxReadAllocationSamples(0, read_buf));
+    ASSERT_EQ(0, SignalFxReadAllocationSamples(4, NULL));
+    AllocationSamplingAppendToBuffer(0, NULL);
+    // No data->0 result
+    ASSERT_EQ(0, SignalFxReadAllocationSamples(4, read_buf));
+    AllocationSamplingAppendToBuffer(1, write_buf);
+    ASSERT_EQ(1, SignalFxReadAllocationSamples(4, read_buf));
+    ASSERT_EQ(0, SignalFxReadAllocationSamples(4, read_buf));
+    AllocationSamplingAppendToBuffer(1, write_buf);
+    AllocationSamplingAppendToBuffer(2, write_buf);
+    ASSERT_EQ(3, SignalFxReadAllocationSamples(4, read_buf));
+    ASSERT_EQ(0, SignalFxReadAllocationSamples(4, read_buf));
+}
+
+
 TEST(ThreadSamplerTest, LRUCache)
 {
     constexpr int max = 10000;


### PR DESCRIPTION
Groundwork for a separate data buffer for allocation samples, with no actual data flowing through it yet.  Renamed old buffer stuff `cpu_buffer` for clarity.