### PR TITLE
Set ProfilerExportInterval

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -201,6 +201,9 @@ namespace Datadog.Trace.Configuration
             RuntimeMetricsEnabled = runtimeMetricsExplicitlyEnabled || memoryProfilingEnabled;
             ThreadSamplingPeriod = GetThreadSamplingPeriod(source);
 
+            var profilingExportInterval = source?.GetInt32(ConfigurationKeys.AlwaysOnProfiler.ExportInterval) ?? 10000;
+            ProfilerExportInterval = TimeSpan.FromMilliseconds(profilingExportInterval);
+
             LogSubmissionSettings = new DirectLogSubmissionSettings(source);
 
             TraceMethods = source?.GetString(ConfigurationKeys.TraceMethods) ??


### PR DESCRIPTION
## Why

ProfilerExportInterval was never set and defaulted to 0.

## What

Set ProfilerExportInterval based on SIGNALFX_PROFILER_EXPORT_INTERVAL value.

