### PR TITLE
[AlwaysOnProfiler] Memory profiler internal docs

### DIFF
--- a/docs/always-on-profiling.md
+++ b/docs/always-on-profiling.md
@@ -46,6 +46,8 @@ Please check [description](advanced-config.md#alwayson-profiling-settings) for t
 * `SIGNALFX_PROFILER_ENABLED`,
 * `SIGNALFX_PROFILER_CALL_STACK_INTERVAL`.
 
+> _NOTE_: `SIGNALFX_PROFILER_LOGS_ENDPOINT` affects both CPU and Memory profiling.
+
 > We strongly recommend using defaults for `SIGNALFX_PROFILER_CALL_STACK_INTERVAL`.
 
 # Escape hatch

--- a/docs/always-on-profiling.md
+++ b/docs/always-on-profiling.md
@@ -62,8 +62,8 @@ Thread sampler will resume when any of the buffers are empty.
 
 ## How do I know if it's working?
 
-At the startup, the SignalFx Instrumentation for .NET will log the string
-`AlwaysOnProfiler::StartThreadSampling` at `info` log level
+At the startup, the SignalFx Instrumentation for .NET logs the string
+`AlwaysOnProfiler::StartThreadSampling` at `info` log level.
 
 You can grep for this in the native logs for the instrumentation
 to see something like this:
@@ -72,14 +72,14 @@ to see something like this:
 10/12/22 12:10:31.962 PM [12096|22036] [info] AlwaysOnProfiler::StartThreadSampling
 ```
 
-Attempt to enable CPU Profiler on the unsupported runtime version
-results in the following entry in the managed logs for the instrumentation:
+If you try to enable CPU Profiler on the unsupported runtime version, you'll get
+a log entry similar to the following in the managed logs for the instrumentation:
 
 ```text
 2022-10-12 12:37:18.640 +02:00 [WRN] Cpu profiling enabled but not supported.
 ```
 
-## How can I see the profiler configuration?
+## How can I see AlwaysOn Profiling configuration?
 
 The SignalFx Instrumentation for .NET logs the profiling configuration
 at `INF` log level during the startup. You can grep for the string `TRACER CONFIGURATION`

--- a/docs/internal/memory-profiling.md
+++ b/docs/internal/memory-profiling.md
@@ -1,5 +1,5 @@
 
-# About the AlwaysOn memory profiling for .NET
+# About AlwaysOn memory profiling for .NET
 
 The SignalFx Instrumentation for .NET includes a memory profiler for Splunk
 APM that can be enabled with a setting. The profiler samples allocations,
@@ -67,8 +67,8 @@ to see something like this:
 10/12/22 12:10:31.962 PM [12096|22036] [info] AlwaysOnProfiler::MemoryProfiling started.
 ```
 
-Attempt to enable Memory Profiler on the unsupported runtime version
-results in an entry in the managed logs for the instrumentation similar to this:
+If you enable the memory profiler on an unsupported runtime version
+an entry in the managed logs for the instrumentation similar to this appears:
 
 ```text
 2022-10-12 12:37:18.640 +02:00 [WRN] Memory profiling enabled but not supported.

--- a/docs/internal/memory-profiling.md
+++ b/docs/internal/memory-profiling.md
@@ -1,25 +1,23 @@
 
-# About the .NET AlwaysOn Profiling
+# About the .NET Memory Profiling
 
-The SignalFx Instrumentation for .NET includes a continuous thread sampler
-that can be enabled with a configuration setting. This sampler periodically captures
-the call stack state for all .NET threads and sends these
-to the Splunk Observability Cloud as logs. You can then view a flame graph of application
-call stacks and inspect individual code-level call stacks for relevant traces.
+The SignalFx Instrumentation for .NET includes a Memory Profiler
+that can be enabled with a configuration setting. This profiler samples allocations,
+captures the call stack state for .NET thread that triggered the allocation,
+and sends these to the Splunk Observability Cloud as logs.
 
-## How does the thread sampler work?
+Memory allocation data, together with the stack traces and dotnet runtime metrics,
+can then be used to investigate memory leaks and unusual consumption patterns.
+
+## How does the memory profiler work?
 
 The profiler leverages [.NET profiling](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/)
-to perform periodic call stack sampling. For every sampling period,
-the runtime is suspended
-and the samples for all managed thread are saved into the buffer,
-then the runtime resumes.
+to perform allocation sampling.
+For every sampled allocation, allocation amount together with state of the thread
+that triggered the allocation are saved into buffer.
 
-The separate managed-thread is processing data from the buffer
-and sends it to the OpenTelemetry Collector.
-
-To make the process more efficient, the sampler uses two independent buffers
-to store samples alternatively.
+The managed-thread shared with [CPU Profiler](../always-on-profiling.md)
+processes the data from the buffer and sends it to the OpenTelemetry Collector.
 
 Stack trace data is embedded as a string inside of an OTLP logs payload. The
 [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)
@@ -28,55 +26,52 @@ Splunk APM.
 
 # Requirements
 
-* .NET Core 3.1 or .NET 5.0 or higher (`ICorProfilerInfo10` available in runtime).
+* .NET 5.0 or higher (`ICorProfilerInfo12` available in runtime).
 * [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)
 version 0.34.0 or higher.
 _Sending profiling data directly to ingest is not supported at this time_.
 
 # Enable the profiler
 
-To enable the profiler, set the `SIGNALFX_PROFILER_ENABLED` environment variable
+To enable the profiler, set the `SIGNALFX_PROFILER_MEMORY_ENABLED` environment variable
 to `true` for your .NET process.
 
 # Configuration settings
 
-Please check [description](advanced-config.md#alwayson-profiling-settings) for the following environment variables
+Please check the descriptions for the following environment variable:
 
-* `SIGNALFX_PROFILER_LOGS_ENDPOINT`,
-* `SIGNALFX_PROFILER_ENABLED`,
-* `SIGNALFX_PROFILER_CALL_STACK_INTERVAL`.
+* [`SIGNALFX_PROFILER_MEMORY_ENABLED`](../internal/internal-config.md#internal-settings)
+* [`SIGNALFX_PROFILER_LOGS_ENDPOINT`](../advanced-config.md#alwayson-profiling-settings)
 
-> We strongly recommend using defaults for `SIGNALFX_PROFILER_CALL_STACK_INTERVAL`.
+> _NOTE_: `SIGNALFX_PROFILER_LOGS_ENDPOINT` affects both CPU and Memory profiling.
 
 # Escape hatch
 
-The profiler limits its own behavior when both buffers
-used to store sampled data are full.
+The profiler limits its own behavior when buffer
+used to store allocation samples is full.
 
 This scenario might happen when the data processing thread is not able
 to send data to collector in the given period of time.
-
-Thread sampler will resume when any of the buffers are empty.
 
 # Troubleshooting the .NET profiler
 
 ## How do I know if it's working?
 
 At the startup, the SignalFx Instrumentation for .NET will log the string
-`AlwaysOnProfiler::StartThreadSampling` at `info` log level
+`AlwaysOnProfiler::MemoryProfiling started` at `info` log level.
 
 You can grep for this in the native logs for the instrumentation
 to see something like this:
 
 ```text
-10/12/22 12:10:31.962 PM [12096|22036] [info] AlwaysOnProfiler::StartThreadSampling
+10/12/22 12:10:31.962 PM [12096|22036] [info] AlwaysOnProfiler::MemoryProfiling started.
 ```
 
-Attempt to enable CPU Profiler on the unsupported runtime version
-results in the following entry in the managed logs for the instrumentation:
+Attempt to enable Memory Profiler on the unsupported runtime version
+results in an entry in the managed logs for the instrumentation similar to this:
 
 ```text
-2022-10-12 12:37:18.640 +02:00 [WRN] Cpu profiling enabled but not supported.
+2022-10-12 12:37:18.640 +02:00 [WRN] Memory profiling enabled but not supported.
 ```
 
 ## How can I see the profiler configuration?
@@ -85,22 +80,17 @@ The SignalFx Instrumentation for .NET logs the profiling configuration
 at `INF` log level during the startup. You can grep for the string `TRACER CONFIGURATION`
 to see the configuration.
 
+Ensure `memory_profiling_enabled` is set to `true`.
+Ensure `logs_endpoint_url` points to the deployed [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector).
+
 ## What does the escape hatch do?
 
-The escape hatch automatically discards profiling data
+The escape hatch automatically discards captured allocation data
 if the ingest limit has been reached.
 
 If the escape hatch activates, it logs the following message:
 
-```text
-Skipping a thread sample period, buffers are full.
-```
-
-You can also look for:
-
-```text
-** THIS WILL RESULT IN LOSS OF PROFILING DATA **.
-```
+`Discarding captured allocation sample. Allocation buffer is full.`
 
 If you see these log messages, check the configuration and communication layer
 between your process and the Collector.
@@ -108,7 +98,7 @@ between your process and the Collector.
 ## What if I'm on an unsupported .NET version?
 
 If you want to use the profiler and see this in your logs, you must upgrade
-your .NET version to .NET Core 3.1 or .NET 5.0 or higher.
+your .NET version to .NET 5.0 or higher.
 None of the .NET Framework versions is supported.
 
 ## Why is the OTLP/logs exporter complaining?
@@ -135,7 +125,3 @@ and that an exporter is configured for `splunk_hec` export.
 Ensure that the `token` and `endpoint` fields are [correctly configured](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver#configuration).
 Lastly, double check that the logs _pipeline_ is configured to use
 the OTLP HTTP receiver and `splunk_hec` exporter.
-
-## Can I tell the sampler to ignore some threads?
-
-There is no such functionality. All managed threads are captured by the profiler.

--- a/docs/internal/memory-profiling.md
+++ b/docs/internal/memory-profiling.md
@@ -13,8 +13,9 @@ to investigate memory leaks and unusual consumption patterns in AlwaysOn Profili
 
 The profiler leverages [.NET profiling](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/)
 to perform allocation sampling.
-For every sampled allocation, allocation amount as well as the state of the thread
-that triggered the allocation are saved into buffer.
+For every sampled allocation, allocation amount together with stack
+trace of the thread that triggered the allocation, and associated
+span context, are saved into buffer.
 
 The managed thread shared with [CPU Profiler](../always-on-profiling.md)
 processes the data from the buffer and sends it to the OpenTelemetry Collector.
@@ -49,6 +50,8 @@ Make sure you're following the documentation for the following environment varia
 
 The profiler limits its own behavior when buffer
 used to store allocation samples is full.
+
+Current maximum size of the buffer is 200 KiB.
 
 This scenario might happen when the data processing thread is not able
 to send data to collector in the given period of time.

--- a/docs/internal/memory-profiling.md
+++ b/docs/internal/memory-profiling.md
@@ -1,28 +1,28 @@
 
-# About the .NET Memory Profiling
+# About the AlwaysOn memory profiling for .NET
 
-The SignalFx Instrumentation for .NET includes a Memory Profiler
-that can be enabled with a configuration setting. This profiler samples allocations,
-captures the call stack state for .NET thread that triggered the allocation,
-and sends these to the Splunk Observability Cloud as logs.
+The SignalFx Instrumentation for .NET includes a memory profiler for Splunk
+APM that can be enabled with a setting. The profiler samples allocations,
+captures the call stack state for the .NET thread that triggered the allocation,
+and sends the telemetry to Splunk Observability Cloud.
 
-Memory allocation data, together with the stack traces and dotnet runtime metrics,
-can then be used to investigate memory leaks and unusual consumption patterns.
+Use the memory allocation data, together with the stack traces and .NET runtime metrics,
+to investigate memory leaks and unusual consumption patterns in AlwaysOn Profiling.
 
 ## How does the memory profiler work?
 
 The profiler leverages [.NET profiling](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/)
 to perform allocation sampling.
-For every sampled allocation, allocation amount together with state of the thread
+For every sampled allocation, allocation amount as well as the state of the thread
 that triggered the allocation are saved into buffer.
 
-The managed-thread shared with [CPU Profiler](../always-on-profiling.md)
+The managed thread shared with [CPU Profiler](../always-on-profiling.md)
 processes the data from the buffer and sends it to the OpenTelemetry Collector.
 
-Stack trace data is embedded as a string inside of an OTLP logs payload. The
+Stack trace data is embedded as a string inside of the OTLP logs payload. The
 [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)
 detects profiling data inside OTLP logs and forwards it to
-Splunk APM.
+the Splunk APM.
 
 # Requirements
 
@@ -38,7 +38,7 @@ to `true` for your .NET process.
 
 # Configuration settings
 
-Please check the descriptions for the following environment variable:
+Make sure you're following the documentation for the following environment variables:
 
 * [`SIGNALFX_PROFILER_MEMORY_ENABLED`](../internal/internal-config.md#internal-settings)
 * [`SIGNALFX_PROFILER_LOGS_ENDPOINT`](../advanced-config.md#alwayson-profiling-settings)
@@ -119,7 +119,7 @@ Other collector distributions might not be able to correctly route
 the log data containing profiles.
 * Make sure that the collector is configured correctly to handle profiling data.
 By default, the [Splunk OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)
-handles this, but a custom configuration might have overridden some settings.
+handles this, but a custom configuration might override some settings.
 Make sure that an OTLP HTTP _receiver_ is configured in the collector
 and that an exporter is configured for `splunk_hec` export.
 Ensure that the `token` and `endpoint` fields are [correctly configured](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver#configuration).

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/always_on_profiler.cpp
@@ -110,6 +110,7 @@ void AllocationSamplingAppendToBuffer(int32_t appendLen, unsigned char* appendBu
 
     if (allocation_buffer->size() + appendLen >= kSamplesBufferMaximumSize)
     {
+        trace::Logger::Warn("Discarding captured allocation sample. Allocation buffer is full.");
         return;
     }
     allocation_buffer->insert(allocation_buffer->end(), appendBuf, &appendBuf[appendLen]);
@@ -876,6 +877,8 @@ void AlwaysOnProfiler::StartAllocationSampling(ICorProfilerInfo12* info12)
     {
         trace::Logger::Error("Could not enable allocation sampling: session pipe error", hr);
     }
+
+    trace::Logger::Info("AlwaysOnProfiler::MemoryProfiling started.");
 }
 
 void AlwaysOnProfiler::ThreadCreated(ThreadID thread_id)


### PR DESCRIPTION
## Why

Document Memory Profiler.

## What

- Separate file in internal docs for MemoryProfiler (based on `always-on-profiling.md`).
- Update `always-on-profiling.md` after recent logging changes.
- Add troubleshooting logs.

## Tests

n/a
