### PR TITLE
Bump .NET to 6.0.402

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   buildConfiguration: Release
-  dotnetSdkVersion: 6.0.401
+  dotnetSdkVersion: 6.0.402
   relativeTracerHome: /shared/bin/monitoring-home/tracer
   relativeArtifacts: /tracer/src/bin/artifacts
   binDir: ${{ github.workspace }}/tracer/src/bin
@@ -74,9 +74,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -129,9 +129,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: Build Docker image
       run: |
         docker build \
@@ -175,9 +175,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - run: ./tracer/build.cmd Clean BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v3.1.1
       with:
@@ -200,9 +200,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: Build Docker image
       run: |
         docker build \
@@ -246,9 +246,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -271,9 +271,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: Build Docker image
       run: |
         docker build \
@@ -320,9 +320,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
     #   if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
@@ -379,9 +379,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: Build Docker image
       run: |
         docker build \
@@ -440,9 +440,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
@@ -489,9 +489,9 @@ jobs:
       with:
         dotnet-version: |
           2.1.818
-          3.1.423
+          3.1.424
           5.0.408
-          6.0.401
+          6.0.402
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     env:
       baseImage: ${{ matrix.baseImage }}
-      dotnetSdkVersion: 6.0.401
+      dotnetSdkVersion: 6.0.402
     steps:
     - uses: actions/checkout@v3.1.0
     - name: Build Docker image
@@ -52,9 +52,9 @@ jobs:
         with:
           dotnet-version: | 
             2.1.818
-            3.1.423
+            3.1.424
             5.0.408
-            6.0.401
+            6.0.402
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Upload Windows MSI

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v3.0.2
         with:
-          dotnet-version: '6.0.401'
+          dotnet-version: '6.0.402'
 
       - name: "Removing existing generated files"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace\Generated" -Recurse -File | Remove-Item

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ linux-build:
     matrix:
       - baseImage: [ alpine, debian ]
   variables:
-    dotnetSdkVersion: 6.0.401
+    dotnetSdkVersion: 6.0.402
   script:
     - |
       rm .dockerignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -487,7 +487,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.402}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
     volumes:
@@ -510,7 +510,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.402}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -583,7 +583,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.402}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -640,7 +640,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.401}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.402}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="signalfx-dotnet-tracing/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=6.0.401 \
+   --build-arg DOTNETSDK_VERSION=6.0.402 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/centos7.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
## Why

Keep in sync with latest release

## What

Bump .NET to 6.0.402 and 3.1.424

## Tests

CI
