### PR TITLE
Separate thread sampling and export intervals

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -158,7 +158,8 @@ of SignalFx Instrumentation for .NET.
 |-|-|-|
 | `SIGNALFX_PROFILER_LOGS_ENDPOINT` | The URL to where logs are exported using [OTLP/HTTP v1 log protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) | `http://localhost:4318/v1/logs` |
 | `SIGNALFX_PROFILER_ENABLED` | Enable to activate thread sampling. | `false` |
-| `SIGNALFX_PROFILER_CALL_STACK_INTERVAL` | Sampling period. It defines how often the threads are stopped in order to fetch all stack traces. This value cannot be lower than `1000` milliseconds. | `10000` |
+| `SIGNALFX_PROFILER_CALL_STACK_INTERVAL` | Sampling period in milliseconds. It defines how often the threads are stopped in order to fetch all stack traces. This value cannot be lower than `1000` milliseconds. | `10000` |
+| `SIGNALFX_PROFILER_EXPORT_INTERVAL` | Profiling exporter interval in milliseconds. It defines how often the profiling data is sent to the collector. If the CPU profiling is enabled this value will automatically be set to match `SIGNALFX_PROFILER_CALL_STACK_INTERVAL` | `10000` |
 
 ## Including query string settings
 
@@ -172,6 +173,6 @@ This feature is ASP.NET Core only.
 
 [^regex]: Query string obfuscation default regex:
 
-    ```txt
-    ((?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:""|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:""|%22)(?:%2[^2]|%[^2]|[^""%])+(?:""|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,})`
-    ```
+```txt
+((?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:""|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:""|%22)(?:%2[^2]|%[^2]|[^""%])+(?:""|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,})`
+```

--- a/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
+++ b/tracer/src/Datadog.Trace/AlwaysOnProfiler/ThreadSampler.cs
@@ -23,13 +23,13 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ThreadSampler));
 
-        private static void SampleReadingThread(INativeBufferExporter nativeBufferExporter, TimeSpan samplingPeriod)
+        private static void SampleReadingThread(INativeBufferExporter nativeBufferExporter, TimeSpan exportInterval)
         {
             var buffer = new byte[BufferSize];
 
             while (true)
             {
-                Thread.Sleep(samplingPeriod);
+                Thread.Sleep(exportInterval);
                 nativeBufferExporter.Export(buffer);
             }
         }
@@ -65,7 +65,7 @@ namespace Datadog.Trace.AlwaysOnProfiler
 
             var thread = new Thread(() =>
             {
-                SampleReadingThread(bufferExporter, tracerSettings.ThreadSamplingPeriod);
+                SampleReadingThread(bufferExporter, tracerSettings.ProfilerExportInterval);
             })
             {
                 Name = BackgroundThreadName,

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -566,7 +566,16 @@ namespace Datadog.Trace.Configuration
             /// The default value is 10000 milliseconds.
             /// </summary>
             /// <seealso cref="TracerSettings.ThreadSamplingPeriod"/>
-            public const string Period = "SIGNALFX_PROFILER_CALL_STACK_INTERVAL";
+            public const string ThreadSamplingPeriod = "SIGNALFX_PROFILER_CALL_STACK_INTERVAL";
+
+            /// <summary>
+            /// Configuration key to set default profiling data export interval.
+            /// If CPU profiling is enables this value should match ThreadSamplingPeriod.
+            /// The default value is 10000 milliseconds.
+            /// </summary>
+            /// <seealso cref="ConfigurationKeys.AlwaysOnProfiler.ThreadSamplingPeriod"/>
+            /// <seealso cref="TracerSettings.ProfilerExportInterval"/>
+            public const string ExportInterval = "SIGNALFX_PROFILER_EXPORT_INTERVAL";
 
             /// <summary>
             /// Configuration key to set export format.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -83,6 +83,8 @@ namespace Datadog.Trace.Configuration
             CpuProfilingEnabled = settings.CpuProfilingEnabled;
             MemoryProfilingEnabled = settings.MemoryProfilingEnabled;
             ThreadSamplingPeriod = settings.ThreadSamplingPeriod;
+            ProfilerExportInterval = CpuProfilingEnabled ? ThreadSamplingPeriod : settings.ProfilerExportInterval;
+
             LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings);
             // Logs injection is enabled by default if direct log submission is enabled, otherwise disabled by default
             LogsInjectionEnabled = settings.LogSubmissionSettings.LogsInjectionEnabled ?? LogSubmissionSettings.IsEnabled;
@@ -371,6 +373,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value for the thread sampling period.
         /// </summary>
         public TimeSpan ThreadSamplingPeriod { get; }
+
+        /// <summary>
+        /// Gets a value for the profiler export interval.
+        /// </summary>
+        internal TimeSpan ProfilerExportInterval { get; }
 
         /// <summary>
         /// Gets a value indicating whether to enable the updated WCF instrumentation that delays execution

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -560,6 +560,15 @@ namespace Datadog.Trace.Configuration
         internal TimeSpan ThreadSamplingPeriod { get; set; }
 
         /// <summary>
+        /// Gets or sets a value for the profiling data export interval.
+        /// The default value is 1000 milliseconds.
+        /// If CPU profiling is enables this value should match ThreadSamplingPeriod.
+        /// </summary>
+        /// <seealso cref="TracerSettings.ProfilerExportInterval"/>
+        /// <seealso cref="TracerSettings.ThreadSamplingPeriod"/>
+        internal TimeSpan ProfilerExportInterval { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the feature flag to enable the updated ASP.NET resource names is enabled
         /// </summary>
         /// <seealso cref="ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled"/>
@@ -754,7 +763,7 @@ namespace Datadog.Trace.Configuration
         {
             // If you change any of these constants, check with always_on_profiler.cpp first
             int period = source.SafeReadInt32(
-                key: ConfigurationKeys.AlwaysOnProfiler.Period,
+                key: ConfigurationKeys.AlwaysOnProfiler.ThreadSamplingPeriod,
                 defaultTo: 10_000,
                 validators: (value) => value >= 1_000);
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -416,6 +416,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("thread_sampling_period");
                     writer.WriteValue(instanceSettings.ThreadSamplingPeriod);
 
+                    writer.WritePropertyName("profiler_export_interval");
+                    writer.WriteValue(instanceSettings.ProfilerExportInterval);
+
                     writer.WritePropertyName("memory_profiling_enabled");
                     writer.WriteValue(instanceSettings.MemoryProfilingEnabled);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPprofTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPprofTests.cs
@@ -36,6 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("SIGNALFX_PROFILER_ENABLED", "true");
             SetEnvironmentVariable("SIGNALFX_PROFILER_CALL_STACK_INTERVAL", "1000");
+            SetEnvironmentVariable("SIGNALFX_PROFILER_EXPORT_INTERVAL", "1000");
 
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var logsCollector = EnvironmentHelper.GetMockOtelLogsCollector())


### PR DESCRIPTION
## Why

There is one variable for gathering thread samples interval and exporter interval. This can be quite misleading when using only memory profiling.

## What

Introduce new `SIGNALFX_PROFILER_EXPORT_INTERVAL` variable that is responsible for exporter interval only.

