### PR TITLE
[RuntimeMetrics] Cleanup

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.RuntimeMetrics
             _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen0Size, tags: GcMetrics.Tags.Gen0);
             _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen1Size, tags: GcMetrics.Tags.Gen1);
             _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen2Size, tags: GcMetrics.Tags.Gen2);
-            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.LohSize, tags: GcMetrics.Tags.Loh);
+            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.LohSize, tags: GcMetrics.Tags.LargeObjectHeap);
 
             GcMetrics.PushCollectionCounts(_statsd);
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -37,10 +37,10 @@ namespace Datadog.Trace.RuntimeMetrics
             var rawValue = EnvironmentHelpers.GetEnvironmentVariable(EnvironmentVariableName);
             var value = JsonConvert.DeserializeObject<PerformanceCountersValue>(rawValue);
 
-            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen0Size, tags: new[] { GcMetrics.GenerationTag(0) });
-            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen1Size, tags: new[] { GcMetrics.GenerationTag(1) });
-            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen2Size, tags: new[] { GcMetrics.GenerationTag(2) });
-            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.LohSize, tags: new[] { GcMetrics.GenerationTag(3) });
+            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen0Size, tags: GcMetrics.Tags.Gen0);
+            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen1Size, tags: GcMetrics.Tags.Gen1);
+            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen2Size, tags: GcMetrics.Tags.Gen2);
+            _statsd.Gauge(MetricsNames.Gc.HeapSize, value.LohSize, tags: GcMetrics.Tags.Loh);
 
             GcMetrics.PushCollectionCounts(_statsd);
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/GcMetrics.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/GcMetrics.cs
@@ -46,17 +46,17 @@ internal static class GcMetrics
 
         public static string[] Gen2 { get; } = new[] { GenerationTag(GcGeneration.Gen2) };
 
-        public static string[] Loh { get; } = new[] { GenerationTag(GcGeneration.LargeObjectHeap) };
+        public static string[] LargeObjectHeap { get; } = new[] { GenerationTag(GcGeneration.LargeObjectHeap) };
 
-        public static string[] Poh { get; } = new[] { GenerationTag(GcGeneration.PinnedObjectHeap) };
+        public static string[] PinnedObjectHeap { get; } = new[] { GenerationTag(GcGeneration.PinnedObjectHeap) };
 
         public static ReadOnlyCollection<string[]> GenerationTags { get; } = new(new List<string[]>
         {
             Gen0,
             Gen1,
             Gen2,
-            Loh,
-            Poh
+            LargeObjectHeap,
+            PinnedObjectHeap
         });
 
         private static string GenerationTag(GcGeneration gcGeneration)

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.RuntimeMetrics
         public const string CpuPercentage = "runtime.dotnet.cpu.percent";
 
         public const string AspNetCoreCurrentRequests = "runtime.dotnet.aspnetcore.requests.current";
+
         public const string AspNetCoreFailedRequests = "runtime.dotnet.aspnetcore.requests.failed";
         public const string AspNetCoreTotalRequests = "runtime.dotnet.aspnetcore.requests.total";
         public const string AspNetCoreRequestQueueLength = "runtime.dotnet.aspnetcore.requests.queue_length";

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.RuntimeMetrics
             TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen0Size, GcMetrics.Tags.Gen0);
             TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen1Size, GcMetrics.Tags.Gen1);
             TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen2Size, GcMetrics.Tags.Gen2);
-            TryUpdateGauge(MetricsNames.Gc.HeapSize, _lohSize, GcMetrics.Tags.Loh);
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _lohSize, GcMetrics.Tags.LargeObjectHeap);
 
             TryUpdateCounter(MetricsNames.ContentionCount, _contentionCount);
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -75,10 +75,10 @@ namespace Datadog.Trace.RuntimeMetrics
                 _instanceName = GetSimpleInstanceName();
             }
 
-            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen0Size, GcMetrics.GenerationTag(0));
-            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen1Size, GcMetrics.GenerationTag(1));
-            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen2Size, GcMetrics.GenerationTag(2));
-            TryUpdateGauge(MetricsNames.Gc.HeapSize, _lohSize, GcMetrics.GenerationTag(3));
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen0Size, GcMetrics.Tags.Gen0);
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen1Size, GcMetrics.Tags.Gen1);
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _gen2Size, GcMetrics.Tags.Gen2);
+            TryUpdateGauge(MetricsNames.Gc.HeapSize, _lohSize, GcMetrics.Tags.Loh);
 
             TryUpdateCounter(MetricsNames.ContentionCount, _contentionCount);
 
@@ -118,13 +118,13 @@ namespace Datadog.Trace.RuntimeMetrics
             }
         }
 
-        private void TryUpdateGauge(string path, PerformanceCounterWrapper counter, string tag)
+        private void TryUpdateGauge(string path, PerformanceCounterWrapper counter, string[] tags)
         {
             var value = counter.GetValue(_instanceName);
 
             if (value != null)
             {
-                _statsd.Gauge(path, value.Value, tags: new[] { tag });
+                _statsd.Gauge(path, value.Value, tags: tags);
             }
         }
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -164,7 +164,7 @@ namespace Datadog.Trace.RuntimeMetrics
                 _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen0Size, tags: GcMetrics.Tags.Gen0);
                 _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen1Size, tags: GcMetrics.Tags.Gen1);
                 _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen2Size, tags: GcMetrics.Tags.Gen2);
-                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.LohSize, tags: GcMetrics.Tags.Loh);
+                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.LohSize, tags: GcMetrics.Tags.LargeObjectHeap);
             }
 #endif
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.RuntimeMetrics
                 ["total-connections"] = MetricsNames.AspNetCoreTotalConnections
             };
 
-            // source originated from: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+            // source originated from: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/bc947a00c3f859cc436f050e81172fc1f8bc09d7/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
 #if NET6_0_OR_GREATER
             var mi = typeof(GC).GetMethod("GetGenerationSize", BindingFlags.NonPublic | BindingFlags.Static);
             if (mi != null)
@@ -104,13 +104,20 @@ namespace Datadog.Trace.RuntimeMetrics
             GcMetrics.PushCollectionCounts(_statsd);
 
 #if NET6_0_OR_GREATER
-            // source originated from: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
+            // source originated from: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/bc947a00c3f859cc436f050e81172fc1f8bc09d7/src/OpenTelemetry.Instrumentation.Runtime/RuntimeMetrics.cs
             var generationInfo = GC.GetGCMemoryInfo().GenerationInfo;
             var maxSupportedLength = Math.Min(generationInfo.Length, GcMetrics.GenNames.Count);
             for (var i = 0; i < maxSupportedLength; i++)
             {
+                // heap size returned by GetGenerationSize, based on value of i:
+                // 0 -> gen0
+                // 1 -> gen1
+                // 2 -> gen2
+                // 3 -> loh
+                // 4 -> poh
+
                 // TODO splunk: opentelemetry-dotnet-contrib plans to change to ObservableUpDownCounter, will need to be adjusted
-                _statsd.Gauge(MetricsNames.Gc.HeapSize, GetGenerationSize(i), tags: new[] { GcMetrics.GenerationTag(i) });
+                _statsd.Gauge(MetricsNames.Gc.HeapSize, GetGenerationSize(i), tags: GcMetrics.Tags.GenerationTags[i]);
             }
 
             if (IsGcInfoAvailable)
@@ -154,10 +161,10 @@ namespace Datadog.Trace.RuntimeMetrics
                 var stats = HeapStats.FromPayload(eventData.Payload);
 
                 // TODO splunk: opentelemetry-dotnet-contrib plans to change to ObservableUpDownCounter, will need to be adjusted
-                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen0Size, tags: new[] { GcMetrics.GenerationTag(0) });
-                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen1Size, tags: new[] { GcMetrics.GenerationTag(1) });
-                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen2Size, tags: new[] { GcMetrics.GenerationTag(2) });
-                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.LohSize, tags: new[] { GcMetrics.GenerationTag(3) });
+                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen0Size, tags: GcMetrics.Tags.Gen0);
+                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen1Size, tags: GcMetrics.Tags.Gen1);
+                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.Gen2Size, tags: GcMetrics.Tags.Gen2);
+                _statsd.Gauge(MetricsNames.Gc.HeapSize, stats.LohSize, tags: GcMetrics.Tags.Loh);
             }
 #endif
 

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -80,6 +80,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), It.IsAny<double>(), new[] { "generation:gen2" }), Times.AtLeastOnce);
 
 #if NET6_0_OR_GREATER
+            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:poh" }), Times.AtLeastOnce);
             statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapCommittedMemory, It.IsAny<double>(), It.IsAny<double>(), It.IsAny<string[]>()), Times.AtLeastOnce);
 #endif
         }


### PR DESCRIPTION
## Why

Address comments from https://github.com/signalfx/signalfx-dotnet-tracing/pull/606

## What

Cleanup.

## Tests

CI tests.
