### PR TITLE
Move env variables to internal config

### DIFF
--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -159,7 +159,6 @@ of SignalFx Instrumentation for .NET.
 | `SIGNALFX_PROFILER_LOGS_ENDPOINT` | The URL to where logs are exported using [OTLP/HTTP v1 log protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) | `http://localhost:4318/v1/logs` |
 | `SIGNALFX_PROFILER_ENABLED` | Enable to activate thread sampling. | `false` |
 | `SIGNALFX_PROFILER_CALL_STACK_INTERVAL` | Sampling period in milliseconds. It defines how often the threads are stopped in order to fetch all stack traces. This value cannot be lower than `1000` milliseconds. | `10000` |
-| `SIGNALFX_PROFILER_EXPORT_INTERVAL` | Profiling exporter interval in milliseconds. It defines how often the profiling data is sent to the collector. If the CPU profiling is enabled this value will automatically be set to match `SIGNALFX_PROFILER_CALL_STACK_INTERVAL` | `10000` |
 
 ## Including query string settings
 

--- a/docs/internal/internal-config.md
+++ b/docs/internal/internal-config.md
@@ -24,6 +24,8 @@ These settings should be never used by the users.
 | `SIGNALFX_LOGS_DIRECT_SUBMISSION_BATCH_PERIOD_SECONDS` | Configuration key for the time in seconds to wait between checking for batches | `2` |
 | `SIGNALFX_PROFILER_EXPORT_FORMAT` | Format in which data will be exported. Available values are: `Pprof` for pprof-gzip-base64 format, and `Text` for plain text stack trace. | `PProf` |
 | `SIGNALFX_PROFILER_MEMORY_ENABLED` | Enable to activate memory profiling. | `false` |
+| `SIGNALFX_PROFILER_MAX_MEMORY_SAMPLES_PER_MINUTE` | Configuratoin key for the maximum number of memory samples gathered per minute. | `200`
+| `SIGNALFX_PROFILER_EXPORT_INTERVAL` | Profiling exporter interval in milliseconds. It defines how often the profiling data is sent to the collector. If the CPU profiling is enabled this value will automatically be set to match `SIGNALFX_PROFILER_CALL_STACK_INTERVAL`. | `10000` |
 
 ## Unsupported upstream settings
 


### PR DESCRIPTION
## Why

@pellared, you may find the solution from https://github.com/signalfx/signalfx-dotnet-tracing/pull/668 more acceptable when the new variable description is moved to the internal config.

## What

Move new variable from https://github.com/signalfx/signalfx-dotnet-tracing/pull/668 to internal config. Document undocumented [variable](https://github.com/signalfx/signalfx-dotnet-tracing/pull/626/files#r983070019).
