### PR TITLE
[Overhead tests] Add memory profiling configuration

### DIFF
--- a/overhead-test/src/Configs/AgentConfig.cs
+++ b/overhead-test/src/Configs/AgentConfig.cs
@@ -19,23 +19,42 @@ internal class AgentConfig
             new("SIGNALFX_PROFILER_ENABLED", "0")
         });
 
-    public static readonly AgentConfig Profiled = new(
+    public static readonly AgentConfig CpuProfiled = new(
         "signalfx-dotnet-with-profiling-10s",
-        "signalfx dotnet with tracing and default profiling frequency (every 10s)",
+        "signalfx dotnet with tracing and default CPU profiling frequency (every 10s)",
         InstrumentedImageName,
         new EnvVar[]
         {
             new("SIGNALFX_PROFILER_ENABLED", "1")
         });
 
-    public static readonly AgentConfig ProfiledHighFrequency = new(
+    public static readonly AgentConfig CpuProfiledHighFrequency = new(
         "signalfx-dotnet-with-profiling-1s",
-        "signalfx dotnet with tracing and max profiling frequency (every 1s)",
+        "signalfx dotnet with tracing and max CPU profiling frequency (every 1s)",
         InstrumentedImageName,
         new EnvVar[]
         {
             new("SIGNALFX_PROFILER_ENABLED", "1"),
             new("SIGNALFX_PROFILER_CALL_STACK_INTERVAL", "1000")
+        });
+
+    public static readonly AgentConfig MemoryProfiled = new(
+        "signalfx-dotnet-with-mem-profiling",
+        "signalfx dotnet with tracing and memory profiling",
+        InstrumentedImageName,
+        new EnvVar[]
+        {
+            new("SIGNALFX_PROFILER_MEMORY_ENABLED", "1")
+        });
+
+    public static readonly AgentConfig CpuAndMemoryProfiled = new(
+        "signalfx-dotnet-with-cpu-and-mem-profiling",
+        "signalfx dotnet with tracing, CPU and memory profiling",
+        InstrumentedImageName,
+        new EnvVar[]
+        {
+            new("SIGNALFX_PROFILER_MEMORY_ENABLED", "1"),
+            new("SIGNALFX_PROFILER_ENABLED", "1"),
         });
 
     private const string BaseImageName = "eshop-app-dc";

--- a/overhead-test/src/Configs/TestConfig.cs
+++ b/overhead-test/src/Configs/TestConfig.cs
@@ -13,8 +13,9 @@ internal class TestConfig
             {
                 AgentConfig.Baseline,
                 AgentConfig.Instrumented,
-                AgentConfig.Profiled,
-                AgentConfig.ProfiledHighFrequency
+                AgentConfig.CpuProfiled,
+                AgentConfig.MemoryProfiled,
+                AgentConfig.CpuAndMemoryProfiled,
             },
             8500,
             30,

--- a/overhead-test/src/Containers/CollectorBase.cs
+++ b/overhead-test/src/Containers/CollectorBase.cs
@@ -12,6 +12,7 @@ internal abstract class CollectorBase : IAsyncDisposable
 
     protected const int TraceReceiverPort = 9411;
     protected const int LogReceiverPort = 4318;
+    protected const int MetricReceiverPort = 9943;
     protected readonly Stream Stream;
 
     protected CollectorBase(DirectoryInfo resultsDirectory)
@@ -25,6 +26,7 @@ internal abstract class CollectorBase : IAsyncDisposable
 
     internal string TraceReceiverUrl => $"http://{Address}:{TraceReceiverPort}/api/v2/spans";
     internal string LogsReceiverUrl => $"http://{Address}:{LogReceiverPort}/v1/logs";
+    internal string MetricsReceiverUrl => $"http://{Address}:{MetricReceiverPort}/v2/datapoint";
 
     public async ValueTask DisposeAsync()
     {

--- a/overhead-test/src/Containers/EshopApp.cs
+++ b/overhead-test/src/Containers/EshopApp.cs
@@ -49,6 +49,7 @@ internal class EshopApp : IAsyncDisposable
             .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
             .WithEnvironment("SIGNALFX_ENDPOINT_URL", collector.TraceReceiverUrl)
             .WithEnvironment("SIGNALFX_PROFILER_LOGS_ENDPOINT", collector.LogsReceiverUrl)
+            .WithEnvironment("SIGNALFX_METRICS_ENDPOINT_URL", collector.MetricsReceiverUrl)
             .WithEnvironment("SIGNALFX_PROFILER_EXCLUDE_PROCESSES", "dotnet-counters")
             .WithEnvironment("SIGNALFX_TRACE_BUFFER_SIZE", "3000")
             .WithEnvironment("ConnectionStrings__CatalogConnection", sqlServer.CatalogConnection)

--- a/overhead-test/src/Docker/otel-config.yaml
+++ b/overhead-test/src/Docker/otel-config.yaml
@@ -3,6 +3,7 @@ extensions:
 
 receivers:
   zipkin:
+  signalfx:
   otlp:
     protocols:
       grpc:
@@ -19,6 +20,10 @@ service:
   pipelines:
     traces:
       receivers: [ zipkin ]
+      processors: [ batch ]
+      exporters: [ logging ]
+    metrics:
+      receivers: [ signalfx ]
       processors: [ batch ]
       exporters: [ logging ]
     logs:

--- a/overhead-test/web/data-client.js
+++ b/overhead-test/web/data-client.js
@@ -8,10 +8,10 @@ async function getRuns(){
         .then(body => body.split("\n").filter(x => x !== 'index.txt'));
 }
 
-async function getResults(name){
+async function getResults(name, config){
     return fetch(`${RESULTS_DIR}/${name}/results.csv`)
         .then(resp => resp.text())
-        .then(body => parseCsv(body))
+        .then(body => parseCsv(body, config))
         .then(data => {
             const aggregated = aggregateRunData(data);
             console.log(aggregated)

--- a/overhead-test/web/data-util.js
+++ b/overhead-test/web/data-util.js
@@ -21,7 +21,7 @@
  */
 function parseCsv(body, config) {
     const runs = parseRuns(body);
-    const agents = body.split('\n')[0].split(',').slice(1).map(x => x.replace(/:.*/, '')).slice(0, config.agents.length);
+    const agents = config.agents.map(config => config.name);
     console.log(agents);
     return {
         agents: agents,

--- a/overhead-test/web/data-util.js
+++ b/overhead-test/web/data-util.js
@@ -19,9 +19,9 @@
  *   ]
  * }
  */
-function parseCsv(body) {
+function parseCsv(body, config) {
     const runs = parseRuns(body);
-    const agents = body.split('\n')[0].split(',').slice(1).map(x => x.replace(/:.*/, '')).slice(0, 4);
+    const agents = body.split('\n')[0].split(',').slice(1).map(x => x.replace(/:.*/, '')).slice(0, config.agents.length);
     console.log(agents);
     return {
         agents: agents,

--- a/overhead-test/web/overhead.js
+++ b/overhead-test/web/overhead.js
@@ -2,8 +2,10 @@
 const MARKETING_NAMES = {
     'none': 'Not instrumented',
     'signalfx-dotnet': 'SignalFx Instrumentation for .NET',
-    'signalfx-dotnet-with-profiling-10s': 'SignalFx Instrumentation for .NET with AlwaysOn Profiling',
-    'signalfx-dotnet-with-profiling-1s': 'SignalFx Instrumentation for .NET with AlwaysOn Profiling - high frequency sampling'
+    'signalfx-dotnet-with-profiling-10s': 'SignalFx Instrumentation for .NET with AlwaysOn CPU Profiling',
+    'signalfx-dotnet-with-profiling-1s': 'SignalFx Instrumentation for .NET with AlwaysOn CPU Profiling - high frequency sampling',
+    'signalfx-dotnet-with-mem-profiling': 'SignalFx Instrumentation for .NET with AlwaysOn Memory Profiling',
+    'signalfx-dotnet-with-cpu-and-mem-profiling' : 'SignalFx Instrumentation for .NET with AlwaysOn CPU and Memory Profiling'
 }
 
 async function startOverhead() {
@@ -23,7 +25,7 @@ async function testRunChosen() {
     const value = document.getElementById('test-run').value;
     console.log(`selection changed ${value}`);
     const config = await getConfig(value);
-    const results = await getResults(value)
+    const results = await getResults(value, config)
     addOverview(config);
     addCharts(results);
 }


### PR DESCRIPTION
## Why

Add memory profiling configuration to overhead tests.

## What

- add memory profiling configuration
- adjust naming
- adjust dashboard code to changed number of configurations

