### PR TITLE
[Runtime metrics] Rewrite process metrics to match otel

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -31,7 +31,7 @@ implementation from the [Runtime](https://github.com/open-telemetry/opentelemetr
 
 ## Process metrics
 
-Names and metric structure of the metrics exported are aligned with OpenTelemetry implementation from [Process](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/926386e68c9066e8032853e8309abdf4088d8dca/src/OpenTelemetry.Instrumentation.Process) package.
+Names and metric structure of the metrics exported are aligned with the OpenTelemetry implementation from the [Process](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/926386e68c9066e8032853e8309abdf4088d8dca/src/OpenTelemetry.Instrumentation.Process) package.
 
 | Metric                               | Description                                                                                                                         | Type              |
 |:-------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------|:------------------|

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,28 +15,31 @@ To learn about differences between SignalFx metric types, visit [documentation](
 
 ## .NET runtime metrics
 
-The names and the metric structure of the metrics exported are aligned with OpenTelemetry
-[implementation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/bc947a00c3f859cc436f050e81172fc1f8bc09d7/src/OpenTelemetry.Instrumentation.Runtime).
+Names and metric structure of the metrics exported are aligned with OpenTelemetry
+implementation from [Runtime](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/bc947a00c3f859cc436f050e81172fc1f8bc09d7/src/OpenTelemetry.Instrumentation.Runtime) package.
 
-| Metric                                                 | Description                                                                                                                     | Type              |
-|:-------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|:------------------|
-| `process.runtime.dotnet.exceptions.count`              | Count of exceptions since the previous observation.                                   | Counter           |
-| `process.runtime.dotnet.gc.collections.count`          | Number of garbage collections since the process started.                                             | CumulativeCounter |
+| Metric                                                 | Description                                                                                                               | Type              |
+|:-------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|:------------------|
+| `process.runtime.dotnet.exceptions.count`              | Count of exceptions since the previous observation.                                                                       | Counter           |
+| `process.runtime.dotnet.gc.collections.count`          | Number of garbage collections since the process started.                                                                  | CumulativeCounter |
 | `process.runtime.dotnet.gc.heap.size`                  | Heap size, as observed during the last garbage collection.                                                                | Gauge             |
-| `process.runtime.dotnet.gc.allocations.size`           | Count of bytes allocated on the managed GC heap since the process started. (.NET Core only)                             | CumulativeCounter |
+| `process.runtime.dotnet.gc.allocations.size`           | Count of bytes allocated on the managed GC heap since the process started. (.NET Core only)                               | CumulativeCounter |
 | `process.runtime.dotnet.gc.committed_memory.size`      | Amount of committed virtual memory for the managed GC heap, as observed during the last garbage collection. (.NET 6 only) | Gauge             |
-| `process.runtime.dotnet.gc.pause.time`                 | Number of milliseconds spent in GC pause. (.NET Core only)                                                                  | Counter           |
-| `process.runtime.dotnet.monitor.lock_contention.count` | Contentions count when trying to acquire a monitor lock since the process started.                   | CumulativeCounter |
-| `process.runtime.dotnet.thread_pool.threads.count`     | Number of thread pool threads, as observed during the last measurement. Only available for .NET Core.                                  | Gauge             |
+| `process.runtime.dotnet.gc.pause.time`                 | Number of milliseconds spent in GC pause. (.NET Core only)                                                                | Counter           |
+| `process.runtime.dotnet.monitor.lock_contention.count` | Contentions count when trying to acquire a monitor lock since the process started.                                        | CumulativeCounter |
+| `process.runtime.dotnet.thread_pool.threads.count`     | Number of thread pool threads, as observed during the last measurement. Only available for .NET Core.                     | Gauge             |
 
 ## Process metrics
 
-| Metric                                                  | Description                                                                                                                       | Type               |
-|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------|:-------------------|
-| `runtime.dotnet.cpu.percent`                            | The percentage of total CPU used by the application.                                                                              | Gauge              |
-| `runtime.dotnet.cpu.system`                             | The number of milliseconds executing outside the kernel.                                                                          | Gauge              |
-| `runtime.dotnet.cpu.user`                               | The number of milliseconds executing in the kernel.                                                                               | Gauge              |
-| `runtime.dotnet.threads.count`                          | The number of threads that were running in the process.                                                                           | Counter            |
+Names and metric structure of the metrics exported are aligned with OpenTelemetry implementation from [Process](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/926386e68c9066e8032853e8309abdf4088d8dca/src/OpenTelemetry.Instrumentation.Process) package.
+
+| Metric                               | Description                                                                                                                         | Type              |
+|:-------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------|:------------------|
+| `process.memory.usage`               | The amount of physical memory allocated for this process.                                                                           | Gauge             |
+| `process.memory.virtual`             | The amount of virtual memory allocated for this process that cannot be shared with other processes.                                 | Gauge             |
+| `process.cpu.time`                   | Total CPU seconds broken down by different states(`user`,`system`).                                                                 | CumulativeCounter |
+| `process.cpu.utilization`            | Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process. | Gauge             |
+| `process.threads`                    | Process threads count.                                                                                                              | Gauge             |
 
 ## ASP.NET Core metrics
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,8 +15,8 @@ To learn about differences between SignalFx metric types, visit [documentation](
 
 ## .NET runtime metrics
 
-Names and metric structure of the metrics exported are aligned with OpenTelemetry
-implementation from [Runtime](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/bc947a00c3f859cc436f050e81172fc1f8bc09d7/src/OpenTelemetry.Instrumentation.Runtime) package.
+Names and metric structure of the metrics exported are aligned with the OpenTelemetry
+implementation from the [Runtime](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/bc947a00c3f859cc436f050e81172fc1f8bc09d7/src/OpenTelemetry.Instrumentation.Runtime) package.
 
 | Metric                                                 | Description                                                                                                               | Type              |
 |:-------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|:------------------|

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -16,6 +16,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -25,8 +26,8 @@ namespace Datadog.Trace.Ci
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CITracerManager>();
 
-        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, ITraceIdConvention traceIdConvention, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, string defaultServiceName)
-            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, traceIdConvention, logSubmissionManager, telemetry, defaultServiceName, new Trace.Processors.ITraceProcessor[]
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, ITraceIdConvention traceIdConvention, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, string defaultServiceName, ISignalFxMetricSender metricSender)
+            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, traceIdConvention, logSubmissionManager, telemetry, defaultServiceName, metricSender, new Trace.Processors.ITraceProcessor[]
             {
                 new Trace.Processors.NormalizerTraceProcessor(),
                 new Trace.Processors.TruncatorTraceProcessor(),

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -18,6 +18,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -43,9 +44,10 @@ namespace Datadog.Trace.Ci
             ITraceIdConvention traceIdConvention,
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
-            string defaultServiceName)
+            string defaultServiceName,
+            ISignalFxMetricSender metricSender)
         {
-            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, traceIdConvention, logSubmissionManager, telemetry, defaultServiceName);
+            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, traceIdConvention, logSubmissionManager, telemetry, defaultServiceName, metricSender);
         }
 
         protected override ISampler GetSampler(ImmutableTracerSettings settings)

--- a/tracer/src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
+++ b/tracer/src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
@@ -76,10 +76,6 @@ namespace Datadog.Trace.DogStatsd
         {
         }
 
-        public void IncrementDouble(string statName, double value, double sampleRate = 1, string[] tags = null)
-        {
-        }
-
         public void Dispose()
         {
         }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/GcMetrics.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/GcMetrics.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Trace.Vendors.StatsdClient;
+using MetricType = Datadog.Tracer.SignalFx.Metrics.Protobuf.MetricType;
 
 namespace Datadog.Trace.RuntimeMetrics;
 
@@ -23,7 +25,7 @@ internal static class GcMetrics
 
     public static ReadOnlyCollection<string> GenNames { get; } = new(new List<string> { "gen0", "gen1", "gen2", "loh", "poh" });
 
-    public static void PushCollectionCounts(IDogStatsd dogStatsd)
+    public static void PushCollectionCounts(ISignalFxMetricSender metricSender)
     {
         long collectionsFromHigherGeneration = 0;
 
@@ -32,7 +34,7 @@ internal static class GcMetrics
             long collectionsFromThisGeneration = GC.CollectionCount(gen);
             var currentValue = collectionsFromThisGeneration - collectionsFromHigherGeneration;
 
-            dogStatsd.Counter(MetricsNames.Gc.CollectionsCount, currentValue, tags: Tags.GenerationTags[gen]);
+            metricSender.SendLong(MetricsNames.Gc.CollectionsCount, currentValue, MetricType.CUMULATIVE_COUNTER, Tags.GenerationTags[gen]);
 
             collectionsFromHigherGeneration = collectionsFromThisGeneration;
         }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
@@ -9,21 +9,12 @@ namespace Datadog.Trace.RuntimeMetrics
 {
     internal static class MetricsNames
     {
-        private const string MetricPrefix = "process.runtime.dotnet.";
-        public const string ExceptionsCount = $"{MetricPrefix}exceptions.count";
+        public const string ExceptionsCount = "process.runtime.dotnet.exceptions.count";
 
         public const string ContentionTime = "runtime.dotnet.threads.contention_time";
-        public const string ContentionCount = $"{MetricPrefix}monitor.lock_contention.count";
+        public const string ContentionCount = "process.runtime.dotnet.monitor.lock_contention.count";
 
-        public const string ThreadPoolWorkersCount = $"{MetricPrefix}thread_pool.threads.count";
-
-        public const string ThreadsCount = "runtime.dotnet.threads.count";
-
-        public const string CommittedMemory = "runtime.dotnet.mem.committed";
-
-        public const string CpuUserTime = "runtime.dotnet.cpu.user";
-        public const string CpuSystemTime = "runtime.dotnet.cpu.system";
-        public const string CpuPercentage = "runtime.dotnet.cpu.percent";
+        public const string ThreadPoolWorkersCount = "process.runtime.dotnet.thread_pool.threads.count";
 
         public const string AspNetCoreCurrentRequests = "runtime.dotnet.aspnetcore.requests.current";
 
@@ -37,11 +28,21 @@ namespace Datadog.Trace.RuntimeMetrics
 
         internal static class Gc
         {
-            public const string CollectionsCount = $"{MetricPrefix}gc.collections.count";
-            public const string HeapSize = $"{MetricPrefix}gc.heap.size";
-            public const string AllocatedBytes = $"{MetricPrefix}gc.allocations.size";
-            public const string HeapCommittedMemory = $"{MetricPrefix}gc.committed_memory.size";
-            public const string PauseTime = $"{MetricPrefix}gc.pause.time";
+            public const string CollectionsCount = "process.runtime.dotnet.gc.collections.count";
+            public const string HeapSize = "process.runtime.dotnet.gc.heap.size";
+            public const string LiveHeapSize = "process.runtime.dotnet.gc.heap.live";
+            public const string AllocatedBytes = "process.runtime.dotnet.gc.allocations.size";
+            public const string HeapCommittedMemory = "process.runtime.dotnet.gc.committed_memory.size";
+            public const string PauseTime = "process.runtime.dotnet.gc.pause.time";
+        }
+
+        internal static class Process
+        {
+            public const string MemoryUsage = "process.memory.usage";
+            public const string MemoryVirtual = "process.memory.virtual";
+            public const string CpuTime = "process.cpu.time";
+            public const string CpuUtilization = "process.cpu.utilization";
+            public const string ThreadsCount = "process.threads";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/SignalFx/Metrics/ISignalFxMetricSender.cs
+++ b/tracer/src/Datadog.Trace/SignalFx/Metrics/ISignalFxMetricSender.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Datadog.Tracer.SignalFx.Metrics.Protobuf;
+
+namespace Datadog.Trace.SignalFx.Metrics;
+
+internal interface ISignalFxMetricSender : IDisposable
+{
+    /// <summary>
+    /// Sends double-valued metric.
+    /// </summary>
+    /// <param name="name">Name of the metric.</param>
+    /// <param name="value">Value of the metric.</param>
+    /// <param name="metricType">Metric type from signalfx proto.</param>
+    /// <param name="tags">Additional tags added to the metric.</param>
+    void SendDouble(string name, double value, MetricType metricType, string[] tags = null);
+
+    /// <summary>
+    /// Sends long-valued metric.
+    /// </summary>
+    /// <param name="name">Name of the metric.</param>
+    /// <param name="value">Value of the metric.</param>
+    /// <param name="metricType">Metric type from signalfx proto.</param>
+    /// <param name="tags">Additional tags added to the metric.</param>
+    void SendLong(string name, long value, MetricType metricType, string[] tags = null);
+}

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, null))
         {
         }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -22,6 +22,7 @@ using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Processors;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 using Datadog.Trace.Util.Http;
@@ -59,6 +60,7 @@ namespace Datadog.Trace
             DirectLogSubmissionManager directLogSubmission,
             ITelemetryController telemetry,
             string defaultServiceName,
+            ISignalFxMetricSender metricSender,
             ITraceProcessor[] traceProcessors = null)
         {
             Settings = settings;
@@ -68,6 +70,7 @@ namespace Datadog.Trace
             Statsd = statsd;
             RuntimeMetrics = runtimeMetricsWriter;
             DefaultServiceName = defaultServiceName;
+            MetricSender = metricSender;
             TraceIdConvention = traceIdConvention;
             DirectLogSubmission = directLogSubmission;
             Telemetry = telemetry;
@@ -133,6 +136,8 @@ namespace Datadog.Trace
         public QueryStringManager QueryStringManager { get; }
 
         public IDogStatsd Statsd { get; }
+
+        public ISignalFxMetricSender MetricSender { get; }
 
         public ITraceProcessor[] TraceProcessors { get; }
 
@@ -208,6 +213,11 @@ namespace Datadog.Trace
                 {
                     statsdReplaced = true;
                     oldManager.Statsd?.Dispose();
+                }
+
+                if (oldManager.MetricSender != newManager.MetricSender)
+                {
+                    oldManager.MetricSender?.Dispose();
                 }
 
                 var runtimeMetricsWriterReplaced = false;

--- a/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Modified by Splunk Inc.
+
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -55,7 +57,6 @@ namespace Datadog.Trace.Util
 
         /// <summary>
         /// Wrapper around <see cref="Process.GetCurrentProcess"/> and its property accesses
-        ///
         /// On .NET Framework the <see cref="Process"/> class is guarded by a
         /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
         /// This exception is thrown when the caller method is being JIT compiled, NOT
@@ -66,8 +67,9 @@ namespace Datadog.Trace.Util
         /// <param name="systemCpuTime">CPU time in kernel mode</param>
         /// <param name="threadCount">Number of threads</param>
         /// <param name="privateMemorySize">Committed memory size</param>
+        /// <param name="workingSet">Working set</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void GetCurrentProcessRuntimeMetrics(out TimeSpan userProcessorTime, out TimeSpan systemCpuTime, out int threadCount, out long privateMemorySize)
+        public static void GetCurrentProcessRuntimeMetrics(out TimeSpan userProcessorTime, out TimeSpan systemCpuTime, out int threadCount, out long privateMemorySize, out long workingSet)
         {
             using var process = Process.GetCurrentProcess();
 
@@ -75,6 +77,7 @@ namespace Datadog.Trace.Util
             systemCpuTime = process.PrivilegedProcessorTime;
             threadCount = process.Threads.Count;
             privateMemorySize = process.PrivateMemorySize64;
+            workingSet = process.WorkingSet64;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/DogStatsdService.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/DogStatsdService.cs
@@ -246,10 +246,6 @@ namespace Datadog.Trace.Vendors.StatsdClient
             _metricsSender?.SendServiceCheck(name, (int)status, timestamp, hostname, tags, message);
         }
 
-        public void IncrementDouble(string statName, double value, double sampleRate = 1, string[] tags = null)
-        {
-        }
-
         /// <summary>
         /// Flushes all metrics.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/IDogStatsd.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/IDogStatsd.cs
@@ -174,14 +174,5 @@ namespace Datadog.Trace.Vendors.StatsdClient
             string hostname = null,
             string[] tags = null,
             string message = null);
-
-        /// <summary>
-        /// Increments the specified double-valued counter.
-        /// </summary>
-        /// <param name="statName">The name of the metric.</param>
-        /// <param name="value">The amount of increment.</param>
-        /// <param name="sampleRate">Percentage of metric to be sent.</param>
-        /// <param name="tags">Array of tags to be added to the data.</param>
-        void IncrementDouble(string statName, double value, double sampleRate = 1, string[] tags = null);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
@@ -7,9 +7,11 @@
 
 using System;
 using Datadog.Trace.RuntimeMetrics;
+using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Trace.Vendors.StatsdClient;
 using Moq;
 using Xunit;
+using MetricType = Datadog.Tracer.SignalFx.Metrics.Protobuf.MetricType;
 
 namespace Datadog.Trace.Tests.RuntimeMetrics
 {
@@ -22,21 +24,21 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                 AzureAppServicePerformanceCounters.EnvironmentVariableName,
                 "{\"bytesInAllHeaps\": 8069304,\"gcHandles\": 6796,\"gen0Collections\": 108,\"gen1Collections\": 76,\"gen2Collections\": 16,\"inducedGC\": 0,\"pinnedObjects\": 20,\"committedBytes\": 17788928,\"reservedBytes\": 50319360,\"timeInGC\": 99342447,\"timeInGCBase\": 385095681,\"allocatedBytes\": 761378928,\"gen0HeapSize\": 8388608,\"gen1HeapSize\": 1448968,\"gen2HeapSize\": 3857504,\"largeObjectHeapSize\": 2762832,\"currentAssemblies\": 104,\"currentClassesLoaded\": 177389,\"exceptionsThrown\": 913,\"appDomains\": 10,\"appDomainsUnloaded\": 8}");
 
-            const double expectedGen0HeapSize = 8388608;
-            const double expectedGen1HeapSize = 1448968;
-            const double expectedGen2HeapSize = 3857504;
-            const double expectedLohHeapSize = 2762832;
+            const long expectedGen0HeapSize = 8388608;
+            const long expectedGen1HeapSize = 1448968;
+            const long expectedGen2HeapSize = 3857504;
+            const long expectedLohHeapSize = 2762832;
 
-            var statsd = new Mock<IDogStatsd>();
+            var statsd = new Mock<ISignalFxMetricSender>();
 
             using var listener = new AzureAppServicePerformanceCounters(statsd.Object);
 
             listener.Refresh();
 
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedGen0HeapSize, 1, new[] { "generation:gen0" }), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedGen1HeapSize, 1, new[] { "generation:gen1" }), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedGen2HeapSize, 1, new[] { "generation:gen2" }), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, expectedLohHeapSize, 1, new[] { "generation:loh" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, expectedGen0HeapSize, MetricType.GAUGE, new[] { "generation:gen0" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, expectedGen1HeapSize, MetricType.GAUGE, new[] { "generation:gen1" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, expectedGen2HeapSize, MetricType.GAUGE, new[] { "generation:gen2" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, expectedLohHeapSize, MetricType.GAUGE, new[] { "generation:loh" }), Times.Once);
 
             statsd.VerifyNoOtherCalls();
         }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
@@ -8,10 +8,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.RuntimeMetrics;
+using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
 using Moq;
 using Xunit;
+using MetricType = Datadog.Tracer.SignalFx.Metrics.Protobuf.MetricType;
 
 namespace Datadog.Trace.Tests.RuntimeMetrics
 {
@@ -20,7 +22,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         [Fact]
         public async Task PushEvents()
         {
-            var statsd = new Mock<IDogStatsd>();
+            var statsd = new Mock<ISignalFxMetricSender>();
 
             using var listener = new PerformanceCountersListener(statsd.Object);
 
@@ -28,12 +30,12 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
             listener.Refresh();
 
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:gen0" }), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:gen1" }), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:gen2" }), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), 1, new[] { "generation:loh" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:gen0" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:gen1" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:gen2" }), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:loh" }), Times.Once);
 
-            statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<long>(), 1, It.IsAny<string[]>()), Times.Once);
+            statsd.Verify(s => s.SendLong(MetricsNames.ContentionCount, It.IsAny<long>(), MetricType.CUMULATIVE_COUNTER, It.IsAny<string[]>()), Times.Once);
 
             statsd.VerifyNoOtherCalls();
         }
@@ -48,7 +50,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                 barrier.SignalAndWait();
             }
 
-            var statsd = new Mock<IDogStatsd>();
+            var statsd = new Mock<ISignalFxMetricSender>();
 
             using var listener = new TestPerformanceCounterListener(statsd.Object, Callback);
 
@@ -72,8 +74,8 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             // The field needs to be volatile because it's used concurrently from two threads
             private volatile Action _callback;
 
-            public TestPerformanceCounterListener(IDogStatsd statsd, Action callback)
-                : base(statsd)
+            public TestPerformanceCounterListener(ISignalFxMetricSender metricSender, Action callback)
+                : base(metricSender)
             {
                 _callback = callback;
             }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -13,9 +13,10 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Threading;
 using Datadog.Trace.RuntimeMetrics;
-using Datadog.Trace.Vendors.StatsdClient;
+using Datadog.Trace.SignalFx.Metrics;
 using Moq;
 using Xunit;
+using MetricType = Datadog.Tracer.SignalFx.Metrics.Protobuf.MetricType;
 
 namespace Datadog.Trace.Tests.RuntimeMetrics
 {
@@ -26,31 +27,31 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         [Fact]
         public void PushEvents()
         {
-            var statsd = new Mock<IDogStatsd>();
+            var metricSender = new Mock<ISignalFxMetricSender>();
 
-            using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(10));
+            using var listener = new RuntimeEventListener(metricSender.Object, TimeSpan.FromSeconds(10));
 
             listener.Refresh();
 
-            statsd.Verify(s => s.Gauge(MetricsNames.ContentionTime, It.IsAny<double>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<long>(), 1, null), Times.Once);
-            statsd.Verify(s => s.Gauge(MetricsNames.ThreadPoolWorkersCount, It.IsAny<double>(), 1, null), Times.Once);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.ContentionTime, It.IsAny<double>(), MetricType.GAUGE, null), Times.Once);
+            metricSender.Verify(s => s.SendLong(MetricsNames.ContentionCount, It.IsAny<long>(), MetricType.CUMULATIVE_COUNTER, null), Times.Once);
+            metricSender.Verify(s => s.SendLong(MetricsNames.ThreadPoolWorkersCount, It.IsAny<long>(), MetricType.GAUGE, null), Times.Once);
         }
 
         [Fact]
         public void MonitorGarbageCollections()
         {
-            var statsd = new Mock<IDogStatsd>();
+            var metricSender = new Mock<ISignalFxMetricSender>();
 
             var mutex = new ManualResetEventSlim();
 
             // TotalPauseTime is pushed on the GcRestartEnd event, which should be the last event for any GC
-            statsd.Setup(s => s.IncrementDouble(MetricsNames.Gc.PauseTime, It.IsAny<double>(), It.IsAny<double>(), It.IsAny<string[]>()))
+            metricSender.Setup(s => s.SendDouble(MetricsNames.Gc.PauseTime, It.IsAny<double>(), MetricType.COUNTER, It.IsAny<string[]>()))
                 .Callback(() => mutex.Set());
 
-            using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(10));
+            using var listener = new RuntimeEventListener(metricSender.Object, TimeSpan.FromSeconds(10));
 
-            statsd.Invocations.Clear();
+            metricSender.Invocations.Clear();
 
             mutex.Reset(); // In case a GC was triggered when creating the listener
 
@@ -63,17 +64,17 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                 throw new TimeoutException("Timed-out waiting for pause times to be reported.");
             }
 
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:gen0" }), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:gen1" }), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:gen2" }), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:loh" }), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:gen0" }), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:gen1" }), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:gen2" }), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:loh" }), Times.AtLeastOnce);
 
-            statsd.Verify(s => s.Counter(MetricsNames.Gc.AllocatedBytes, It.IsAny<long>(), It.IsAny<double>(), It.IsAny<string[]>()), Times.AtLeastOnce);
-            statsd.Verify(s => s.IncrementDouble(MetricsNames.Gc.PauseTime, It.IsAny<double>(), It.IsAny<double>(), It.IsAny<string[]>()), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendLong(MetricsNames.Gc.AllocatedBytes, It.IsAny<long>(), MetricType.CUMULATIVE_COUNTER, It.IsAny<string[]>()), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.Gc.PauseTime, It.IsAny<double>(), MetricType.COUNTER, It.IsAny<string[]>()), Times.AtLeastOnce);
 
 #if NET6_0_OR_GREATER
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapSize, It.IsAny<double>(), It.IsAny<double>(), new[] { "generation:poh" }), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.Gc.HeapCommittedMemory, It.IsAny<double>(), It.IsAny<double>(), It.IsAny<string[]>()), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendLong(MetricsNames.Gc.HeapSize, It.IsAny<long>(), MetricType.GAUGE, new[] { "generation:poh" }), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendLong(MetricsNames.Gc.HeapCommittedMemory, It.IsAny<long>(), MetricType.GAUGE, It.IsAny<string[]>()), Times.AtLeastOnce);
 #endif
         }
 
@@ -104,18 +105,18 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                 new PollingCounter("Dummy", eventSource, callback)
             };
 
-            var statsd = new Mock<IDogStatsd>();
-            using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(1));
+            var metricSender = new Mock<ISignalFxMetricSender>();
+            using var listener = new RuntimeEventListener(metricSender.Object, TimeSpan.FromSeconds(1));
 
             // Wait for the counters to be refreshed
             mutex.Wait();
 
-            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreCurrentRequests, 1.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreFailedRequests, 2.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreTotalRequests, 4.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreRequestQueueLength, 8.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreConnectionQueueLength, 16.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreTotalConnections, 32.0, 1, null), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.AspNetCoreCurrentRequests, 1.0, MetricType.GAUGE, null), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.AspNetCoreFailedRequests, 2.0, MetricType.GAUGE, null), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.AspNetCoreTotalRequests, 4.0, MetricType.GAUGE, null), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.AspNetCoreRequestQueueLength, 8.0, MetricType.GAUGE, null), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.AspNetCoreConnectionQueueLength, 16.0, MetricType.GAUGE, null), Times.AtLeastOnce);
+            metricSender.Verify(s => s.SendDouble(MetricsNames.AspNetCoreTotalConnections, 32.0, MetricType.GAUGE, null), Times.AtLeastOnce);
 
             foreach (var counter in counters)
             {

--- a/tracer/test/Datadog.Trace.Tests/SignalFx/Metrics/SignalFxMetricSenderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SignalFx/Metrics/SignalFxMetricSenderTests.cs
@@ -2,6 +2,7 @@
 using Datadog.Trace.SignalFx.Metrics;
 using Datadog.Tracer.SignalFx.Metrics.Protobuf;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.SignalFx.Metrics
@@ -9,14 +10,14 @@ namespace Datadog.Trace.Tests.SignalFx.Metrics
     public class SignalFxMetricSenderTests
     {
         [Fact]
-        public void Gauge_metric_types_are_sent()
+        public void Gauge_double_metrics_are_sent()
         {
-            var reporter = new TestWriter();
-            var sender = new SignalFxMetricSender(reporter, new[] { "tag1:v1" });
+            var testWriter = new TestWriter();
+            var sender = new SignalFxMetricSender(new[] { "tag1:v1" }, Mock.Of<ISignalFxMetricExporter>(), 100, (_, _) => testWriter);
 
-            sender.SendGaugeMetric("test_metric", 1.11, tags: new[] { "tag2:v2" });
+            sender.SendDouble("test_metric", 1.11, MetricType.GAUGE, new[] { "tag2:v2" });
 
-            var dataPointUploadMessages = reporter.SentMessages;
+            var dataPointUploadMessages = testWriter.SentMessages;
             dataPointUploadMessages.Should().HaveCount(1);
             var dataPoint = dataPointUploadMessages[0];
 
@@ -27,14 +28,50 @@ namespace Datadog.Trace.Tests.SignalFx.Metrics
         }
 
         [Fact]
-        public void Counter_metric_types_are_sent()
+        public void Gauge_long_metrics_are_sent()
         {
-            var reporter = new TestWriter();
-            var sender = new SignalFxMetricSender(reporter, new[] { "tag1:v1" });
+            var testWriter = new TestWriter();
+            var sender = new SignalFxMetricSender(new[] { "tag1:v1" }, Mock.Of<ISignalFxMetricExporter>(), 100, (_, _) => testWriter);
 
-            sender.SendCounterMetric("test_metric", 1, tags: new[] { "tag2:v2" });
+            sender.SendLong("test_metric", 1, MetricType.GAUGE, new[] { "tag2:v2" });
 
-            var dataPointUploadMessages = reporter.SentMessages;
+            var dataPointUploadMessages = testWriter.SentMessages;
+            dataPointUploadMessages.Should().HaveCount(1);
+            var dataPoint = dataPointUploadMessages[0];
+
+            AssertCommon(dataPoint);
+
+            dataPoint.value.intValue.Should().Be(1);
+            dataPoint.metricType.Should().Be(MetricType.GAUGE);
+        }
+
+        [Fact]
+        public void Counter_double_metrics_are_sent()
+        {
+            var testWriter = new TestWriter();
+            var sender = new SignalFxMetricSender(new[] { "tag1:v1" }, Mock.Of<ISignalFxMetricExporter>(), 100, (_, _) => testWriter);
+
+            sender.SendDouble("test_metric", 1.11, MetricType.COUNTER, new[] { "tag2:v2" });
+
+            var dataPointUploadMessages = testWriter.SentMessages;
+            dataPointUploadMessages.Should().HaveCount(1);
+            var dataPoint = dataPointUploadMessages[0];
+
+            AssertCommon(dataPoint);
+
+            dataPoint.value.doubleValue.Should().Be(1.11);
+            dataPoint.metricType.Should().Be(MetricType.COUNTER);
+        }
+
+        [Fact]
+        public void Counter_long_metrics_are_sent()
+        {
+            var testWriter = new TestWriter();
+            var sender = new SignalFxMetricSender(new[] { "tag1:v1" }, Mock.Of<ISignalFxMetricExporter>(), 100, (_, _) => testWriter);
+
+            sender.SendLong("test_metric", 1, MetricType.COUNTER, new[] { "tag2:v2" });
+
+            var dataPointUploadMessages = testWriter.SentMessages;
             dataPointUploadMessages.Should().HaveCount(1);
             var dataPoint = dataPointUploadMessages[0];
 
@@ -45,14 +82,14 @@ namespace Datadog.Trace.Tests.SignalFx.Metrics
         }
 
         [Fact]
-        public void Cumulative_counter_metric_types_are_sent()
+        public void Cumulative_counter_metrics_are_sent()
         {
-            var reporter = new TestWriter();
-            var sender = new SignalFxMetricSender(reporter, new[] { "tag1:v1" });
+            var testWriter = new TestWriter();
+            var sender = new SignalFxMetricSender(new[] { "tag1:v1" }, Mock.Of<ISignalFxMetricExporter>(), 100, (_, _) => testWriter);
 
-            sender.SendCumulativeCounterMetric("test_metric", 1, tags: new[] { "tag2:v2" });
+            sender.SendLong("test_metric", 1, MetricType.CUMULATIVE_COUNTER, new[] { "tag2:v2" });
 
-            var dataPointUploadMessages = reporter.SentMessages;
+            var dataPointUploadMessages = testWriter.SentMessages;
             dataPointUploadMessages.Should().HaveCount(1);
             var dataPoint = dataPointUploadMessages[0];
 


### PR DESCRIPTION
## Why

Align process metrics implementation with [otel](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Process).

## What

- modify process metrics implementation to match otel
- cleanup disposal for runtime metrics dependencies
- use `ISignalfxMetricSender` directly instead of through `SignalFxStats` in `RuntimeMetricsWriter`
- inline metric prefix for better discoverability
- revert previous changes to vendored code
- `SignalFxStats` used only for tracer metrics

## Tests

Included in PR + existing tests.
