### PR TITLE
[RuntimeMetrics] update api used for process.memory.virtual

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,7 +39,7 @@ Names and metric structure of the metrics exported are aligned with the OpenTele
 | Metric                               | Description                                                                                                                         | Type              |
 |:-------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------|:------------------|
 | `process.memory.usage`               | The amount of physical memory allocated for this process.                                                                           | Gauge             |
-| `process.memory.virtual`             | The amount of virtual memory allocated for this process that cannot be shared with other processes.                                 | Gauge             |
+| `process.memory.virtual`             | The amount of committed virtual memory for this process.                                                                            | Gauge             |
 | `process.cpu.time`                   | Total CPU seconds broken down by different states(`user`,`system`).                                                                 | CumulativeCounter |
 | `process.cpu.utilization`            | Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process. | Gauge             |
 | `process.threads`                    | Process threads count.                                                                                                              | Gauge             |

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
                 if (_enableProcessMetrics)
                 {
-                    ProcessHelpers.GetCurrentProcessRuntimeMetrics(out var newUserCpu, out var newSystemCpu, out var threadCount, out var privateMemory, out var workingSet);
+                    ProcessHelpers.GetCurrentProcessRuntimeMetrics(out var newUserCpu, out var newSystemCpu, out var threadCount, out var virtualMemory, out var workingSet);
 
                     var userCpu = newUserCpu - _previousUserCpu;
                     var systemCpu = newSystemCpu - _previousSystemCpu;
@@ -122,7 +122,7 @@ namespace Datadog.Trace.RuntimeMetrics
                     _metricSender.SendLong(MetricsNames.Process.ThreadsCount, threadCount, MetricType.GAUGE);
 
                     _metricSender.SendLong(MetricsNames.Process.MemoryUsage, workingSet, MetricType.GAUGE);
-                    _metricSender.SendLong(MetricsNames.Process.MemoryVirtual, privateMemory, MetricType.GAUGE);
+                    _metricSender.SendLong(MetricsNames.Process.MemoryVirtual, virtualMemory, MetricType.GAUGE);
 
                     _metricSender.SendDouble(MetricsNames.Process.CpuTime, newUserCpu.TotalSeconds, MetricType.CUMULATIVE_COUNTER, CpuUserTag);
                     _metricSender.SendDouble(MetricsNames.Process.CpuTime, newSystemCpu.TotalSeconds, MetricType.CUMULATIVE_COUNTER, CpuSystemTag);

--- a/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -66,17 +66,17 @@ namespace Datadog.Trace.Util
         /// <param name="userProcessorTime">CPU time in user mode</param>
         /// <param name="systemCpuTime">CPU time in kernel mode</param>
         /// <param name="threadCount">Number of threads</param>
-        /// <param name="privateMemorySize">Committed memory size</param>
+        /// <param name="virtualMemorySize">Committed memory size</param>
         /// <param name="workingSet">Working set</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void GetCurrentProcessRuntimeMetrics(out TimeSpan userProcessorTime, out TimeSpan systemCpuTime, out int threadCount, out long privateMemorySize, out long workingSet)
+        public static void GetCurrentProcessRuntimeMetrics(out TimeSpan userProcessorTime, out TimeSpan systemCpuTime, out int threadCount, out long virtualMemorySize, out long workingSet)
         {
             using var process = Process.GetCurrentProcess();
 
             userProcessorTime = process.UserProcessorTime;
             systemCpuTime = process.PrivilegedProcessorTime;
             threadCount = process.Threads.Count;
-            privateMemorySize = process.PrivateMemorySize64;
+            virtualMemorySize = process.VirtualMemorySize64;
             workingSet = process.WorkingSet64;
         }
     }


### PR DESCRIPTION
## Why

Adjust to [otel](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/762/files) implementation.

## What

- use `Process.VirtualMemorySize64` to retrieve value for metric
- update `metrics.md`

## Tests

Existing tests.
