### PR TITLE
[AlwaysOnProfiler] Export allocation samples

### DIFF
--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/AllocationSample.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/AllocationSample.cs
@@ -1,4 +1,4 @@
-﻿namespace Datadog.Trace.AlwaysOnProfiler;
+namespace Datadog.Trace.AlwaysOnProfiler;
 
 internal class AllocationSample
 {

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/Pprof.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/Pprof.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using Datadog.Trace.AlwaysOnProfiler.Builder;
 using Datadog.Tracer.Pprof.Proto.Profile;
 
 namespace Datadog.Trace.AlwaysOnProfiler

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/SampleBuilder.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/SampleBuilder.cs
@@ -4,16 +4,23 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Tracer.Pprof.Proto.Profile;
 
-namespace Datadog.Trace.AlwaysOnProfiler.Builder
+namespace Datadog.Trace.AlwaysOnProfiler
 {
     internal class SampleBuilder
     {
         private readonly Sample _sample = new();
         private readonly IList<ulong> _locationIds = new List<ulong>();
+        private readonly IList<long> _values = new List<long>();
 
         public SampleBuilder AddLabel(Label label)
         {
             _sample.Labels.Add(label);
+            return this;
+        }
+
+        public SampleBuilder AddValue(long val)
+        {
+            _values.Add(val);
             return this;
         }
 
@@ -26,6 +33,7 @@ namespace Datadog.Trace.AlwaysOnProfiler.Builder
         public Sample Build()
         {
             _sample.LocationIds = _locationIds.ToArray();
+            _sample.Values = _values.ToArray();
 
             return _sample;
         }

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
@@ -1,6 +1,7 @@
 // Modified by Splunk Inc.
 
 using System;
+using System.IO;
 using System.Threading;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PlainTextThreadSampleExporterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PlainTextThreadSampleExporterTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Datadog.Trace.AlwaysOnProfiler;
 using Datadog.Trace.Configuration;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace Datadog.Trace.Tests.AlwaysOnProfiler;
@@ -100,11 +101,86 @@ public class PlainTextThreadSampleExporterTests
         format.Value.StringValue.Should().Be("text");
     }
 
+    [Fact]
+    public void Required_attributes_are_set_for_exported_allocation_sample()
+    {
+        var settings = DefaultSettings();
+        var testSender = new TestSender();
+        var exporter = new PlainTextThreadSampleExporter(settings, testSender);
+
+        var allocationSample = new AllocationSample(
+            1000,
+            "System.String",
+            new ThreadSample
+            {
+                Timestamp = new ThreadSample.Time(10000)
+            });
+
+        exporter.ExportAllocationSamples(new List<AllocationSample> { allocationSample });
+
+        var sentLog = testSender.SentLogs[0];
+
+        using (new AssertionScope())
+        {
+            // https://github.com/signalfx/gdi-specification/blob/bd5c6f56f26b535c6fa922d2d9b5d00a7b7b5afd/specification/semantic_conventions.md#logrecord-message-common-attributes
+            // These attributes are common for cpu and allocation samples
+            var sourceType = sentLog.Attributes.Single(kv => kv.Key == "com.splunk.sourcetype");
+            sourceType.Value.StringValue.Should().Be("otel.profiling");
+
+            var dataType = sentLog.Attributes.Single(kv => kv.Key == "profiling.data.type");
+            dataType.Value.StringValue.Should().Be("allocation");
+
+            var dataFormat = sentLog.Attributes.Single(kv => kv.Key == "profiling.data.format");
+            dataFormat.Value.StringValue.Should().Be("text");
+
+            // https://github.com/signalfx/gdi-specification/blob/bd5c6f56f26b535c6fa922d2d9b5d00a7b7b5afd/specification/semantic_conventions.md#logrecord-message-text-data-format-specific-attributes
+            // This is specific to allocation sample
+            var memoryAllocated = sentLog.Attributes.Single(kv => kv.Key == "memory.allocated");
+            memoryAllocated.Value.IntValue.Should().Be(1000);
+        }
+    }
+
+    [Fact]
+    public void Context_is_set_for_exported_allocation_sample()
+    {
+        var settings = DefaultSettings();
+        var testSender = new TestSender();
+        var exporter = new PlainTextThreadSampleExporter(settings, testSender);
+
+        var allocationSample = new AllocationSample(
+            1000,
+            "System.String",
+            new ThreadSample
+            {
+                Timestamp = new ThreadSample.Time(1_000),
+                SpanId = 1234567890,
+                TraceIdLow = 1234567890,
+                TraceIdHigh = 0987654321
+            });
+
+        exporter.ExportAllocationSamples(new List<AllocationSample> { allocationSample });
+
+        var sentLog = testSender.SentLogs[0];
+
+        var expectedSpanBytes = new byte[8] { 0, 0, 0, 0, 73, 150, 2, 210 };
+
+        // 987654321 in big-endian order concatenated with 1234567890 in big-endian order
+        var expectedTraceBytes = new byte[16] { 0, 0, 0, 0, 58, 222, 104, 177, 0, 0, 0, 0, 73, 150, 2, 210 };
+
+        using (new AssertionScope())
+        {
+            sentLog.SpanId.Should().Equal(expectedSpanBytes);
+            sentLog.TraceId.Should().Equal(expectedTraceBytes);
+
+            sentLog.TimeUnixNano.Should().Be(1_000_000_000);
+        }
+    }
+
     private static ImmutableTracerSettings DefaultSettings(long samplingPeriodMs = 10000)
     {
         return new ImmutableTracerSettings(new TracerSettings
         {
-            ExporterSettings = new ExporterSettings()
+            ExporterSettings = new ExporterSettings
             {
                 ProfilerExportFormat = ProfilerExportFormat.Text
             },

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/PprofTests.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using Datadog.Trace.AlwaysOnProfiler;
-using Datadog.Trace.AlwaysOnProfiler.Builder;
 using FluentAssertions;
 using Xunit;
 

--- a/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/SampleBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AlwaysOnProfiler/SampleBuilderTests.cs
@@ -1,11 +1,11 @@
 // Modified by Splunk Inc.
 
-using Datadog.Trace.AlwaysOnProfiler.Builder;
+using Datadog.Trace.AlwaysOnProfiler;
 using Datadog.Tracer.Pprof.Proto.Profile;
 using FluentAssertions;
 using Xunit;
 
-namespace Datadog.Trace.Tests.AlwaysOnProfiler.Builder
+namespace Datadog.Trace.Tests.AlwaysOnProfiler
 {
     public class SampleBuilderTests
     {


### PR DESCRIPTION
## Why

Export captured allocation samples.

## What

Build `LogRecord`s as required by [spec](https://github.com/signalfx/gdi-specification/blob/main/specification/semantic_conventions.md).

## Tests

Included in PR.
