### PR TITLE
Configurable trace exporter buffer size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### Enhancements
 
+- Add `SIGNALFX_TRACE_BUFFER_SIZE` setting to configure trace exporter buffer size.
+
 ## [Release 0.2.9](https://github.com/signalfx/signalfx-dotnet-tracing/releases/tag/v0.2.9)
 
 ### Bugfixes

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -72,7 +72,7 @@ The following settings are common to most instrumentation scenarios:
 
 ## Exporter settings
 
-Use following settings to configure where the telemetry data is being exported.
+Use following settings to configure where and how the telemetry data is being exported.
 
 | Setting | Description | Default |
 |-|-|-|
@@ -82,6 +82,7 @@ Use following settings to configure where the telemetry data is being exported.
 | `SIGNALFX_METRICS_ENDPOINT_URL` | The URL to where metric exporters send metrics. Overrides `SIGNALFX_REALM` configuration for the metrics ingestion endpoint. | `http://localhost:9943/v2/datapoint` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED` | Enable to export traces that contain a minimum number of closed spans, as defined by `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS`. | `false` |
 | `SIGNALFX_TRACE_PARTIAL_FLUSH_MIN_SPANS` | Minimum number of closed spans in a trace before it's exported. The default value is ``500``. Requires the value of the ``SIGNALFX_TRACE_PARTIAL_FLUSH_ENABLED`` environment variable to be ``true``. | `500` |
+| `SIGNALFX_TRACE_BUFFER_SIZE` | The size of the trace exporter buffer, expressed as the number of traces. | `1000` |
 
 ### Exporting directly to Splunk Observability Cloud
 

--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -54,7 +54,6 @@ These settings should be never used by the users.
 | `SIGNALFX_TRACE_AGENT_PORT` | The Agent port where the tracer can send traces | `9411` |
 | `SIGNALFX_TRACE_ANALYTICS_ENABLED` | Enable to activate default Analytics. | `false` |
 | `SIGNALFX_TRACE_BATCH_INTERVAL` | The batch interval in milliseconds for the serialization queue. | `100` |
-| `SIGNALFX_TRACE_BUFFER_SIZE` | The size in bytes of the trace buffer. | `1024 * 1024 * 10 (10MB)` |
 | `SIGNALFX_TRACE_LOG_PATH` | (Deprecated) The path of the profiler log file. | Linux: `/var/log/signalfx/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%\SignalFx .NET Tracing\logs\dotnet-profiler.log` |
 | `SIGNALFX_TRACE_HEADER_TAG_NORMALIZATION_FIX_ENABLED` | Enables a fix around header tags normalization. We used to normalize periods even if a tag was provided for a header, whereas we should not. | `true` |
 | `SIGNALFX_TRACE_PIPE_NAME` | The named pipe where the tracer can send traces. |  |

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -105,5 +105,10 @@ namespace Datadog.Trace.Configuration
         /// Default is <c>false</c>
         /// </summary>
         public const string TraceSyncExport = "SIGNALFX_TRACE_SYNC_EXPORT";
+
+        /// <summary>
+        /// Configuration key for setting the size of the trace buffer
+        /// </summary>
+        public const string TraceBufferSize = "SIGNALFX_TRACE_BUFFER_SIZE";
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -133,11 +133,6 @@ namespace Datadog.Trace.Configuration
         public const string ServiceNameMappings = "SIGNALFX_TRACE_SERVICE_MAPPING";
 
         /// <summary>
-        /// Configuration key for setting the size in bytes of the trace buffer
-        /// </summary>
-        public const string BufferSize = "SIGNALFX_TRACE_BUFFER_SIZE";
-
-        /// <summary>
         /// Configuration key for setting the batch interval in milliseconds for the serialization queue
         /// </summary>
         public const string SerializationBatchInterval = "SIGNALFX_TRACE_BATCH_INTERVAL";

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -99,6 +99,11 @@ namespace Datadog.Trace.Configuration
                 validators: (val) => val > 0);
             SyncExport = source?.GetBool(ConfigurationKeys.TraceSyncExport) ?? false;
 
+            TraceBufferSize = source.SafeReadInt32(
+                key: ConfigurationKeys.TraceBufferSize,
+                defaultTo: 1000,
+                validators: configuredSize => configuredSize > 0);
+
             var stringProfileExportFormat = source?.GetString(ConfigurationKeys.AlwaysOnProfiler.ExportFormat);
             if (string.IsNullOrEmpty(stringProfileExportFormat))
             {
@@ -184,6 +189,11 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating whether to do synchronous export.
         /// </summary>
         public bool SyncExport { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the trace buffer.
+        /// </summary>
+        public int TraceBufferSize { get; set; }
 
         /// <summary>
         /// Gets or sets the type of metrics exporter.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.Configuration
             ProfilerExportFormat = settings.ProfilerExportFormat;
 
             SyncExport = settings.SyncExport;
+            TraceBufferSize = settings.TraceBufferSize;
         }
 
         /// <summary>
@@ -120,6 +121,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether exports should be synchronous.
         /// </summary>
         public bool SyncExport { get; }
+
+        /// <summary>
+        /// Gets a value indicating the size of the trace buffer
+        /// </summary>
+        public int TraceBufferSize { get; }
 
         /// <summary>
         /// Gets the transport used to send traces to the Agent.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -65,7 +65,6 @@ namespace Datadog.Trace.Configuration
             HttpServerErrorStatusCodes = settings.HttpServerErrorStatusCodes;
             HttpClientErrorStatusCodes = settings.HttpClientErrorStatusCodes;
             ServiceNameMappings = settings.ServiceNameMappings;
-            TraceBufferSize = settings.TraceBufferSize;
             TraceBatchInterval = settings.TraceBatchInterval;
             RouteTemplateResourceNamesEnabled = settings.RouteTemplateResourceNamesEnabled;
             DelayWcfInstrumentationEnabled = settings.DelayWcfInstrumentationEnabled;
@@ -262,11 +261,6 @@ namespace Datadog.Trace.Configuration
         /// Gets configuration values for changing service names based on configuration
         /// </summary>
         internal ServiceNames ServiceNameMappings { get; }
-
-        /// <summary>
-        /// Gets a value indicating the size in bytes of the trace buffer
-        /// </summary>
-        internal int TraceBufferSize { get; }
 
         /// <summary>
         /// Gets a value indicating the batch interval for the serialization queue, in milliseconds

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -158,9 +158,6 @@ namespace Datadog.Trace.Configuration
                                         "400-599";
             HttpClientErrorStatusCodes = ParseHttpCodesToArray(httpClientErrorStatusCodes);
 
-            TraceBufferSize = source?.GetInt32(ConfigurationKeys.BufferSize)
-                           ?? 1024 * 1024 * 10; // 10MB
-
             TraceBatchInterval = source?.GetInt32(ConfigurationKeys.SerializationBatchInterval)
                               ?? 100;
 
@@ -533,11 +530,6 @@ namespace Datadog.Trace.Configuration
         /// Gets configuration values for changing service names based on configuration
         /// </summary>
         internal ServiceNames ServiceNameMappings { get; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the size in bytes of the trace buffer
-        /// </summary>
-        internal int TraceBufferSize { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the batch interval for the serialization queue, in milliseconds

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -388,6 +388,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("partialflush_minspans");
                     writer.WriteValue(instanceSettings.ExporterSettings.PartialFlushMinSpans);
 
+                    writer.WritePropertyName("trace_buffer_size");
+                    writer.WriteValue(instanceSettings.ExporterSettings.TraceBufferSize);
+
                     writer.WritePropertyName("runtime_id");
                     writer.WriteValue(DistributedTracer.Instance.GetRuntimeId());
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -180,14 +180,14 @@ namespace Datadog.Trace
             switch (settings.Exporter)
             {
                 case ExporterType.Zipkin:
-                    return new ExporterWriter(new ZipkinExporter(settings), metrics);
+                    return new ExporterWriter(new ZipkinExporter(settings), metrics, queueSize: settings.ExporterSettings.TraceBufferSize);
                 default:
                     var apiRequestFactory = TracesTransportStrategy.Get(settings.ExporterSettings);
                     var api = new Api(apiRequestFactory, statsd, sampler.SetDefaultSampleRates, settings.ExporterSettings.PartialFlushEnabled, settings.StatsComputationEnabled);
 
                     var statsAggregator = StatsAggregator.Create(api, settings);
 
-                    return new AgentWriter(api, statsAggregator, metrics, maxBufferSize: settings.TraceBufferSize);
+                    return new AgentWriter(api, statsAggregator, metrics, maxBufferSize: settings.ExporterSettings.TraceBufferSize);
             }
         }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -187,7 +187,8 @@ namespace Datadog.Trace
 
                     var statsAggregator = StatsAggregator.Create(api, settings);
 
-                    return new AgentWriter(api, statsAggregator, metrics, maxBufferSize: settings.ExporterSettings.TraceBufferSize);
+                    const int maxBufferSize = 1024 * 1024 * 10;
+                    return new AgentWriter(api, statsAggregator, metrics, maxBufferSize: maxBufferSize);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -81,6 +81,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.PartialFlushMinSpans == i.PartialFlushMinSpans,
                 (e, i) => e.ValidationWarnings.Count == i.ValidationWarnings.Count,
                 (e, i) => e.SyncExport == i.SyncExport,
+                (e, i) => e.TraceBufferSize == i.TraceBufferSize,
                 (e, i) => e.ProfilerExportFormat == i.ProfilerExportFormat
             };
 

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.SignalFx.Tracing.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.SignalFx.Tracing.PublicApiHasNotChanged.verified.txt
@@ -51,6 +51,7 @@ namespace Datadog.Trace.Configuration
         public bool PartialFlushEnabled { get; set; }
         public int PartialFlushMinSpans { get; set; }
         public bool SyncExport { get; set; }
+        public int TraceBufferSize { get; set; }
         public string TracesPipeName { get; set; }
         public int TracesPipeTimeoutMs { get; set; }
     }
@@ -90,6 +91,7 @@ namespace Datadog.Trace.Configuration
         public bool PartialFlushEnabled { get; }
         public int PartialFlushMinSpans { get; }
         public bool SyncExport { get; }
+        public int TraceBufferSize { get; }
         public string TracesPipeName { get; }
         public int TracesPipeTimeoutMs { get; }
     }


### PR DESCRIPTION
## Why

Add an option to configure size of trace exporter buffer.

## What

- use `SIGNALFX_TRACE_BUFFER_SIZE` env variable for configuring trace exporter buffer size
- minor cleanup
- update doc
- log size of the trace exporter buffer in diagnostic log

## Tests

Included in PR.
