### PR TITLE
Release 1.0.1

### DIFF
--- a/Splunk.SignalFx.DotNet.psm1
+++ b/Splunk.SignalFx.DotNet.psm1
@@ -24,7 +24,7 @@ function Reset-IIS() {
 #>
 function Install-SignalFxDotnet() {
     # signalfx-dotnet-tracing github repository API
-    $release = "1.0.0"
+    $release = "1.0.1"
     $api = "https://api.github.com/repos/signalfx/signalfx-dotnet-tracing/releases/tags/v$($release)"
 
     # determine OS architecture

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,13 +11,17 @@ and this repository adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
 ### General
 
-- Deprecate `process.cpu.utilization` metric.
-
 ### Breaking changes
 
 ### Bugfixes
 
 ### Enhancements
+
+## [Release 1.0.1](https://github.com/signalfx/signalfx-dotnet-tracing/releases/tag/v1.0.1)
+
+### General
+
+- Deprecate `process.cpu.utilization` metric.
 
 ## [Release 1.0.0](https://github.com/signalfx/signalfx-dotnet-tracing/releases/tag/v1.0.0)
 

--- a/docs/internal/docker-windows.md
+++ b/docs/internal/docker-windows.md
@@ -6,7 +6,7 @@ Setting up SignalFx Instrumentation for .NET to run in Windows Nano Server Docke
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-nanoserver-ltsc2022
 
 # Download SignalFx Instrumentation for .NET zip.
-ARG TRACER_VERSION=1.0.0
+ARG TRACER_VERSION=1.0.1
 ADD https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing-${TRACER_VERSION}.zip "C:/signalfx-dotnet-tracing.zip"
 
 # Extract zip to C:/signalfx/
@@ -48,7 +48,7 @@ ENV CORECLR_ENABLE_PROFILING=1 \
     CORECLR_PROFILER='{B4C89B0F-9908-4F73-9F59-0D77C5A06874}' \
     SIGNALFX_ENDPOINT_URL='<my-endpoint-here>' \
 
-ARG TRACER_VERSION=1.0.0
+ARG TRACER_VERSION=1.0.1
 
 # Download and install SignalFx Instrumentation for .NET MSI.
 # Note: MSI is preferred installation method for Windows to setup profiler at once and reduce manual steps.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.AutoInstrumentation.Profiler.Native.Linux" VERSION 1.0.0)
+project("Datadog.AutoInstrumentation.Profiler.Native.Linux" VERSION 1.0.1)
 
 option(RUN_ASAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
 option(RUN_UBSAN "Build with Clang Undefined-Behavior Sanitizer" OFF)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
@@ -62,8 +62,8 @@ END
 
 // ------- version info -------------------------------------------------------
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION             1,0,0,0
-PRODUCTVERSION          1,0,0,0
+FILEVERSION             1,0,1,0
+PRODUCTVERSION          1,0,1,0
 FILEFLAGSMASK           VS_FF_PRERELEASE
 FILEOS                  VOS_NT
 FILETYPE                VFT_DLL
@@ -74,12 +74,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog"
             VALUE "FileDescription", "Continuous Profiler for .NET Applications"
-            VALUE "FileVersion", "1.0.0.0"
+            VALUE "FileVersion", "1.0.1.0"
             VALUE "InternalName", "Native Profiler Engine"
             VALUE "LegalCopyright", "(c) Datadog 2020-2022"
             VALUE "OriginalFilename", "Datadog.Profiler.Native.dll"
             VALUE "ProductName", "Continuous Profiler for .NET Applications"
-            VALUE "ProductVersion", "1.0.0.0"
+            VALUE "ProductVersion", "1.0.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-constexpr auto PROFILER_VERSION = "1.0.0";
+constexpr auto PROFILER_VERSION = "1.0.1";
 
 // The beta revision is temporary
 constexpr auto PROFILER_BETA_REVISION = "1";

--- a/profiler/src/ProfilerEngine/ProductVersion.props
+++ b/profiler/src/ProfilerEngine/ProductVersion.props
@@ -6,7 +6,7 @@
   <!-- * * * * * * * * * * * INPUTS. Update this section EVERY time the component is shipped/released! * * * * * * * * * * *                -->
   <PropertyGroup>
     <!-- GA 1.2.0                                                                                                                           -->
-    <ProductVersion>1.0.0</ProductVersion>
+    <ProductVersion>1.0.1</ProductVersion>
     <BetaVersion>1</BetaVersion>
 
     <!-- ProductVersionPrerelease format examples: alpha.1, alpha.2, beta.1, beta.2; EMPTY for stable releases.                             -->

--- a/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
+++ b/shared/src/azure-site-extension/Azure.Site.Extension.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>SignalFx.NET.Tracing.Azure.Site.Extension</id>
-    <version>1.0.0.0</version>
+    <version>1.0.1.0</version>
     <title>SignalFx .NET Tracing</title>
     <authors>SignalFx</authors>
     <icon>icon.png</icon>

--- a/shared/src/azure-site-extension/applicationHost.xdt
+++ b/shared/src/azure-site-extension/applicationHost.xdt
@@ -25,17 +25,17 @@
         <add name="COMPLUS_LoaderOptimization" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="COR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v1.0.0\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v1.0.0\win-x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v1.0.0\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\signalfx\tracing\v1.0.1\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v1.0.1\win-x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v1.0.1\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="CORECLR_PROFILER" value="{B4C89B0F-9908-4F73-9F59-0D77C5A06874}" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v1.0.0\win-x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v1.0.0\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\signalfx\tracing\v1.0.1\win-x86\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\signalfx\tracing\v1.0.1\win-x64\SignalFx.Tracing.ClrProfiler.Native.dll" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
 
-        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v1.0.0" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
-        <add name="SIGNALFX_TRACE_LOG_DIRECTORY" value="%HOME%\LogFiles\signalfx\tracing\v1.0.0\" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_DOTNET_TRACER_HOME" value="%HOME%\signalfx\tracing\v1.0.1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
+        <add name="SIGNALFX_TRACE_LOG_DIRECTORY" value="%HOME%\LogFiles\signalfx\tracing\v1.0.1\" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_AZURE_APP_SERVICES" value="1" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
         <add name="SIGNALFX_PROFILER_EXCLUDE_PROCESSES" value="SnapshotUploader.exe;workerforwarder.exe" xdt:Locator="Match(name)" xdt:Transform="Insert"/>
       </environmentVariables>

--- a/shared/src/azure-site-extension/install.cmd
+++ b/shared/src/azure-site-extension/install.cmd
@@ -8,7 +8,7 @@ echo Extension directory is %extensionBaseDir%
 echo Site root directory is %siteHome%
 
 REM Create version specific tracer directory
-SET tracerDir=%siteHome%\signalfx\tracing\v1.0.0
+SET tracerDir=%siteHome%\signalfx\tracing\v1.0.1
 if not exist %tracerDir% mkdir %tracerDir%
 
 REM Copy tracer to version specific directory

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -17,7 +17,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>datadog-dotnet-apm-1.0.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
+    <OutputName>datadog-dotnet-apm-1.0.1-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
     <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\bin\windows-tracer-home</TracerHomeDirectory>
     <ProfilerHomeDirectory Condition="'$(ProfilerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\bin\DDProf-Deploy</ProfilerHomeDirectory>

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -21,7 +21,7 @@
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
     <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\bin\windows-tracer-home</TracerHomeDirectory>
     <ProfilerHomeDirectory Condition="'$(ProfilerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\bin\DDProf-Deploy</ProfilerHomeDirectory>
-    <DefineConstants>InstallerVersion=1.0.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);TracerHomeDirectory=$(TracerHomeDirectory);LibDdwafDirectory=$(LibDdwafDirectory);ProfilerHomeDirectory=$(ProfilerHomeDirectory)</DefineConstants>
+    <DefineConstants>InstallerVersion=1.0.1;MonitoringHomeDirectory=$(MonitoringHomeDirectory);TracerHomeDirectory=$(TracerHomeDirectory);LibDdwafDirectory=$(LibDdwafDirectory);ProfilerHomeDirectory=$(ProfilerHomeDirectory)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>$(DefineConstants);Debug</DefineConstants>

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -65,7 +65,7 @@ partial class Build : NukeBuild
     readonly bool IsAlpine = false;
 
     [Parameter("The current version of the source and build")]
-    readonly string Version = "1.0.0";
+    readonly string Version = "1.0.1";
 
     [Parameter("Whether the current build version is a prerelease(for packaging purposes)")]
     readonly bool IsPrerelease = false;

--- a/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=1.0.0
+ARG TRACER_VERSION=1.0.1
 RUN mkdir -p /var/log/signalfx
 RUN mkdir -p /opt/signalfx
 RUN curl -L https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=1.0.0
+ARG TRACER_VERSION=1.0.1
 RUN mkdir -p /var/log/signalfx
 RUN mkdir -p /opt/signalfx
 RUN curl -L https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Debian.dockerfile
+++ b/tracer/samples/ConsoleApp/Debian.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Set up Datadog APM
-ARG TRACER_VERSION=1.0.0
+ARG TRACER_VERSION=1.0.1
 RUN mkdir -p /var/log/signalfx
 RUN mkdir -p /opt/signalfx
 RUN curl -LO https://github.com/signalfx/signalfx-dotnet-tracing/releases/download/v${TRACER_VERSION}/signalfx-dotnet-tracing_${TRACER_VERSION}_amd64.deb

--- a/tracer/samples/WindowsContainer/Dockerfile
+++ b/tracer/samples/WindowsContainer/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:5.0-windowsservercore-ltsc2019 AS base
 WORKDIR /app
 
-ARG TRACER_VERSION=1.0.0
+ARG TRACER_VERSION=1.0.1
 ENV SIGNALFX_TRACER_VERSION=$TRACER_VERSION
 ENV ASPNETCORE_URLS=http://*.80
 

--- a/tracer/src/Datadog.Monitoring.Distribution/Datadog.Monitoring.Distribution.csproj
+++ b/tracer/src/Datadog.Monitoring.Distribution/Datadog.Monitoring.Distribution.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Version>$(Version)-beta01</Version> <!-- Unconditionally add a beta suffix to the package, but keep the rest of the name so we can associate it with the rest of the release -->
     <Title>Datadog APM Auto-instrumentation Assets</Title>
     <Description>Auto-instrumentation assets for Datadog APM</Description>

--- a/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <AssemblyName>SignalFx.Tracing.AspNet</AssemblyName>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>SignalFx.Tracing.ClrProfiler.Managed.Loader</AssemblyName>
 
     <!-- NuGet -->
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private const string AssemblyName = "SignalFx.Tracing, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e43a27c2023d388a";
+        private const string AssemblyName = "SignalFx.Tracing, Version=1.0.1.0, Culture=neutral, PublicKeyToken=e43a27c2023d388a";
         private const string AzureAppServicesKey = "SIGNALFX_AZURE_APP_SERVICES";
         private const string AasCustomTracingKey = "SIGNALFX_AAS_ENABLE_CUSTOM_TRACING";
         private const string AasCustomMetricsKey = "SIGNALFX_AAS_ENABLE_CUSTOM_METRICS";

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 # Project definition
 # ******************************************************
 
-project("SignalFx.Tracing.ClrProfiler.Native" VERSION 1.0.0)
+project("SignalFx.Tracing.ClrProfiler.Native" VERSION 1.0.1)
 
 # ******************************************************
 # Environment detection

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -49,8 +49,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,0
- PRODUCTVERSION 1,0,0,0
+ FILEVERSION 1,0,1,0
+ PRODUCTVERSION 1,0,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -67,12 +67,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "SignalFx"
             VALUE "FileDescription", "SignalFx CLR Profiler"
-            VALUE "FileVersion", "1.0.0.0"
+            VALUE "FileVersion", "1.0.1.0"
             VALUE "InternalName", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "LegalCopyright", "Copyright (C) 2021-2023"
             VALUE "OriginalFilename", "SignalFx.Tracing.ClrProfiler.Native.DLL"
             VALUE "ProductName", "SignalFx .NET Tracing"
-            VALUE "ProductVersion", "1.0.0"
+            VALUE "ProductVersion", "1.0.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -83,7 +83,7 @@ const shared::WSTRING system_private_corelib_assemblyName = WStr("System.Private
 const shared::WSTRING datadog_trace_clrprofiler_managed_loader_assemblyName = WStr("SignalFx.Tracing.ClrProfiler.Managed.Loader");
 
 const shared::WSTRING managed_profiler_full_assembly_version =
-    WStr("SignalFx.Tracing, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e43a27c2023d388a");
+    WStr("SignalFx.Tracing, Version=1.0.1.0, Culture=neutral, PublicKeyToken=e43a27c2023d388a");
 
 const shared::WSTRING managed_profiler_name = WStr("SignalFx.Tracing");
 
@@ -121,7 +121,7 @@ const AssemblyProperty managed_profiler_assembly_property = AssemblyProperty(
                   123, 102, 42,  57,  219, 122, 95,  191, 59,  10,  120, 157, 167, 170, 1,   81,  183, 182, 51,  111,
                   204, 130, 205, 122, 20,  157, 247, 246, 102, 245, 57,  108, 141, 233, 44,  166, 68,  215, 162, 209},
     160, 32772, 1)
-        .WithVersion(1, 0, 0, 0);
+        .WithVersion(1, 0, 1, 0);
 
 } // namespace trace
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/version.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "1.0.0";
+constexpr auto PROFILER_VERSION = "1.0.1";

--- a/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
+++ b/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <AssemblyName>SignalFx.Tracing.MSBuild</AssemblyName>
   </PropertyGroup>
 

--- a/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>SignalFx Tracing OpenTracing</Title>
     <Description>Provides OpenTracing support for SignalFx Tracing</Description>
 	  <AssemblyName>SignalFx.Tracing.OpenTracing</AssemblyName>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>SignalFx .NET Tracing</Title>
     <Description>SignalFx .NET Tracing library</Description>
     <AssemblyName>SignalFx.Tracing</AssemblyName>

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -430,7 +430,7 @@ namespace Datadog.Trace
                 return;
             }
 
-            var signalFxOpenTracingAssembly = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e43a27c2023d388a"));
+            var signalFxOpenTracingAssembly = Assembly.Load(new AssemblyName("SignalFx.Tracing.OpenTracing, Version=1.0.1.0, Culture=neutral, PublicKeyToken=e43a27c2023d388a"));
             var openTracingTracerFactoryType = signalFxOpenTracingAssembly.GetType("Datadog.Trace.OpenTracing.OpenTracingTracerFactory");
             var methodInfo = openTracingTracerFactoryType.GetMethod("RegisterGlobalTracerIfAbsent");
             object[] args = { instance };

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -17,6 +17,6 @@ namespace Datadog.Trace
         /// </summary>
         public const ulong MaxTraceId = 9_223_372_036_854_775_807;
 
-        public static readonly string AssemblyVersion = "1.0.0.0";
+        public static readonly string AssemblyVersion = "1.0.1.0";
     }
 }

--- a/tracer/src/WindowsInstaller/WindowsInstaller.wixproj
+++ b/tracer/src/WindowsInstaller/WindowsInstaller.wixproj
@@ -17,9 +17,9 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>signalfx-dotnet-tracing-1.0.0-$(Platform)</OutputName>
+    <OutputName>signalfx-dotnet-tracing-1.0.1-$(Platform)</OutputName>
     <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\bin\dd-tracer-home</TracerHomeDirectory>
-    <DefineConstants>InstallerVersion=1.0.0;TracerHomeDirectory=$(TracerHomeDirectory)</DefineConstants>
+    <DefineConstants>InstallerVersion=1.0.1;TracerHomeDirectory=$(TracerHomeDirectory)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>$(DefineConstants);Debug</DefineConstants>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         AssertTargetSpanEqual(targetSpan, "signalfx.tracing.library", "dotnet-tracing");
 
                         // check the SignalFx library version
-                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "1.0.0.0");
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "1.0.1.0");
 
                         // checks the runtime id tag
                         AssertTargetSpanExists(targetSpan, Tags.RuntimeId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         AssertTargetSpanEqual(targetSpan, "signalfx.tracing.library", "dotnet-tracing");
 
                         // check the SignalFx library version
-                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "1.0.0.0");
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "1.0.1.0");
 
                         // checks the runtime id tag
                         AssertTargetSpanExists(targetSpan, Tags.RuntimeId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         AssertTargetSpanEqual(targetSpan, "signalfx.tracing.library", "dotnet-tracing");
 
                         // check the SignalFx library version
-                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "1.0.0.0");
+                        AssertTargetSpanEqual(targetSpan, "signalfx.tracing.version", "1.0.1.0");
 
                         // checks the origin tag
                         CheckOriginTag(targetSpan);


### PR DESCRIPTION
## General

- Deprecate `process.cpu.utilization` metric

## Note
Previous release PR's were updating additional [file](https://github.com/signalfx/signalfx-dotnet-tracing/blob/8d5f8f56e7d75360632baceec1cb1d2df438e4f3/tracer/tools/PipelineMonitor/PipelineMonitor.csproj#L11) which seems redundant. I did not update it here.
