### PR TITLE
[Runtime Metrics] Enable runtime metrics with memory profiling

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,6 +10,8 @@ to Splunk Observability Cloud.
 To enable runtime metrics, set the `SIGNALFX_RUNTIME_METRICS_ENABLED` environment
 variable to `true` for your .NET process.
 
+> Runtime metrics are automatically enabled when [AlwaysOn memory profiling](internal/memory-profiling.md) is enabled. 
+
 The following metrics are collected by default after enabling .NET metrics.
 To learn about differences between SignalFx metric types, visit [documentation](https://docs.splunk.com/Observability/metrics-and-metadata/metric-types.html#metric-types).
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,7 +10,7 @@ to Splunk Observability Cloud.
 To enable runtime metrics, set the `SIGNALFX_RUNTIME_METRICS_ENABLED` environment
 variable to `true` for your .NET process.
 
-> Runtime metrics are automatically enabled when [AlwaysOn memory profiling](internal/memory-profiling.md) is enabled. 
+> Runtime metrics are automatically enabled when [AlwaysOn memory profiling](internal/memory-profiling.md) is enabled. Memory profiling setting overrides metrics setting (runtime metrics will always be enabled if memory profiling is enabled, even if `SIGNALFX_RUNTIME_METRICS_ENABLED` is set to `false`). 
 
 The following metrics are collected by default after enabling .NET metrics.
 To learn about differences between SignalFx metric types, visit [documentation](https://docs.splunk.com/Observability/metrics-and-metadata/metric-types.html#metric-types).

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -123,9 +123,6 @@ namespace Datadog.Trace.Configuration
 
             StatsComputationEnabled = source?.GetBool(ConfigurationKeys.StatsComputationEnabled) ?? false;
 
-            RuntimeMetricsEnabled = source?.GetBool(ConfigurationKeys.RuntimeMetricsEnabled) ??
-                                    false;
-
             CustomSamplingRules = source?.GetString(ConfigurationKeys.CustomSamplingRules);
 
             GlobalSamplingRate = source?.GetDouble(ConfigurationKeys.GlobalSamplingRate);
@@ -197,7 +194,11 @@ namespace Datadog.Trace.Configuration
 
             // If you change this, change environment_variables.h too
             CpuProfilingEnabled = source?.GetBool(ConfigurationKeys.AlwaysOnProfiler.CpuEnabled) ?? false;
-            MemoryProfilingEnabled = source?.GetBool(ConfigurationKeys.AlwaysOnProfiler.MemoryEnabled) ?? false;
+            var memoryProfilingEnabled = source?.GetBool(ConfigurationKeys.AlwaysOnProfiler.MemoryEnabled) ?? false;
+            MemoryProfilingEnabled = memoryProfilingEnabled;
+            var runtimeMetricsExplicitlyEnabled = source?.GetBool(ConfigurationKeys.RuntimeMetricsEnabled) ??
+                                        false;
+            RuntimeMetricsEnabled = runtimeMetricsExplicitlyEnabled || memoryProfilingEnabled;
             ThreadSamplingPeriod = GetThreadSamplingPeriod(source);
 
             LogSubmissionSettings = new DirectLogSubmissionSettings(source);

--- a/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -107,6 +107,24 @@ namespace Datadog.Trace.Tests
         }
 
         [Theory]
+        [InlineData("1", "0", true)]
+        [InlineData("0", "1", true)]
+        [InlineData("0", "0", false)]
+        [InlineData("1", "1", true)]
+        public void EnableRuntimeMetrics(string metricsExplicitlyEnabled, string memoryProfilingEnabled, bool expected)
+        {
+            var settings = new NameValueCollection
+            {
+                { ConfigurationKeys.RuntimeMetricsEnabled, metricsExplicitlyEnabled },
+                { ConfigurationKeys.AlwaysOnProfiler.MemoryEnabled, memoryProfilingEnabled }
+            };
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings));
+
+            Assert.Equal(expected, tracerSettings.RuntimeMetricsEnabled);
+        }
+
+        [Theory]
         [InlineData("a,b,c,d,,f", new[] { "a", "b", "c", "d", "f" })]
         [InlineData(" a, b ,c, ,,f ", new[] { "a", "b", "c", "f" })]
         [InlineData("a,b, c ,d,      e      ,f  ", new[] { "a", "b", "c", "d", "e", "f" })]

--- a/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -111,6 +111,8 @@ namespace Datadog.Trace.Tests
         [InlineData("0", "1", true)]
         [InlineData("0", "0", false)]
         [InlineData("1", "1", true)]
+        [InlineData(null, "1", true)]
+        [InlineData(null, null, false)]
         public void EnableRuntimeMetrics(string metricsExplicitlyEnabled, string memoryProfilingEnabled, bool expected)
         {
             var settings = new NameValueCollection


### PR DESCRIPTION
## Why

Enable runtime metrics when memory profiling is enabled.

## What

- consider memory profiling configuration when enabling runtime metrics
- update `metrics.md`

## Tests

Included in PR.
