### PR TITLE
[AlwaysOnProfiler] set span context if only mem profiling is enabled

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -112,7 +112,9 @@ namespace Datadog.Trace
             sampler ??= GetSampler(settings);
 
             agentWriter ??= GetAgentWriter(settings, statsd, sampler);
-            scopeManager ??= new AsyncLocalScopeManager(settings.CpuProfilingEnabled && FrameworkDescription.Instance.SupportsCpuProfiling());
+            var supportsCpuProfiling = settings.CpuProfilingEnabled && FrameworkDescription.Instance.SupportsCpuProfiling();
+            var supportsMemoryProfiling = settings.MemoryProfilingEnabled && FrameworkDescription.Instance.SupportsMemoryProfiling();
+            scopeManager ??= new AsyncLocalScopeManager(supportsCpuProfiling || supportsMemoryProfiling);
 
             if (settings.RuntimeMetricsEnabled && !DistributedTracer.Instance.IsChildTracer)
             {


### PR DESCRIPTION
## What
Set span context if only memory profiling is enabled.
