### PR TITLE
Rename SIGNALFX_TRACE_METRICS_ENABLED to SIGNALFX_METRICS_Traces_ENABLED

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 - Replace `SIGNALFX_RUNTIME_METRICS_ENABLED` setting with `SIGNALFX_METRICS_{0}_ENABLED`,
 that allows to enable specific metrics groups (See [advanced-config](advanced-config.md)).
+- Rename `SIGNALFX_TRACE_METRICS_ENABLED` to `SIGNALFX_METRICS_Traces_ENABLED` to
+preserve consistent naming convention.
 
 ### Bugfixes
 

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -60,7 +60,7 @@ The following settings are common to most instrumentation scenarios:
 | `SIGNALFX_TRACE_ENABLED` | Enable to activate the tracer. | `true` |
 | `SIGNALFX_METRICS_{0}_ENABLED` | Configuration pattern for enabling or disabling a specific group of metrics. See [metrics.md](metrics.md)
 for details. | `false` |
-| `SIGNALFX_TRACE_METRICS_ENABLED` | Enable to activate additional trace metrics. | `false` |
+| `SIGNALFX_METRICS_Traces_ENABLED` | Enable to activate additional trace metrics. | `false` |
 
 ## Global instrumentation settings
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -84,7 +84,7 @@ net localgroup "Performance Monitor Users" "IIS APPPOOL\DefaultAppPool" /add
 
 The SignalFx Instrumentation for .NET supports trace metrics collection.
 
-To enable additional metrics related to traces, set the `SIGNALFX_TRACE_METRICS_ENABLED`
+To enable additional metrics related to traces, set the `SIGNALFX_METRICS_Traces_ENABLED`
 environment variable to `true` for your .NET process.
 
 | Metric                                   | Description                                               | Type     |

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -196,7 +196,7 @@ namespace Datadog.Trace.Configuration
         /// Configuration key for enabling or disabling internal metrics sent to DogStatsD.
         /// Default value is <c>false</c> (disabled).
         /// </summary>
-        public const string TracerMetricsEnabled = "SIGNALFX_TRACE_METRICS_ENABLED";
+        public const string TracerMetricsEnabled = "SIGNALFX_METRICS_Traces_ENABLED";
 
         /// <summary>
         /// Configuration key for enabling or disabling tagging Redis


### PR DESCRIPTION
## Why

To preserve naming conventions for metrics.

## What

Rename `SIGNALFX_TRACE_METRICS_ENABLED` to `SIGNALFX_METRICS_Traces_ENABLED`

