### PR TITLE
[AlwaysOnProfiler] enable stack snapshots when only allocation profiling is enabled

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -178,7 +178,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // get ICorProfilerInfo12 for >= .NET 5.0
     ICorProfilerInfo12* info12 = nullptr;
     hr = info_->QueryInterface(__uuidof(ICorProfilerInfo12), (void**) &info12);
-
     if (SUCCEEDED(hr))
     {
         Logger::Debug("Interface ICorProfilerInfo12 found.");

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -203,7 +203,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
                        COR_PRF_MONITOR_MODULE_LOADS | COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS |
                        COR_PRF_ENABLE_REJIT;
 
-    if (IsThreadSamplingEnabled() && metThreadSamplingRequirements || IsAllocationSamplingEnabled() && metAllocationSamplingRequirements)
+    if ((IsThreadSamplingEnabled() && metThreadSamplingRequirements) || (IsAllocationSamplingEnabled() && metAllocationSamplingRequirements))
     {
         event_mask |= COR_PRF_MONITOR_THREADS | COR_PRF_ENABLE_STACK_SNAPSHOT;
     }


### PR DESCRIPTION
## Why

Enable stack snapshots when only allocation profiling is enabled.

## What

Set required flags to be able to do stack snapshots when only allocation profiling is enabled. 
DoStackSnapshot returns [CORPROF_E_INCONSISTENT_WITH_FLAGS](https://github.com/dotnet/runtime/blob/db213657acc53fc48212867d5728e83d9e36a558/src/coreclr/inc/corerror.xml#L1091) which results in empty stack traces when additional flags are not set.


