### PR TITLE
Update .NET7.0 to stable version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ on:
 
 env:
   buildConfiguration: Release
-  dotnetSdkVersion: 7.0.100-rc.2.22477.23
-  dotnetSdkImageVersion: 7.0.100-rc.2
+  dotnetSdkVersion: 7.0.100
   relativeTracerHome: /shared/bin/monitoring-home/tracer
   relativeArtifacts: /tracer/src/bin/artifacts
   binDir: ${{ github.workspace }}/tracer/src/bin
@@ -78,7 +77,7 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -134,12 +133,11 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: Build Docker image
       run: |
         docker build \
           --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
-          --build-arg DOTNETSDKIMAGE_VERSION=${dotnetSdkImageVersion} \
           --tag dd-trace-dotnet/${{ matrix.base-image }}-builder \
           --target builder \
           --file "./tracer/build/_build/docker/${{ matrix.base-image }}.dockerfile" \
@@ -182,7 +180,7 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - run: ./tracer/build.cmd Clean BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v3.1.1
       with:
@@ -208,12 +206,11 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: Build Docker image
       run: |
         docker build \
           --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
-          --build-arg DOTNETSDKIMAGE_VERSION=${dotnetSdkImageVersion} \
           --tag dd-trace-dotnet/${{ matrix.base-image }}-tester \
           --target tester \
           --file "./tracer/build/_build/docker/${{ matrix.base-image }}.dockerfile" \
@@ -256,7 +253,7 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
       run: curl -sL https://cmake.org/files/v3.19/cmake-3.19.8-Linux-x86_64.sh -o cmakeinstall.sh && chmod +x cmakeinstall.sh && sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
@@ -282,12 +279,11 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: Build Docker image
       run: |
         docker build \
           --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
-          --build-arg DOTNETSDKIMAGE_VERSION=${dotnetSdkImageVersion} \
           --tag dd-trace-dotnet/${{ matrix.base-image }}-builder \
           --target builder \
           --file "./tracer/build/_build/docker/${{ matrix.base-image }}.dockerfile" \
@@ -333,7 +329,7 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
     #   if: ${{ matrix.target == 'BuildAndRunWindowsIntegrationTests' }}
@@ -393,12 +389,11 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: Build Docker image
       run: |
         docker build \
           --build-arg DOTNETSDK_VERSION=${dotnetSdkVersion} \
-          --build-arg DOTNETSDKIMAGE_VERSION=${dotnetSdkImageVersion} \
           --tag dd-trace-dotnet/${{ matrix.base-image }}-builder \
           --target builder \
           --file "./tracer/build/_build/docker/${{ matrix.base-image }}.dockerfile" \
@@ -456,7 +451,7 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
@@ -506,7 +501,7 @@ jobs:
           3.1.424
           5.0.408
           6.0.402
-          7.0.100-rc.2.22477.23
+          7.0.100
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
@@ -130,9 +130,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: Build Docker image
       run: |
@@ -177,9 +177,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - run: ./tracer/build.cmd Clean BuildTracerHome BuildAndRunManagedUnitTests
     - uses: actions/upload-artifact@v3.1.1
@@ -203,9 +203,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: Build Docker image
       run: |
@@ -250,9 +250,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: Install CMake 3.19.8
       if: ${{ runner.os == 'Linux' }}
@@ -276,9 +276,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: Build Docker image
       run: |
@@ -326,9 +326,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
     # - name: Start CosmosDB Emulator
@@ -386,9 +386,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: Build Docker image
       run: |
@@ -448,9 +448,9 @@ jobs:
       with:
         dotnet-version: | 
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |
@@ -498,9 +498,9 @@ jobs:
       with:
         dotnet-version: |
           2.1.818
-          3.1.424
+          3.1.425
           5.0.408
-          6.0.402
+          6.0.403
           7.0.100
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
       run: |

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -52,9 +52,9 @@ jobs:
         with:
           dotnet-version: | 
             2.1.818
-            3.1.424
+            3.1.425
             5.0.408
-            6.0.402
+            6.0.403
             7.0.100
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     env:
       baseImage: ${{ matrix.baseImage }}
-      dotnetSdkVersion: 7.0.100-rc.2
+      dotnetSdkVersion: 7.0.100
     steps:
     - uses: actions/checkout@v3.1.0
     - name: Build Docker image
@@ -55,7 +55,7 @@ jobs:
             3.1.424
             5.0.408
             6.0.402
-            7.0.100-rc.2.22477.23
+            7.0.100
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome
         shell: cmd
       - name: Upload Windows MSI

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: '7.0.100-rc.2.22477.23'
+          dotnet-version: '7.0.100'
 
       - name: "Removing existing generated files"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace\Generated" -Recurse -File | Remove-Item

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ linux-build:
     matrix:
       - baseImage: [ alpine, debian ]
   variables:
-    dotnetSdkVersion: 7.0.100-rc.2
+    dotnetSdkVersion: 7.0.100
   script:
     - |
       rm .dockerignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -487,8 +487,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100-rc.2.22477.23}
-        - DOTNETSDKIMAGE_VERSION=${dotnetCoreSdkLatestImageVersion:-7.0.100-rc.2}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
     volumes:
@@ -511,8 +510,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100-rc.2.22477.23}
-        - DOTNETSDKIMAGE_VERSION=${dotnetCoreSdkLatestImageVersion:-7.0.100-rc.2}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -585,8 +583,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100-rc.2.22477.23}
-        - DOTNETSDKIMAGE_VERSION=${dotnetCoreSdkLatestImageVersion:-7.0.100-rc.2}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -643,8 +640,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100-rc.2.22477.23}
-        - DOTNETSDKIMAGE_VERSION=${dotnetCoreSdkLatestImageVersion:-7.0.100-rc.2}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,5 +1,5 @@
-ARG DOTNETSDKIMAGE_VERSION
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDKIMAGE_VERSION-alpine3.16 as base
+ARG DOTNETSDK_VERSION
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.16 as base
 
 # SECURITY NOTE: Exception is made for APK packages, 
 # no need to lock versions
@@ -44,13 +44,13 @@ FROM base as tester
 # Install .NET Core runtimes using install script
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "aaa889cd9fd06f098144fc065db3ab8525133666d9a21c2ca45017aabfef4d23  dotnet-install.sh" | sha256sum -c \
+    && echo "2c51739e843231e9829a777fc6038e50b31d420e12a593edb9e858d3587ea361  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime aspnetcore --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.0.3 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 3.1.30 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh --runtime aspnetcore --version 3.1.31 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 5.0.17 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 6.0.10 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh --runtime aspnetcore --version 6.0.11 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 # Copy the build project in and build it

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update \
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "aaa889cd9fd06f098144fc065db3ab8525133666d9a21c2ca45017aabfef4d23  dotnet-install.sh" | sha256sum -c \
+    && echo "2c51739e843231e9829a777fc6038e50b31d420e12a593edb9e858d3587ea361  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
     && rm ./dotnet-install.sh \
@@ -79,13 +79,13 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     fi \
     && curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "aaa889cd9fd06f098144fc065db3ab8525133666d9a21c2ca45017aabfef4d23  dotnet-install.sh" | sha256sum -c \
+    && echo "2c51739e843231e9829a777fc6038e50b31d420e12a593edb9e858d3587ea361  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime $NETCORERUNTIME2_1 --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.0.3 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 3.1.30 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh --runtime aspnetcore --version 3.1.31 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 5.0.17 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 6.0.10 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh --runtime aspnetcore --version 6.0.11 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="signalfx-dotnet-tracing/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=7.0.100-rc.2 \
+   --build-arg DOTNETSDK_VERSION=7.0.100 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/centos7.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
## Why

MS just released stable, we can drop testing with RC.

## What

Update .NET7.0 to stable version

## Tests

CI
