### PR TITLE
Revert execution ClrProfilerIntegrationTests on Windows

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1036,7 +1036,7 @@ partial class Build
                     .SetProperty("VSTestNoBuild", true)
                     .SetNoLogo(true)
                     .SetFilter(Filter ?? "RunOnWindows=True&LoadFromGAC!=True&IIS!=True")
-                    .CombineWith(ParallelIntegrationTests, (s, project) => s
+                    .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .SetTargetPath(project)));
             }


### PR DESCRIPTION
## Why

Partial revert from #655 

## What

Revert execution ClrProfilerIntegrationTests on Windows

## Tests

CI
