### PR TITLE
Capture call stacks in allocation samples

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -745,7 +745,7 @@ void CaptureAllocationStack(ThreadSampler* ts, ThreadSamplesBuffer * buffer)
     // Read explanation of volatile clearing in SamplingHelper::Lookup
     ts->helper.volatile_function_name_cache_.Clear();
     HelperAndBuffer hb = HelperAndBuffer(&ts->helper, buffer);
-    HRESULT hr = ts->info10->DoStackSnapshot(NULL, &FrameCallback, COR_PRF_SNAPSHOT_DEFAULT, &hb, nullptr, 0);
+    HRESULT hr = ts->info10->DoStackSnapshot((ThreadID) NULL, &FrameCallback, COR_PRF_SNAPSHOT_DEFAULT, &hb, nullptr, 0);
     if (FAILED(hr))
     {
         trace::Logger::Debug("DoStackSnapshot failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);


### PR DESCRIPTION
Add a lock around usage of the `SamplingHelper` name cache(s).  Clear the volatile cache when capturing an allocation sample call stack.  Share out the code for parsing call stacks in C# to read this new data.  The `FrameCallback` (that can only take one parameter) now takes a new type to distinguish that we want to use the global name cache but an AllocationTick-local buffer to write data into, while the original CPU sampler wants something slightly different.  This (separating name cache from buffer management) will be refactored in a followup PR rather than polluting the locking changes further in this one.
