### PR TITLE
Make .psm1 easier to use with Dockerfiles

### DIFF
--- a/Splunk.SignalFx.DotNet.psm1
+++ b/Splunk.SignalFx.DotNet.psm1
@@ -37,11 +37,11 @@ function Install-SignalFxDotnet() {
 
     try {
         # Find MSI to download
-        $download = (Invoke-WebRequest $api | ConvertFrom-Json).assets | Where-Object { $_.name -eq $asset_name } | Select-Object -Property browser_download_url,name
+        $download = (Invoke-WebRequest $api -UseBasicParsing | ConvertFrom-Json).assets | Where-Object { $_.name -eq $asset_name } | Select-Object -Property browser_download_url,name
 
         # Download installer MSI to Temp
         $msi = Get-TempPath | Join-Path -ChildPath $download.name
-        Invoke-WebRequest -Uri $download.browser_download_url -OutFile $msi
+        Invoke-WebRequest -Uri $download.browser_download_url -OutFile $msi -UseBasicParsing
     }
     catch {
         $msg = $_


### PR DESCRIPTION
## Why

Very hard (impossible?) to use the powershell module from the collector script due to restrictions on first use of `Invoke-WebRequest`

## What

Adding the `-UseBasicParsing` prevents the issue on the usage of `Invoke-WebRequest`. The web proposes various workarounds and while they work for the install script from the collector they don't work for the `Invoke-WebRequest` of the imported module - which is very weird since the most straightforward workaround uses the registry. Anyway, adding the parameters prevents the issue.

I will add this parameter to the collector install script while creating the respective test on the collector repo.

## Tests

I locally validated the fix in an ltsc2019 `windowsservercore` running IIS.