### PR TITLE
[AlwaysOnProfiler] handle memory profiling configuration on managed side

### DIFF
--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -23,6 +23,7 @@ These settings should be never used by the users.
 | `SIGNALFX_LOGS_DIRECT_SUBMISSION_MAX_QUEUE_SIZE` | Configuration key for the maximum number of logs to hold in internal queue at any one time | `100000` |
 | `SIGNALFX_LOGS_DIRECT_SUBMISSION_BATCH_PERIOD_SECONDS` | Configuration key for the time in seconds to wait between checking for batches | `2` |
 | `SIGNALFX_PROFILER_EXPORT_FORMAT` | Format in which data will be exported. Available values are: `Pprof` for pprof-gzip-base64 format, and `Text` for plain text stack trace. | `PProf` |
+| `SIGNALFX_PROFILER_MEMORY_ENABLED` | Enable to activate memory profiling. | `false` |
 
 ## Unsupported upstream settings
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/INativeBufferExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/INativeBufferExporter.cs
@@ -1,0 +1,6 @@
+﻿namespace Datadog.Trace.AlwaysOnProfiler;
+
+internal interface INativeBufferExporter
+{
+    void Export(byte[] buffer);
+}

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/NativeBufferExporters/AllocationNativeBufferExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/NativeBufferExporters/AllocationNativeBufferExporter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Datadog.Trace.ClrProfiler;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.AlwaysOnProfiler.NativeBufferExporters;
+
+internal class AllocationNativeBufferExporter : INativeBufferExporter
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AllocationNativeBufferExporter));
+    private readonly ThreadSampleExporter _exporter;
+
+    public AllocationNativeBufferExporter(ThreadSampleExporter exporter)
+    {
+        _exporter = exporter ?? throw new ArgumentNullException(nameof(exporter));
+    }
+
+    /// <summary>
+    /// Exports allocation samples captured on the native side using provided buffer.
+    /// </summary>
+    /// <param name="buffer">the buffer to read captured allocation samples into</param>
+    public void Export(byte[] buffer)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        try
+        {
+            // Managed-side calls to this method dictate buffer changeover, no catch up call needed
+            var read = NativeMethods.SignalFxReadAllocationSamples(buffer.Length, buffer);
+            if (read <= 0)
+            {
+                // No data just return.
+                return;
+            }
+
+            var allocationSamples = SampleNativeFormatParser.ParseAllocationSamples(buffer, read);
+            _exporter.ExportAllocationSamples(allocationSamples);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error processing allocation samples batch.");
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/NativeBufferExporters/CpuNativeBufferExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/NativeBufferExporters/CpuNativeBufferExporter.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Datadog.Trace.ClrProfiler;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.AlwaysOnProfiler.NativeBufferExporters;
+
+internal class CpuNativeBufferExporter : INativeBufferExporter
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(CpuNativeBufferExporter));
+    private readonly ThreadSampleExporter _exporter;
+
+    public CpuNativeBufferExporter(ThreadSampleExporter exporter)
+    {
+        _exporter = exporter ?? throw new ArgumentNullException(nameof(exporter));
+    }
+
+    /// <summary>
+    /// Exports cpu samples captured on the native side using provided buffer.
+    /// </summary>
+    /// <param name="buffer">the buffer to read captured cpu samples into</param>
+    public void Export(byte[] buffer)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        try
+        {
+            // Call twice in quick succession to catch up any blips; the second will likely return 0 (no buffer)
+            ReadAndExportThreadSampleBatch(buffer);
+            ReadAndExportThreadSampleBatch(buffer);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error processing cpu samples batch.");
+        }
+    }
+
+    private void ReadAndExportThreadSampleBatch(byte[] buffer)
+    {
+        var read = NativeMethods.SignalFxReadThreadSamples(buffer.Length, buffer);
+        if (read <= 0)
+        {
+            // No data just return.
+            return;
+        }
+
+        var threadSamples = SampleNativeFormatParser.ParseThreadSamples(buffer, read);
+        _exporter.ExportThreadSamples(threadSamples);
+    }
+}

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/NativeBufferExporters/SequentialNativeBufferExporter.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/NativeBufferExporters/SequentialNativeBufferExporter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Datadog.Trace.AlwaysOnProfiler.NativeBufferExporters;
+
+internal class SequentialNativeBufferExporter : INativeBufferExporter
+{
+    private readonly INativeBufferExporter _cpuNativeBufferExporter;
+    private readonly INativeBufferExporter _allocationNativeBufferExporter;
+
+    public SequentialNativeBufferExporter(INativeBufferExporter cpuNativeBufferExporter, INativeBufferExporter allocationNativeBufferExporter)
+    {
+        _cpuNativeBufferExporter = cpuNativeBufferExporter ?? throw new ArgumentNullException(nameof(cpuNativeBufferExporter));
+        _allocationNativeBufferExporter = allocationNativeBufferExporter ?? throw new ArgumentNullException(nameof(allocationNativeBufferExporter));
+    }
+
+    /// <summary>
+    /// Exports cpu and allocation samples sequentially, reusing the provided buffer.
+    /// </summary>
+    /// <param name="buffer">the buffer to read captured samples into</param>
+    public void Export(byte[] buffer)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        _cpuNativeBufferExporter.Export(buffer);
+        _allocationNativeBufferExporter.Export(buffer);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -186,7 +186,7 @@ namespace Datadog.Trace.ClrProfiler
                 }
             }
 
-            InitializeThreadSampling();
+            InitializeAlwaysOnProfiling();
 
             Log.Debug("Initialization finished.");
         }
@@ -298,29 +298,21 @@ namespace Datadog.Trace.ClrProfiler
             Log.Debug("Initialization of non native parts finished.");
         }
 
-        private static void InitializeThreadSampling()
+        private static void InitializeAlwaysOnProfiling()
         {
             // this method should be called when Tracer.Instance is initialized
             // otherwise it can produce multiple tracer instances
             // Thread Sampling ("profiling") feature
-            if (TracerManager.Instance.Settings.ThreadSamplingEnabled)
+            var tracerSettings = TracerManager.Instance.Settings;
+            if (tracerSettings.CpuProfilingEnabled || tracerSettings.MemoryProfilingEnabled)
             {
-                if (FrameworkDescription.Instance.SupportsAlwaysOnProfiler())
+                try
                 {
-                    try
-                    {
-                        Log.Debug("Initializing thread sampling.");
-                        ThreadSampler.Initialize(TracerManager.Instance.Settings);
-                        Log.Information("Thread sampling initialized.");
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(e, "Cannot initialize thread sampling.");
-                    }
+                    ThreadSampler.Initialize(tracerSettings);
                 }
-                else
+                catch (Exception e)
                 {
-                    Log.Error("Cannot initialize thread sampling. .NET version is not supported.");
+                    Log.Error(e, "Cannot initialize thread sampling.");
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -548,15 +548,22 @@ namespace Datadog.Trace.Configuration
         internal static class AlwaysOnProfiler
         {
             /// <summary>
-            /// Configuration key for enabling or disabling the thread sampling.
+            /// Configuration key for enabling or disabling the cpu profiling.
             /// The default value is false (disabled)
             /// </summary>
-            /// <seealso cref="TracerSettings.ThreadSamplingEnabled"/>
-            public const string Enabled = "SIGNALFX_PROFILER_ENABLED";
+            /// <seealso cref="TracerSettings.CpuProfilingEnabled"/>
+            public const string CpuEnabled = "SIGNALFX_PROFILER_ENABLED";
+
+            /// <summary>
+            /// Configuration key for enabling or disabling the allocation profiling.
+            /// The default value is false (disabled)
+            /// </summary>
+            /// <seealso cref="TracerSettings.MemoryProfilingEnabled"/>
+            public const string MemoryEnabled = "SIGNALFX_PROFILER_MEMORY_ENABLED";
 
             /// <summary>
             /// Configuration key to set default thread sampling period.
-            /// The default value is 1000 milliseconds.
+            /// The default value is 10000 milliseconds.
             /// </summary>
             /// <seealso cref="TracerSettings.ThreadSamplingPeriod"/>
             public const string Period = "SIGNALFX_PROFILER_CALL_STACK_INTERVAL";
@@ -565,7 +572,7 @@ namespace Datadog.Trace.Configuration
             /// Configuration key to set export format.
             /// The default value is Pprof.
             /// </summary>
-            /// <seealso cref="TracerSettings.ThreadSamplingEnabled"/>
+            /// <seealso cref="ExporterSettings.ProfilerExportFormat"/>
             public const string ExportFormat = "SIGNALFX_PROFILER_EXPORT_FORMAT";
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -80,7 +80,8 @@ namespace Datadog.Trace.Configuration
             Convention = settings.Convention;
             Exporter = settings.Exporter;
 
-            ThreadSamplingEnabled = settings.ThreadSamplingEnabled;
+            CpuProfilingEnabled = settings.CpuProfilingEnabled;
+            MemoryProfilingEnabled = settings.MemoryProfilingEnabled;
             ThreadSamplingPeriod = settings.ThreadSamplingPeriod;
             LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings);
             // Logs injection is enabled by default if direct log submission is enabled, otherwise disabled by default
@@ -357,9 +358,14 @@ namespace Datadog.Trace.Configuration
         public ExporterType Exporter { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the thread sampling is enabled.
+        /// Gets a value indicating whether the cpu profiling is enabled.
         /// </summary>
-        public bool ThreadSamplingEnabled { get; }
+        public bool CpuProfilingEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the memory profiling is enabled.
+        /// </summary>
+        public bool MemoryProfilingEnabled { get; }
 
         /// <summary>
         /// Gets a value for the thread sampling period.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -196,7 +196,8 @@ namespace Datadog.Trace.Configuration
             TagElasticsearchQueries = source?.GetBool(ConfigurationKeys.TagElasticsearchQueries) ?? true;
 
             // If you change this, change environment_variables.h too
-            ThreadSamplingEnabled = source?.GetBool(ConfigurationKeys.AlwaysOnProfiler.Enabled) ?? false;
+            CpuProfilingEnabled = source?.GetBool(ConfigurationKeys.AlwaysOnProfiler.CpuEnabled) ?? false;
+            MemoryProfilingEnabled = source?.GetBool(ConfigurationKeys.AlwaysOnProfiler.MemoryEnabled) ?? false;
             ThreadSamplingPeriod = GetThreadSamplingPeriod(source);
 
             LogSubmissionSettings = new DirectLogSubmissionSettings(source);
@@ -537,11 +538,18 @@ namespace Datadog.Trace.Configuration
         internal int TraceBatchInterval { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the thread sampling is enabled.
+        /// Gets or sets a value indicating whether the cpu profiling is enabled.
         /// The default value is false (disabled)
         /// </summary>
-        /// <seealso cref="TracerSettings.ThreadSamplingEnabled"/>
-        internal bool ThreadSamplingEnabled { get; set; }
+        /// <seealso cref="ConfigurationKeys.AlwaysOnProfiler.CpuEnabled"/>
+        internal bool CpuProfilingEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the allocation profiling is enabled.
+        /// The default value is false (disabled)
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.AlwaysOnProfiler.MemoryEnabled"/>
+        internal bool MemoryProfilingEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets a value for the thread sampling period.

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -78,9 +78,14 @@ namespace Datadog.Trace
             return Name.ToLowerInvariant().Contains("core") || IsNet5();
         }
 
-        public bool SupportsAlwaysOnProfiler()
+        public bool SupportsCpuProfiling()
         {
             return Environment.Version.Major is 3 or >= 5;
+        }
+
+        public bool SupportsMemoryProfiling()
+        {
+            return Environment.Version.Major >= 5;
         }
 
         private static string GetNetCoreOrNetFrameworkVersion()

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
@@ -50,7 +50,12 @@ namespace Datadog.Trace
             return false;
         }
 
-        public bool SupportsAlwaysOnProfiler()
+        public bool SupportsCpuProfiling()
+        {
+            return false;
+        }
+
+        public bool SupportsMemoryProfiling()
         {
             return false;
         }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -401,10 +401,13 @@ namespace Datadog.Trace
                     writer.WriteValue(agentError ?? string.Empty);
 
                     writer.WritePropertyName("thread_sampling_enabled");
-                    writer.WriteValue(instanceSettings.ThreadSamplingEnabled);
+                    writer.WriteValue(instanceSettings.CpuProfilingEnabled);
 
                     writer.WritePropertyName("thread_sampling_period");
                     writer.WriteValue(instanceSettings.ThreadSamplingPeriod);
+
+                    writer.WritePropertyName("memory_profiling_enabled");
+                    writer.WriteValue(instanceSettings.MemoryProfilingEnabled);
 
                     writer.WritePropertyName("logs_endpoint_url");
                     writer.WriteValue(instanceSettings.ExporterSettings.LogsEndpointUrl);

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace
             sampler ??= GetSampler(settings);
 
             agentWriter ??= GetAgentWriter(settings, statsd, sampler);
-            scopeManager ??= new AsyncLocalScopeManager(settings.ThreadSamplingEnabled && FrameworkDescription.Instance.SupportsAlwaysOnProfiler());
+            scopeManager ??= new AsyncLocalScopeManager(settings.CpuProfilingEnabled && FrameworkDescription.Instance.SupportsCpuProfiling());
 
             if (settings.RuntimeMetricsEnabled && !DistributedTracer.Instance.IsChildTracer)
             {

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.SignalFx.Tracing.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.SignalFx.Tracing.PublicApiHasNotChanged.verified.txt
@@ -114,6 +114,7 @@ namespace Datadog.Trace.Configuration
             "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
         public bool AnalyticsEnabled { get; }
         public Datadog.Trace.Configuration.ConventionType Convention { get; }
+        public bool CpuProfilingEnabled { get; }
         public string CustomSamplingRules { get; }
         public string Environment { get; }
         public Datadog.Trace.Configuration.ExporterType Exporter { get; }
@@ -126,6 +127,7 @@ namespace Datadog.Trace.Configuration
         public bool KafkaCreateConsumerScopeEnabled { get; }
         public bool LogsInjectionEnabled { get; }
         public int MaxTracesSubmittedPerSecond { get; }
+        public bool MemoryProfilingEnabled { get; }
         public int RecordedValueMaxLength { get; }
         public string ServiceName { get; }
         public string ServiceVersion { get; }
@@ -133,7 +135,6 @@ namespace Datadog.Trace.Configuration
         public bool StatsComputationEnabled { get; }
         public bool TagElasticsearchQueries { get; }
         public bool TagRedisCommands { get; }
-        public bool ThreadSamplingEnabled { get; }
         public System.TimeSpan ThreadSamplingPeriod { get; }
         public bool TraceEnabled { get; }
         public bool TracerMetricsEnabled { get; }


### PR DESCRIPTION
## Why

Handle memory profiling configuration on the managed side.

## What

- Attempt to consume and export allocation samples only if memory profiling is enabled
- Rename properties related to AlwaysOnProfiling
- Reorganize the code related to exporting cpu/allocation samples
- Update `internal-config.md`

## Tests

Existing tests.