### PR TITLE
Refactor several names/types for allocation sampling

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -30,7 +30,7 @@ class DebuggerMethodRewriter;
 
 namespace always_on_profiler
 {
-class ThreadSampler;
+class AlwaysOnProfiler;
 }
 
 namespace trace
@@ -57,7 +57,7 @@ private:
     std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
     bool is_desktop_iis = false;
 
-    always_on_profiler::ThreadSampler* threadSampler;
+    always_on_profiler::AlwaysOnProfiler* alwaysOnProfiler;
 
     //
     // CallTarget Members
@@ -171,7 +171,7 @@ public:
     //
     void InitializeProfiler(WCHAR* id, CallTargetDefinition* items, int size);
 
-    // ICorProfilerInfo callbacks to track thread naming (used by ThreadSampler only)
+    // ICorProfilerInfo callbacks to track thread naming (used by AlwaysOnProfiler only)
     HRESULT STDMETHODCALLTYPE ThreadCreated(ThreadID threadId)override;
     HRESULT STDMETHODCALLTYPE ThreadDestroyed(ThreadID threadId)override;
     HRESULT STDMETHODCALLTYPE ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId) override;

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
@@ -9,9 +9,9 @@
 
 using namespace always_on_profiler;
 
-TEST(ThreadSamplerTest, ThreadStateTracking)
+TEST(AlwaysOnProfilerTest, ThreadStateTracking)
 {
-    ThreadSampler ts; // Do NOT call StartSampling on this, which will create a background thread, etc.
+    AlwaysOnProfiler ts; // Do NOT call StartSampling on this, which will create a background thread, etc.
     ts.ThreadAssignedToOsThread(1, 1001);
     ts.ThreadNameChanged(1, 6, const_cast<WCHAR*>(L"Sample"));
     ts.ThreadCreated(1);
@@ -27,7 +27,7 @@ TEST(ThreadSamplerTest, ThreadStateTracking)
     EXPECT_EQ(0, ts.managed_tid_to_state_.size());
 }
 
-TEST(ThreadSamplerTest, BasicBufferBehavior)
+TEST(AlwaysOnProfilerTest, BasicBufferBehavior)
 {
     auto buf = std::vector<unsigned char>();
     shared::WSTRING longThreadName;
@@ -52,7 +52,7 @@ TEST(ThreadSamplerTest, BasicBufferBehavior)
     ASSERT_EQ(1290, tsb.buffer_->size()); // not manually calculated but does depend on thread name limiting and not repeating frame strings
     ASSERT_EQ(2, tsb.codes_.size());
 }
-TEST(ThreadSamplerTest, AllocationSampleBuffer)
+TEST(AlwaysOnProfilerTest, AllocationSampleBuffer)
 {
     auto buf = std::vector<unsigned char>();
     shared::WSTRING longThreadName;
@@ -74,7 +74,7 @@ TEST(ThreadSamplerTest, AllocationSampleBuffer)
     ASSERT_EQ(1109, tsb.buffer_->size()); // not manually calculated
 }
 
-TEST(ThreadSamplerTest, BufferOverrunBehavior)
+TEST(AlwaysOnProfilerTest, BufferOverrunBehavior)
 {
     auto buf = std::vector<unsigned char>();
     shared::WSTRING long_thread_name;
@@ -106,7 +106,7 @@ TEST(ThreadSamplerTest, BufferOverrunBehavior)
     ASSERT_TRUE(buf.size() < 210000 && buf.size() >= 200000);
 }
 
-TEST(ThreadSamplerTest, StaticBufferManagement)
+TEST(AlwaysOnProfilerTest, StaticBufferManagement)
 {
     const auto buf_a = new std::vector<unsigned char>();
     buf_a->resize(1);
@@ -150,7 +150,7 @@ TEST(ThreadSamplerTest, StaticBufferManagement)
     ASSERT_EQ('E', read_buf[0]);
 }
 
-TEST(ThreadSamplerTest, AllocationBufferBehavior)
+TEST(AlwaysOnProfilerTest, AllocationBufferBehavior)
 {
     unsigned char read_buf[4];
     unsigned char write_buf[] = {5, 6, 7, 8};
@@ -170,7 +170,7 @@ TEST(ThreadSamplerTest, AllocationBufferBehavior)
 }
 
 
-TEST(ThreadSamplerTest, LRUCache)
+TEST(AlwaysOnProfilerTest, LRUCache)
 {
     constexpr int max = 10000;
     NameCache<FunctionID, std::pair<shared::WSTRING*, FunctionIdentifier>> cache(max, std::pair<shared::WSTRING*, FunctionIdentifier>(nullptr, {}));


### PR DESCRIPTION
- Move logic for managing cpu buffers to `ThreadSampler` rather than `SamplingHelper` which should just be responsible for the name caches
- Rename `SamplingHelper` to `NamingHelper` accordingly
- Rename `ThreadSampler` to `AlwaysOnProfiler` as it now encapsulates both cpu- and memory-profiling functionality; change variable names from `ts` to `prof`.
- Rename `cur_writer_` as `cur_cpu_writer_` to distinguish its purpose, and refactor away its associated buffer field
- Rename `HelperAndBuffer` to `DoStackSnapshotParams` and document why it exists
- Rename `ThreadSamplerTest` to `AlwaysOnProfilerTest`