### PR TITLE
Hook up allocation subsampling to the ticks

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -23,6 +23,8 @@ constexpr auto kSamplesBufferDefaultSize = 20 * 1024;
 constexpr auto kDefaultSamplePeriod = 10000;
 constexpr auto kMinimumSamplePeriod = 1000;
 
+constexpr auto kDefaultMaxAllocsPerMinute = 200;
+
 // FIXME make configurable (hidden)?
 // These numbers were chosen to keep total overhead under 1 MB of RAM in typical cases (name lengths being the biggest
 // variable)
@@ -591,12 +593,12 @@ void CaptureSamples(AlwaysOnProfiler* prof, ICorProfilerInfo10* info10)
     prof->cur_cpu_writer_->EndBatch();
 }
 
-int GetSamplingPeriod()
+int GetConfiguredInt(const shared::WSTRING key, const int minimumValue, const int defaultValue)
 {
-    const shared::WSTRING val = shared::GetEnvironmentValue(trace::environment::thread_sampling_period);
+    const shared::WSTRING val = shared::GetEnvironmentValue(key);
     if (val.empty())
     {
-        return kDefaultSamplePeriod;
+        return defaultValue;
     }
     try
     {
@@ -607,12 +609,21 @@ int GetSamplingPeriod()
         std::string str = convert.to_bytes(val);
         int parsedValue = std::stoi(str);
 #endif
-        return (int) std::max(kMinimumSamplePeriod, parsedValue);
+        return (int) std::max(minimumValue, parsedValue);
     }
     catch (...)
     {
-        return kDefaultSamplePeriod;
+        return defaultValue;
     }
+}
+
+int GetSamplingPeriod()
+{
+    return GetConfiguredInt(trace::environment::thread_sampling_period, kMinimumSamplePeriod, kDefaultSamplePeriod);
+}
+int GetMaxAllocationsPerMinute()
+{
+    return GetConfiguredInt(trace::environment::max_allocation_samples_per_minute, 1, kDefaultMaxAllocsPerMinute);
 }
 
 void PauseClrAndCaptureSamples(AlwaysOnProfiler* prof, ICorProfilerInfo10* info10)
@@ -804,6 +815,11 @@ bool AllocationSubSampler::ShouldSample()
 
 void AlwaysOnProfiler::AllocationTick(ULONG dataLen, LPCBYTE data)
 {
+    if (this->allocationSubSampler == nullptr || !this->allocationSubSampler->ShouldSample())
+    {
+        return;
+    }
+
     // In v4 it's the last field, so use a relative offset from the end
     uint64_t allocatedSize = *((uint64_t*) &(data[dataLen - 8]));
     // Here's the first byte of the typeName
@@ -843,6 +859,8 @@ void AlwaysOnProfiler::AllocationTick(ULONG dataLen, LPCBYTE data)
 
 void AlwaysOnProfiler::StartAllocationSampling(ICorProfilerInfo12* info12)
 {
+    this->allocationSubSampler = new AllocationSubSampler(GetMaxAllocationsPerMinute(), 60);
+
     EVENTPIPE_SESSION session;
     COR_PRF_EVENTPIPE_PROVIDER_CONFIG sessionConfig[] = {{WStr("Microsoft-Windows-DotNETRuntime"),
                                                           0x1, // CLR_GC_KEYWORD

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.h
@@ -217,6 +217,7 @@ public:
     std::unordered_map<ThreadID, ThreadState*> managed_tid_to_state_;
     std::mutex thread_state_lock_;
     NamingHelper helper;
+    AllocationSubSampler* allocationSubSampler = nullptr;
 
     // These cycle every sample and/or are owned externally
     ThreadSamplesBuffer* cur_cpu_writer_ = nullptr;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -115,6 +115,7 @@ namespace environment {
     const shared::WSTRING allocation_sampling_enabled = WStr("SIGNALFX_PROFILER_MEMORY_ENABLED");
 
     const shared::WSTRING thread_sampling_period = WStr("SIGNALFX_PROFILER_CALL_STACK_INTERVAL");
+    const shared::WSTRING max_allocation_samples_per_minute = WStr("SIGNALFX_PROFILER_MAX_MEMORY_SAMPLES_PER_MINUTE");
 } // namespace environment
 } // namespace trace
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/always_on_profiler_test.cpp
@@ -271,6 +271,13 @@ TEST(AlwaysOnProfilerTest, AllocationSubSampler)
     ASSERT_TRUE(timedSamp.ShouldSample());
     ASSERT_FALSE(timedSamp.ShouldSample());
     ASSERT_FALSE(timedSamp.ShouldSample());
-    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    // advance cycle
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    timedSamp.ShouldSample(); // 50/50 chance on this, no assert
+    // advance cycle again - with lastCycle == 1, the next should be guaranteed reset of state
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
     ASSERT_TRUE(timedSamp.ShouldSample());
+    ASSERT_TRUE(timedSamp.ShouldSample());
+    ASSERT_FALSE(timedSamp.ShouldSample());
+    ASSERT_FALSE(timedSamp.ShouldSample());
 }


### PR DESCRIPTION
I chose an arbitrary default of (max) 200 allocation samples per minute.  Open to arguments over that or we can merge this and change later after more discussion.