### PR TITLE
Bump .NET to 6.0.401

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   buildConfiguration: Release
-  dotnetSdkVersion: 6.0.301
+  dotnetSdkVersion: 6.0.401
   relativeTracerHome: /shared/bin/monitoring-home/tracer
   relativeArtifacts: /tracer/src/bin/artifacts
   binDir: ${{ github.workspace }}/tracer/src/bin
@@ -74,9 +74,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -129,9 +129,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -175,9 +175,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - run: ./tracer/build.cmd Clean BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v3.1.0
       with:
@@ -200,9 +200,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -246,9 +246,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -271,9 +271,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -320,9 +320,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
     #   if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
@@ -379,9 +379,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: Build Docker image
       run: |
         docker build \
@@ -440,9 +440,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
@@ -489,9 +489,9 @@ jobs:
       with:
         dotnet-version: |
           2.1.818
-          3.1.420
+          3.1.423
           5.0.408
-          6.0.301
+          6.0.401
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     env:
       baseImage: ${{ matrix.baseImage }}
-      dotnetSdkVersion: 6.0.301
+      dotnetSdkVersion: 6.0.401
     steps:
     - uses: actions/checkout@v3.0.2
     - name: Build Docker image
@@ -52,9 +52,9 @@ jobs:
         with:
           dotnet-version: | 
             2.1.818
-            3.1.420
+            3.1.423
             5.0.408
-            6.0.301
+            6.0.401
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Upload Windows MSI

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v2.1.0
         with:
-          dotnet-version: '6.0.301'
+          dotnet-version: '6.0.401'
 
       - name: "Removing existing generated files"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace\Generated" -Recurse -File | Remove-Item

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ linux-build:
     matrix:
       - baseImage: [ alpine, debian ]
   variables:
-    dotnetSdkVersion: 6.0.301
+    dotnetSdkVersion: 6.0.401
   script:
     - |
       rm .dockerignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -487,7 +487,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
     volumes:
@@ -510,7 +510,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -583,7 +583,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -640,7 +640,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.301}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/shared/src/native-lib/coreclr/src/inc/corhlpr.cpp
+++ b/shared/src/native-lib/coreclr/src/inc/corhlpr.cpp
@@ -26,15 +26,15 @@
 extern "C" {
 
 /***************************************************************************/
-/* Note that this construtor does not set the LocalSig, but has the
-   advantage that it does not have any dependancy on EE structures.
+/* Note that this constructor does not set the LocalSig, but has the
+   advantage that it does not have any dependency on EE structures.
    inside the EE use the FunctionDesc constructor */
 
 void __stdcall DecoderInit(void *pThis, COR_ILMETHOD *header)
 {
+    memset(pThis, 0, sizeof(COR_ILMETHOD_DECODER));
     COR_ILMETHOD_DECODER *decoder = (COR_ILMETHOD_DECODER *)pThis;
 
-    memset(decoder, 0, sizeof(COR_ILMETHOD_DECODER));
     if (header->Tiny.IsTiny())
     {
         decoder->SetMaxStack(header->Tiny.GetMaxStack());
@@ -48,7 +48,7 @@ void __stdcall DecoderInit(void *pThis, COR_ILMETHOD *header)
 #ifdef HOST_64BIT
         if((((size_t) header) & 3) == 0)        // header is aligned
 #else
-        _ASSERTE((((size_t) header) & 3) == 0);        // header is aligned
+        assert((((size_t) header) & 3) == 0);        // header is aligned
 #endif
         {
             *((COR_ILMETHOD_FAT *)decoder) = header->Fat;
@@ -129,18 +129,20 @@ unsigned __stdcall IlmethodEmit(unsigned size, COR_ILMETHOD_FAT* header,
     }
     else {
             // Fat format
-        _ASSERTE((((size_t) outBuff) & 3) == 0);               // header is dword aligned
+        assert((((size_t) outBuff) & 3) == 0);               // header is dword aligned
         COR_ILMETHOD_FAT* fatHeader = (COR_ILMETHOD_FAT*) outBuff;
         outBuff += sizeof(COR_ILMETHOD_FAT);
         *fatHeader = *header;
         fatHeader->SetFlags(fatHeader->GetFlags() | CorILMethod_FatFormat);
-        _ASSERTE((fatHeader->GetFlags() & CorILMethod_FormatMask) == CorILMethod_FatFormat);
+        assert((fatHeader->GetFlags() & CorILMethod_FormatMask) == CorILMethod_FatFormat);
         if (moreSections)
             fatHeader->SetFlags(fatHeader->GetFlags() | CorILMethod_MoreSects);
         fatHeader->SetSize(sizeof(COR_ILMETHOD_FAT) / 4);
     }
 #ifndef SOS_INCLUDE
-    _ASSERTE(&origBuff[size] == outBuff);
+#ifdef _DEBUG
+    assert(&origBuff[size] == outBuff);
+#endif
 #endif // !SOS_INCLUDE
     return(size);
 }
@@ -211,7 +213,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
     if (size == 0)
        return(0);
 
-    _ASSERTE((((size_t) outBuff) & 3) == 0);               // header is dword aligned
+    assert((((size_t) outBuff) & 3) == 0);               // header is dword aligned
     BYTE* origBuff = outBuff;
     if (ehCount <= 0)
         return 0;
@@ -234,11 +236,11 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
                     fatClause->GetHandlerLength() > 0xFF) {
                 break;  // fall through and generate as FAT
             }
-            _ASSERTE((fatClause->GetFlags() & ~0xFFFF) == 0);
-            _ASSERTE((fatClause->GetTryOffset() & ~0xFFFF) == 0);
-            _ASSERTE((fatClause->GetTryLength() & ~0xFF) == 0);
-            _ASSERTE((fatClause->GetHandlerOffset() & ~0xFFFF) == 0);
-            _ASSERTE((fatClause->GetHandlerLength() & ~0xFF) == 0);
+            assert((fatClause->GetFlags() & ~0xFFFF) == 0);
+            assert((fatClause->GetTryOffset() & ~0xFFFF) == 0);
+            assert((fatClause->GetTryLength() & ~0xFF) == 0);
+            assert((fatClause->GetHandlerOffset() & ~0xFFFF) == 0);
+            assert((fatClause->GetHandlerLength() & ~0xFF) == 0);
 
             COR_ILMETHOD_SECT_EH_CLAUSE_SMALL* smallClause = (COR_ILMETHOD_SECT_EH_CLAUSE_SMALL*)&EHSect->Clauses[i];
             smallClause->SetFlags((CorExceptionFlag) fatClause->GetFlags());
@@ -253,13 +255,9 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
             EHSect->Kind = CorILMethod_Sect_EHTable;
             if (moreSections)
                 EHSect->Kind |= CorILMethod_Sect_MoreSects;
-#ifndef SOS_INCLUDE
-            EHSect->DataSize = EHSect->Size(ehCount);
-#else
             EHSect->DataSize = (BYTE) EHSect->Size(ehCount);
-#endif // !SOS_INCLUDE
             EHSect->Reserved = 0;
-            _ASSERTE(EHSect->DataSize == EHSect->Size(ehCount)); // make sure didn't overflow
+            assert(EHSect->DataSize == EHSect->Size(ehCount)); // make sure didn't overflow
             outBuff = (BYTE*) &EHSect->Clauses[ehCount];
             // Set the offsets for the exception type tokens.
             if (ehTypeOffsets)
@@ -268,7 +266,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
                     COR_ILMETHOD_SECT_EH_CLAUSE_SMALL* smallClause = (COR_ILMETHOD_SECT_EH_CLAUSE_SMALL*)&EHSect->Clauses[i];
                     if (smallClause->GetFlags() == COR_ILEXCEPTION_CLAUSE_NONE)
                     {
-                        _ASSERTE(! IsNilToken(smallClause->GetClassToken()));
+                        assert(! IsNilToken(smallClause->GetClassToken()));
                         ehTypeOffsets[i] = (ULONG)((BYTE *)&smallClause->ClassToken - origBuff);
                     }
                 }
@@ -285,7 +283,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
     EHSect->SetDataSize(EHSect->Size(ehCount));
     memcpy(EHSect->Clauses, clauses, ehCount * sizeof(COR_ILMETHOD_SECT_EH_CLAUSE_FAT));
     outBuff = (BYTE*) &EHSect->Clauses[ehCount];
-    _ASSERTE(&origBuff[size] == outBuff);
+    assert(&origBuff[size] == outBuff);
     // Set the offsets for the exception type tokens.
     if (ehTypeOffsets)
     {
@@ -293,7 +291,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
             COR_ILMETHOD_SECT_EH_CLAUSE_FAT* fatClause = (COR_ILMETHOD_SECT_EH_CLAUSE_FAT*)&EHSect->Clauses[i];
             if (fatClause->GetFlags() == COR_ILEXCEPTION_CLAUSE_NONE)
             {
-                _ASSERTE(! IsNilToken(fatClause->GetClassToken()));
+                assert(! IsNilToken(fatClause->GetClassToken()));
                 ehTypeOffsets[i] = (ULONG)((BYTE *)&fatClause->ClassToken - origBuff);
             }
         }

--- a/shared/src/native-lib/coreclr/src/inc/corhlpr.h
+++ b/shared/src/native-lib/coreclr/src/inc/corhlpr.h
@@ -17,6 +17,7 @@
 #define CORHLPR_TURNED_FPO_ON 1
 #endif
 
+#include <assert.h>
 #include "cor.h"
 #include "corhdr.h"
 #include "corerror.h"
@@ -82,19 +83,10 @@ do { hr = (EXPR); if(FAILED(hr)) { goto LABEL; } } while (0)
 #endif
 
 
-#ifndef _ASSERTE
-#define _ASSERTE(expr)
-#endif
-
-#ifndef COUNTOF
-#define COUNTOF(a) (sizeof(a) / sizeof(*a))
-#endif
-
 #if !BIGENDIAN
 #define VAL16(x) x
 #define VAL32(x) x
 #endif
-
 
 //*****************************************************************************
 //
@@ -264,7 +256,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return VAL16(TryOffset);
     }
     void SetTryOffset(DWORD Offset) {
-        _ASSERTE((Offset & ~0xffff) == 0);
+        assert((Offset & ~0xffff) == 0);
         TryOffset = VAL16(Offset);
     }
 
@@ -272,7 +264,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return TryLength;
     }
     void SetTryLength(DWORD Length) {
-        _ASSERTE((Length & ~0xff) == 0);
+        assert((Length & ~0xff) == 0);
         TryLength = Length;
     }
 
@@ -280,7 +272,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return VAL16(HandlerOffset);
     }
     void SetHandlerOffset(DWORD Offset) {
-        _ASSERTE((Offset & ~0xffff) == 0);
+        assert((Offset & ~0xffff) == 0);
         HandlerOffset = VAL16(Offset);
     }
 
@@ -288,7 +280,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return HandlerLength;
     }
     void SetHandlerLength(DWORD Length) {
-        _ASSERTE((Length & ~0xff) == 0);
+        assert((Length & ~0xff) == 0);
         HandlerLength = Length;
     }
 
@@ -336,7 +328,7 @@ struct COR_ILMETHOD_SECT
     const COR_ILMETHOD_SECT* Next() const
     {
         if (!More()) return(0);
-        return ((COR_ILMETHOD_SECT*)(((BYTE *)this) + DataSize()))->Align();
+        return ((COR_ILMETHOD_SECT*)Align(((BYTE *)this) + DataSize()));
     }
 
     const BYTE* Data() const
@@ -374,9 +366,9 @@ struct COR_ILMETHOD_SECT
         return((AsSmall()->Kind & CorILMethod_Sect_FatFormat) != 0);
     }
 
-    const COR_ILMETHOD_SECT* Align() const
+    static const void* Align(const void* p)
     {
-        return((COR_ILMETHOD_SECT*) ((((UINT_PTR) this) + 3) & ~3));
+        return((void*) ((((UINT_PTR) p) + 3) & ~3));
     }
 
 protected:
@@ -506,7 +498,7 @@ typedef struct tagCOR_ILMETHOD_TINY : IMAGE_COR_ILMETHOD_TINY
 
 
 /************************************/
-// This strucuture is the 'fat' layout, where no compression is attempted.
+// This structure is the 'fat' layout, where no compression is attempted.
 // Note that this structure can be added on at the end, thus making it extensible
 typedef struct tagCOR_ILMETHOD_FAT : IMAGE_COR_ILMETHOD_FAT
 {
@@ -579,7 +571,7 @@ typedef struct tagCOR_ILMETHOD_FAT : IMAGE_COR_ILMETHOD_FAT
 
     const COR_ILMETHOD_SECT* GetSect() const {
         if (!More()) return (0);
-        return(((COR_ILMETHOD_SECT*) (GetCode() + GetCodeSize()))->Align());
+        return(((COR_ILMETHOD_SECT*) COR_ILMETHOD_SECT::Align(GetCode() + GetCodeSize())));
     }
 } COR_ILMETHOD_FAT;
 
@@ -624,7 +616,7 @@ struct COR_ILMETHOD
 extern "C" {
 /***************************************************************************/
 /* COR_ILMETHOD_DECODER is the only way functions internal to the EE should
-   fetch data from a COR_ILMETHOD.  This way any dependancy on the file format
+   fetch data from a COR_ILMETHOD.  This way any dependency on the file format
    (and the multiple ways of encoding the header) is centralized to the
    COR_ILMETHOD_DECODER constructor) */
     void __stdcall DecoderInit(void * pThis, COR_ILMETHOD* header);

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,5 +1,5 @@
 ARG DOTNETSDK_VERSION
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.14 as base
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.16 as base
 
 # SECURITY NOTE: Exception is made for APK packages, 
 # no need to lock versions

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="signalfx-dotnet-tracing/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=6.0.301 \
+   --build-arg DOTNETSDK_VERSION=6.0.401 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/centos7.dockerfile" \
    "$BUILD_DIR"

--- a/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.TestHelpers
                                                                     "testhost",
                                                                     "testhost.x86",
                                                                     "testhost.net461.x86",
+                                                                    "testhost.net461",
                                                                     "vstest.console",
                                                                     "xunit.console.x86",
                                                                     "xunit.console.x64",


### PR DESCRIPTION
## Why

Keep in sync with .NET releases

## What

Bump .NET to 6.0.401 and 3.1.423.

## Tests

CI
