### PR TITLE
[Overhead tests] Increase trace exporter buffer size

### DIFF
--- a/overhead-test/src/Containers/EshopApp.cs
+++ b/overhead-test/src/Containers/EshopApp.cs
@@ -46,6 +46,8 @@ internal class EshopApp : IAsyncDisposable
             .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
             .WithEnvironment("SIGNALFX_ENDPOINT_URL", collector.TraceReceiverUrl)
             .WithEnvironment("SIGNALFX_PROFILER_LOGS_ENDPOINT", collector.LogsReceiverUrl)
+            .WithEnvironment("SIGNALFX_PROFILER_EXCLUDE_PROCESSES", "dotnet-counters")
+            .WithEnvironment("SIGNALFX_TRACE_BUFFER_SIZE", "3000")
             .WithEnvironment("ConnectionStrings__CatalogConnection", sqlServer.CatalogConnection)
             .WithEnvironment("ConnectionStrings__IdentityConnection", sqlServer.IdentityConnection)
             .WithEnvironment("Logging__LogLevel__Microsoft", "Warning")

--- a/overhead-test/src/OverheadTest.cs
+++ b/overhead-test/src/OverheadTest.cs
@@ -68,6 +68,11 @@ public class OverheadTest : IAsyncLifetime
     [Fact]
     public async Task Run()
     {
+        // Test expects eshop-app-dc and eshop-app-dc-instrumented container images to be present.
+        // They should be built based on eshop-app.dockerfile in Docker directory.
+        // When running locally, ensure package.deb is present at the root of the repository,
+        // before attempting to build an instrumented image.
+
         _testOutputHelper.WriteLine($"----------------Starting execution: {(ShouldRunLocally() ? "local" : "remote")}");
         _testOutputHelper.WriteLine($"Directory for iteration results created at: {_iterationResults}");
 


### PR DESCRIPTION
## Why

Avoid trace exporter buffer limit being reached and traces being dropped.

## What

- increase trace exporter buffer size
- don't attach profiler to `dotnet-counters` 
- describe prerequisites for running test

## Tests

n/a
