### PR TITLE
Additional work on a data pipe for allocation samples

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -112,11 +112,14 @@ public:
     void EndSample() const;
     void EndBatch() const;
     void WriteFinalStats(const SamplingStatistics& stats) const;
+    void AllocationSample(uint64_t allocSize, const WCHAR* allocType, size_t allocTypeCharLen, ThreadID id, const ThreadState* state, const thread_span_context& span_context) const;
 
 private:
+    void WriteCurrentTimeMillis() const;
     void WriteCodedFrameString(FunctionID fid, const shared::WSTRING& str);
     void WriteShort(int16_t val) const;
     void WriteInt(int32_t val) const;
+    void WriteString(const WCHAR* s, size_t len) const;
     void WriteString(const shared::WSTRING& str) const;
     void WriteByte(unsigned char b) const;
     void WriteUInt64(uint64_t val) const;

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampleNativeFormatParser.cs
@@ -146,6 +146,22 @@ namespace Datadog.Trace.AlwaysOnProfiler
                         new object[] { microsSuspended, numThreads, totalFrames, numCacheMisses });
                     }
                 }
+                else if (operationCode == OpCodes.AllocationSample)
+                {
+                    var timestampMillis = ReadInt64();
+                    var allocatedSize = ReadInt64(); // Technically uint64 but whatever
+                    var typeName = ReadString();
+                    var managedId = ReadInt();
+                    var nativeId = ReadInt();
+                    var threadName = ReadString();
+                    var traceIdHigh = ReadInt64();
+                    var traceIdLow = ReadInt64();
+                    var spanId = ReadInt64();
+                    // TODO Splunk: read stack frame (share code with above StartSample)
+                    var stackFrameCodeCurrentlyZero = ReadShort();
+                    // TODO Splunk: export this somewhere
+                    // Console.WriteLine("ALLOC: " + allocatedSize + " " + typeName);
+                }
                 else
                 {
                     _position = _length + 1;
@@ -232,6 +248,11 @@ namespace Datadog.Trace.AlwaysOnProfiler
             /// Marks the beginning of a section with statistics, see THREAD_SAMPLES_FINAL_STATS on native code.
             /// </summary>
             public const byte BatchStats = 0x07;
+
+            /// <summary>
+            /// Marks the start of an allocation sample, see THREAD_SAMPLES_ALLOCATION_SAMPLE on native code.
+            /// </summary>
+            public const byte AllocationSample = 0x08;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
@@ -52,6 +52,27 @@ TEST(ThreadSamplerTest, BasicBufferBehavior)
     ASSERT_EQ(1290, tsb.buffer_->size()); // not manually calculated but does depend on thread name limiting and not repeating frame strings
     ASSERT_EQ(2, tsb.codes_.size());
 }
+TEST(ThreadSamplerTest, AllocationSampleBuffer)
+{
+    auto buf = std::vector<unsigned char>();
+    shared::WSTRING longThreadName;
+    for (int i = 0; i < 400; i++)
+    {
+        longThreadName.append(WStr("blah blah "));
+    }
+    const shared::WSTRING frame1 = WStr("SomeFairlyLongClassName::SomeMildlyLongMethodName");
+    const shared::WSTRING frame2 = WStr("SomeFairlyLongClassName::ADifferentMethodName");
+    const shared::WSTRING typeName = WStr("ThisIsMyTypeName");
+    ThreadSamplesBuffer tsb(&buf);
+    ThreadState threadState;
+    threadState.native_id_ = 1000;
+    threadState.thread_name_.append(longThreadName);
+
+    tsb.AllocationSample(32, typeName.c_str(), typeName.length(), 1, &threadState, thread_span_context());
+    // TODO Splunk: record frames here
+
+    ASSERT_EQ(1109, tsb.buffer_->size()); // not manually calculated
+}
 
 TEST(ThreadSamplerTest, BufferOverrunBehavior)
 {


### PR DESCRIPTION
Skeleton for pushing data from native capture of allocation samples through to managed space.  Still no stack frames, no actual export from the managed side, but a bit of progress nonetheless.