### PR TITLE
Rename FOSSA stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ include:
 stages:
   - build
   - sign
-  - verify
+  - fossa-scan
   - checksum
   - checksum-sign
   - run-overhead-test
@@ -184,7 +184,7 @@ run-overhead-test:
     - ./overhead-test/provision/create-results-pr.sh
 
 oss-scan:
-  stage: verify
+  stage: fossa-scan
   rules:
     - if: '$CI_COMMIT_REF_NAME == "main"'
   extends: .oss-scan


### PR DESCRIPTION
## Why

Give a more meaningful name to the FOSSA stage.

## What

Just renamed the stage.

## Tests

Manually validated the new name on gitlab UI.