### PR TITLE
Tweak allocations buffer to be more atomic

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -106,12 +106,11 @@ void AllocationSamplingAppendToBuffer(int32_t appendLen, unsigned char* appendBu
     }
     std::lock_guard<std::mutex> guard(allocation_buffer_lock);
 
-    if (allocation_buffer->size() >= kSamplesBufferMaximumSize)
+    if (allocation_buffer->size() + appendLen >= kSamplesBufferMaximumSize)
     {
         return;
     }
-    size_t actualLen = std::min((size_t) appendLen, kSamplesBufferMaximumSize - allocation_buffer->size());
-    allocation_buffer->insert(allocation_buffer->end(), appendBuf, &appendBuf[actualLen]);
+    allocation_buffer->insert(allocation_buffer->end(), appendBuf, &appendBuf[appendLen]);
 }
 
 // Can return 0


### PR DESCRIPTION
Check available space before accepting an allocation sample into the appropriate buffer, rather than relying on the underlying code to bail out partway through.  Add unit test for same.