### PR TITLE
[Overhead tests] update test application

### DIFF
--- a/overhead-test/src/Containers/EshopApp.cs
+++ b/overhead-test/src/Containers/EshopApp.cs
@@ -39,6 +39,9 @@ internal class EshopApp : IAsyncDisposable
         _logStream = File.Create(Path.Combine(namingConvention.ContainerLogs, "eshop-app.txt"));
         _resultStream = File.Create(Path.Combine(namingConvention.AgentResults, CounterResultsFile));
 
+        var instrumentationLogs = Path.Combine(namingConvention.AgentResults, "instrumentation-logs");
+        Directory.CreateDirectory(instrumentationLogs);
+
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
             .WithImage(config.DockerImageName)
             .WithName(ContainerName)
@@ -54,6 +57,7 @@ internal class EshopApp : IAsyncDisposable
             .WithEnvironment("Logging__LogLevel__Default", "Warning")
             .WithEnvironment("Logging__LogLevel__System", "Warning")
             .WithEnvironment("Logging__LogLevel__Microsoft.Hosting.Lifetime", "Information")
+            .WithBindMount(instrumentationLogs, "/var/log/signalfx")
             .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(AppPort))
             .WithOutputConsumer(Consume.RedirectStdoutAndStderrToStream(_logStream, _logStream));
         foreach (var envVar in config.AdditionalEnvVars)

--- a/overhead-test/src/K6/basic.js
+++ b/overhead-test/src/K6/basic.js
@@ -14,11 +14,11 @@ function rand(max) {
 function randomItem(items) {
     const toDuplicate = randItem(items);
     return {
-        // for now, use fixed type/brand, duplicate other values from a random item from the list
-        catalogBrandId: 1,
-        catalogTypeId: 1,
-        description: `duplicate for ${toDuplicate.id}`,
-        name: `duplicated from ${toDuplicate.name}`,
+        catalogBrandId: 2,
+        catalogTypeId: 2,
+        description: `short`,
+        // name is being checked for uniqueness during insertion
+        name: Math.random().toString(16),
         pictureUri: toDuplicate.pictureUri,
         price: toDuplicate.price + 1
     };
@@ -26,7 +26,7 @@ function randomItem(items) {
 
 export default function () {
 
-    const catalogItems = `${baseUri}/catalog/list`;
+    const catalogItems = `${baseUri}/catalog-items`;
     const catalogRetrieval = http.get(catalogItems);
     check(catalogRetrieval, {"retrieve catalog status 200": r => r.status === 200});
 

--- a/overhead-test/src/OverheadTest.cs
+++ b/overhead-test/src/OverheadTest.cs
@@ -86,12 +86,14 @@ public class OverheadTest : IAsyncLifetime
 
             Directory.CreateDirectory(resultsConvention.ContainerLogs);
 
-            _testOutputHelper.WriteLine($"Directory for configuration created at: {resultsConvention.AgentResults}");
+            _testOutputHelper.WriteLine(
+            $"Directory for configuration created at: {resultsConvention.AgentResults}");
 
             await using var sqlServer = CreateSqlServer(resultsConvention);
             await sqlServer.StartAsync();
 
-            await using var eshopApp = new EshopApp(_network, _collector, sqlServer, resultsConvention, agentConfig);
+            await using var eshopApp =
+                new EshopApp(_network, _collector, sqlServer, resultsConvention, agentConfig);
             await eshopApp.StartAsync();
 
             _testOutputHelper.WriteLine("----------------Starting warmup.");
@@ -114,7 +116,7 @@ public class OverheadTest : IAsyncLifetime
 
             // there should be 2 processes running inside the container: the app and dotnet-counters
             Assert.Equal(2, processList.Count);
-            Assert.Contains(processList, s => s.Contains("dotnet Web.dll"));
+            Assert.Contains(processList, s => s.Contains("dotnet PublicApi.dll"));
             Assert.Contains(processList, s => s.Contains("./dotnet-counters"));
 
             _testOutputHelper.WriteLine("----------------Starting driving a load on the app.");


### PR DESCRIPTION
## Why

Update test app to version that targets net6.0

## What

- update `dockerfile` for test app
- adjust test script
- fix cleanup on not-started container
- persist containers instrumentation logs

## Tests

n/a