### PR TITLE
[Runtime Metrics] Time in gc metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -18,15 +18,16 @@ To learn about differences between SignalFx metric types, visit [documentation](
 The names and the metric structure of the metrics exported are aligned with OpenTelemetry
 [implementation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/bc947a00c3f859cc436f050e81172fc1f8bc09d7/src/OpenTelemetry.Instrumentation.Runtime).
 
-| Metric                                                  | Description                                                                                                                      | Type               |
-|:--------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|:-------------------|
-| `process.runtime.dotnet.exceptions.count`               | The count of exceptions that have been thrown in managed code since the previous observation.                                    | Counter            |
-| `process.runtime.dotnet.gc.collections.count`           | The number of garbage collections that have occurred since the process was started.                                              | CumulativeCounter  |
-| `process.runtime.dotnet.gc.heap.size`                   | The heap size, as observed during the latest garbage collection.                                                                 | Gauge              |
-| `process.runtime.dotnet.gc.allocations.size`            | The count of bytes allocated on the managed GC heap since the process was started. (.NET Core only)                              | CumulativeCounter  |
-| `process.runtime.dotnet.gc.committed_memory.size`       | The amount of committed virtual memory for the managed GC heap, as observed during the latest garbage collection. (.NET 6 only)  | Gauge              |
-| `process.runtime.dotnet.monitor.lock_contention.count`  | The number of times there was contention when trying to acquire a monitor lock since the process was started.                    | CumulativeCounter  |
-| `process.runtime.dotnet.thread_pool.threads.count`      | The number of thread pool threads, as observed during the latest measurement. (.NET Core only)                                   | Gauge              |
+| Metric                                                 | Description                                                                                                                     | Type              |
+|:-------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|:------------------|
+| `process.runtime.dotnet.exceptions.count`              | The count of exceptions that have been thrown in managed code since the previous observation.                                   | Counter           |
+| `process.runtime.dotnet.gc.collections.count`          | The number of garbage collections that have occurred since the process was started.                                             | CumulativeCounter |
+| `process.runtime.dotnet.gc.heap.size`                  | The heap size, as observed during the latest garbage collection.                                                                | Gauge             |
+| `process.runtime.dotnet.gc.allocations.size`           | The count of bytes allocated on the managed GC heap since the process was started. (.NET Core only)                             | CumulativeCounter |
+| `process.runtime.dotnet.gc.committed_memory.size`      | The amount of committed virtual memory for the managed GC heap, as observed during the latest garbage collection. (.NET 6 only) | Gauge             |
+| `process.runtime.dotnet.gc.pause.time`                 | The number of milliseconds spent in GC pause. (.NET Core only)                                                                  | Counter           |
+| `process.runtime.dotnet.monitor.lock_contention.count` | The number of times there was contention when trying to acquire a monitor lock since the process was started.                   | CumulativeCounter |
+| `process.runtime.dotnet.thread_pool.threads.count`     | The number of thread pool threads, as observed during the latest measurement. (.NET Core only)                                  | Gauge             |
 
 ## Process metrics
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,14 +20,14 @@ The names and the metric structure of the metrics exported are aligned with Open
 
 | Metric                                                 | Description                                                                                                                     | Type              |
 |:-------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|:------------------|
-| `process.runtime.dotnet.exceptions.count`              | The count of exceptions that have been thrown in managed code since the previous observation.                                   | Counter           |
-| `process.runtime.dotnet.gc.collections.count`          | The number of garbage collections that have occurred since the process was started.                                             | CumulativeCounter |
-| `process.runtime.dotnet.gc.heap.size`                  | The heap size, as observed during the latest garbage collection.                                                                | Gauge             |
-| `process.runtime.dotnet.gc.allocations.size`           | The count of bytes allocated on the managed GC heap since the process was started. (.NET Core only)                             | CumulativeCounter |
-| `process.runtime.dotnet.gc.committed_memory.size`      | The amount of committed virtual memory for the managed GC heap, as observed during the latest garbage collection. (.NET 6 only) | Gauge             |
-| `process.runtime.dotnet.gc.pause.time`                 | The number of milliseconds spent in GC pause. (.NET Core only)                                                                  | Counter           |
-| `process.runtime.dotnet.monitor.lock_contention.count` | The number of times there was contention when trying to acquire a monitor lock since the process was started.                   | CumulativeCounter |
-| `process.runtime.dotnet.thread_pool.threads.count`     | The number of thread pool threads, as observed during the latest measurement. (.NET Core only)                                  | Gauge             |
+| `process.runtime.dotnet.exceptions.count`              | Count of exceptions since the previous observation.                                   | Counter           |
+| `process.runtime.dotnet.gc.collections.count`          | Number of garbage collections since the process started.                                             | CumulativeCounter |
+| `process.runtime.dotnet.gc.heap.size`                  | Heap size, as observed during the last garbage collection.                                                                | Gauge             |
+| `process.runtime.dotnet.gc.allocations.size`           | Count of bytes allocated on the managed GC heap since the process started. (.NET Core only)                             | CumulativeCounter |
+| `process.runtime.dotnet.gc.committed_memory.size`      | Amount of committed virtual memory for the managed GC heap, as observed during the last garbage collection. (.NET 6 only) | Gauge             |
+| `process.runtime.dotnet.gc.pause.time`                 | Number of milliseconds spent in GC pause. (.NET Core only)                                                                  | Counter           |
+| `process.runtime.dotnet.monitor.lock_contention.count` | Contentions count when trying to acquire a monitor lock since the process started.                   | CumulativeCounter |
+| `process.runtime.dotnet.thread_pool.threads.count`     | Number of thread pool threads, as observed during the last measurement. Only available for .NET Core.                                  | Gauge             |
 
 ## Process metrics
 

--- a/tracer/src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
+++ b/tracer/src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
@@ -76,6 +76,10 @@ namespace Datadog.Trace.DogStatsd
         {
         }
 
+        public void IncrementDouble(string statName, double value, double sampleRate = 1, string[] tags = null)
+        {
+        }
+
         public void Dispose()
         {
         }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -42,8 +42,6 @@ namespace Datadog.Trace.RuntimeMetrics
             _statsd.Gauge(MetricsNames.Gc.HeapSize, value.Gen2Size, tags: GcMetrics.Tags.Gen2);
             _statsd.Gauge(MetricsNames.Gc.HeapSize, value.LohSize, tags: GcMetrics.Tags.LargeObjectHeap);
 
-            GcMetrics.PushCollectionCounts(_statsd);
-
             Log.Debug("Sent the following metrics: {metrics}", GarbageCollectionMetrics);
         }
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
@@ -41,6 +41,7 @@ namespace Datadog.Trace.RuntimeMetrics
             public const string HeapSize = $"{MetricPrefix}gc.heap.size";
             public const string AllocatedBytes = $"{MetricPrefix}gc.allocations.size";
             public const string HeapCommittedMemory = $"{MetricPrefix}gc.committed_memory.size";
+            public const string PauseTime = $"{MetricPrefix}gc.pause.time";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -82,8 +82,6 @@ namespace Datadog.Trace.RuntimeMetrics
 
             TryUpdateCounter(MetricsNames.ContentionCount, _contentionCount);
 
-            GcMetrics.PushCollectionCounts(_statsd);
-
             Log.Debug("Sent the following metrics: {metrics}", GarbageCollectionMetrics);
         }
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -101,6 +101,8 @@ namespace Datadog.Trace.RuntimeMetrics
             {
                 _listener?.Refresh();
 
+                GcMetrics.PushCollectionCounts(_statsd);
+
                 if (_enableProcessMetrics)
                 {
                     ProcessHelpers.GetCurrentProcessRuntimeMetrics(out var newUserCpu, out var newSystemCpu, out var threadCount, out var memoryUsage);

--- a/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxMetricSender.cs
+++ b/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxMetricSender.cs
@@ -59,6 +59,17 @@ namespace Datadog.Trace.SignalFx.Metrics
             Send(MetricType.COUNTER, name, datum => datum.intValue = value, tags);
         }
 
+        /// <summary>
+        /// Sends counter metric with a double value using configured reporter.
+        /// </summary>
+        /// <param name="name">The name of the metric.</param>
+        /// <param name="value">The value of the metric.</param>
+        /// <param name="tags">Tags added to the metric.</param>
+        public void SendDoubleCounterMetric(string name, double value, string[] tags = null)
+        {
+            Send(MetricType.COUNTER, name, datum => datum.doubleValue = value, tags);
+        }
+
         public void Dispose()
         {
             _writer?.Dispose();

--- a/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxStats.cs
+++ b/tracer/src/Datadog.Trace/SignalFx/Metrics/SignalFxStats.cs
@@ -44,6 +44,11 @@ namespace Datadog.Trace.SignalFx.Metrics
             _metricSender.SendCounterMetric(statName, value, tags);
         }
 
+        public void IncrementDouble(string statName, double value, double sampleRate = 1, string[] tags = null)
+        {
+            _metricSender.SendDoubleCounterMetric(statName, value, tags);
+        }
+
         public void Decrement(string statName, int value = 1, double sampleRate = 1, params string[] tags)
         {
         }

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/DogStatsdService.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/DogStatsdService.cs
@@ -246,6 +246,10 @@ namespace Datadog.Trace.Vendors.StatsdClient
             _metricsSender?.SendServiceCheck(name, (int)status, timestamp, hostname, tags, message);
         }
 
+        public void IncrementDouble(string statName, double value, double sampleRate = 1, string[] tags = null)
+        {
+        }
+
         /// <summary>
         /// Flushes all metrics.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/IDogStatsd.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/IDogStatsd.cs
@@ -174,5 +174,14 @@ namespace Datadog.Trace.Vendors.StatsdClient
             string hostname = null,
             string[] tags = null,
             string message = null);
+
+        /// <summary>
+        /// Increments the specified double-valued counter.
+        /// </summary>
+        /// <param name="statName">The name of the metric.</param>
+        /// <param name="value">The amount of increment.</param>
+        /// <param name="sampleRate">Percentage of metric to be sent.</param>
+        /// <param name="tags">Array of tags to be added to the data.</param>
+        void IncrementDouble(string statName, double value, double sampleRate = 1, string[] tags = null);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
@@ -38,11 +38,6 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedGen2HeapSize, 1, new[] { "generation:gen2" }), Times.Once);
             statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedLohHeapSize, 1, new[] { "generation:loh" }), Times.Once);
 
-            // note: collections count no longer extracted from counters
-            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen0" }), Times.Once);
-            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen1" }), Times.Once);
-            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen2" }), Times.Once);
-
             statsd.VerifyNoOtherCalls();
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
@@ -33,10 +33,6 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:gen2" }), Times.Once);
             statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:loh" }), Times.Once);
 
-            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen0" }), Times.Once);
-            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen1" }), Times.Once);
-            statsd.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), 1, new[] { "generation:gen2" }), Times.Once);
-
             statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<long>(), 1, It.IsAny<string[]>()), Times.Once);
 
             statsd.VerifyNoOtherCalls();

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -35,6 +35,21 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         }
 
         [Fact]
+        public void PushGcCollectionCounts()
+        {
+            var listener = new Mock<IRuntimeMetricsListener>();
+
+            var stats = new Mock<IDogStatsd>();
+            using var runtimeMetricsWriter = new RuntimeMetricsWriter(stats.Object, TimeSpan.FromMilliseconds(10), (statsd, timeSpan) => listener.Object);
+
+            runtimeMetricsWriter.PushEvents();
+
+            stats.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), It.IsAny<double>(), new[] { "generation:gen0" }), Times.AtLeastOnce);
+            stats.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), It.IsAny<double>(), new[] { "generation:gen1" }), Times.AtLeastOnce);
+            stats.Verify(s => s.Counter(MetricsNames.Gc.CollectionsCount, It.IsAny<long>(), It.IsAny<double>(), new[] { "generation:gen2" }), Times.AtLeastOnce);
+        }
+
+        [Fact]
         public void ShouldSwallowFactoryExceptions()
         {
             var writer = new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), TimeSpan.FromMilliseconds(10), (statsd, timeSpan) => throw new InvalidOperationException("This exception should be caught"));


### PR DESCRIPTION
## Why

Reintroduce metric that shows time spent in gc pause.

## What

- reintroduce implementation from upstream (.NET Core only)
- send as a double-valued counter
- move pushing gc collection counts metrics to common place

For now, I extended existing metrics interface. We should consider using metric sender directly (requires additional changes, postponed for now).

## Tests

Included in PR.
