### PR TITLE
Update dotnet sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   buildConfiguration: Release
-  dotnetSdkVersion: 6.0.301
+  dotnetSdkVersion: 6.0.401
   relativeTracerHome: /shared/bin/monitoring-home/tracer
   relativeArtifacts: /tracer/src/bin/artifacts
   binDir: ${{ github.workspace }}/tracer/src/bin
@@ -76,7 +76,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -131,7 +131,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -177,7 +177,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - run: ./tracer/build.cmd Clean BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v3.1.0
       with:
@@ -202,7 +202,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -248,7 +248,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -273,7 +273,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -322,7 +322,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
     #   if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
@@ -381,7 +381,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -442,7 +442,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
@@ -491,7 +491,7 @@ jobs:
           2.1.818
           3.1.420
           5.0.408
-          6.0.301
+          6.0.401
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     env:
       baseImage: ${{ matrix.baseImage }}
-      dotnetSdkVersion: 6.0.301
+      dotnetSdkVersion: 6.0.401
     steps:
     - uses: actions/checkout@v3.0.2
     - name: Build Docker image
@@ -54,7 +54,7 @@ jobs:
             2.1.818
             3.1.420
             5.0.408
-            6.0.301
+            6.0.401
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Upload Windows MSI

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v2.1.0
         with:
-          dotnet-version: '6.0.301'
+          dotnet-version: '6.0.401'
 
       - name: "Removing existing generated files"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace\Generated" -Recurse -File | Remove-Item

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ linux-build:
     matrix:
       - baseImage: [ alpine, debian ]
   variables:
-    dotnetSdkVersion: 6.0.301
+    dotnetSdkVersion: 6.0.401
   script:
     - |
       rm .dockerignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -487,7 +487,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
     volumes:
@@ -510,7 +510,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -583,7 +583,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -640,7 +640,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,5 +1,5 @@
 ARG DOTNETSDK_VERSION
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.14 as base
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.16 as base
 
 # SECURITY NOTE: Exception is made for APK packages, 
 # no need to lock versions

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="signalfx-dotnet-tracing/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=6.0.301 \
+   --build-arg DOTNETSDK_VERSION=6.0.401 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/centos7.dockerfile" \
    "$BUILD_DIR"

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
@@ -528,7 +528,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
-                return EndMethodHandler<TIntegration, TTarget>.Invoke(instance, exception, in state);
+                EndMethodHandler<TIntegration, TTarget>.Invoke(instance, exception, in state);
             }
 
             return CallTargetReturn.GetDefault();
@@ -551,7 +551,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
-                return EndMethodHandler<TIntegration, TTarget, TReturn>.Invoke(instance, returnValue, exception, in state);
+                var result = EndMethodHandler<TIntegration, TTarget, TReturn>.Invoke(instance, returnValue, exception, in state);
+                return new CallTargetReturn<TReturn>(result.GetReturnValue());
             }
 
             return new CallTargetReturn<TReturn>(returnValue);

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.TestHelpers
                                                                     "testhost",
                                                                     "testhost.x86",
                                                                     "testhost.net461.x86",
+                                                                    "testhost.net461",
                                                                     "vstest.console",
                                                                     "xunit.console.x86",
                                                                     "xunit.console.x64",


### PR DESCRIPTION
## Why

Use up-to-date version of dotnet-sdk.

## What

- update dotnet-sdk version used
- bring related fixes from upstream

## Tests

n/a
