### PR TITLE
[AlwaysOnProfiling] add total frame count to LogRecord attributes

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPlainTextTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPlainTextTests.cs
@@ -59,9 +59,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     using (new AssertionScope())
                     {
-                        AllShouldHaveCorrectAttributes(logRecords, ExpectedAttributes());
+                        AllShouldHaveBasicAttributes(logRecords, ExpectedAttributes());
                         AllBodiesShouldHaveCorrectFormat(logRecords);
-                        ContainsExpectedAttributes(dataResourceLog.Resource);
+                        ResourceContainsExpectedAttributes(dataResourceLog.Resource);
                         HasNameAndVersionSet(instrumentationLibraryLogs.InstrumentationLibrary);
                     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPprofTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerPprofTests.cs
@@ -15,6 +15,7 @@ using Datadog.Tracer.Pprof.Proto.Profile;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using OpenTelemetry.TestHelpers.Proto.Common.V1;
+using OpenTelemetry.TestHelpers.Proto.Logs.V1;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -71,12 +72,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     using (new AssertionScope())
                     {
-                        AllShouldHaveCorrectAttributes(logRecords, ExpectedAttributes());
-                        ContainsExpectedAttributes(dataResourceLog.Resource);
+                        AllShouldHaveBasicAttributes(logRecords, ConstantValuedAttributes());
+                        RecordsContainFrameCountAttribute(logRecords);
+                        ResourceContainsExpectedAttributes(dataResourceLog.Resource);
                         HasNameAndVersionSet(instrumentationLibraryLogs.InstrumentationLibrary);
                     }
 
-                    // all samples should contain the same common attributes, only stack traces are vary
                     logRecords.Clear();
                 }
 
@@ -84,7 +85,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        private static List<KeyValue> ExpectedAttributes()
+        private static void RecordsContainFrameCountAttribute(List<LogRecord> logRecords)
+        {
+            foreach (var logRecord in logRecords)
+            {
+                logRecord.Attributes.Should().Contain(attr => attr.Key == "profiling.data.total.frame.count");
+            }
+        }
+
+        private static List<KeyValue> ConstantValuedAttributes()
         {
             return new List<KeyValue>
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AlwaysOnProfilerTests.cs
@@ -27,11 +27,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        protected static void AllShouldHaveCorrectAttributes(List<LogRecord> logRecords, List<KeyValue> attributes)
+        protected static void AllShouldHaveBasicAttributes(List<LogRecord> logRecords, List<KeyValue> attributes)
         {
-            var expectedAttributesForLogRecord = new LogRecord();
-            expectedAttributesForLogRecord.Attributes.AddRange(attributes);
-            logRecords.Should().AllBeEquivalentTo(expectedAttributesForLogRecord, option => option.Including(x => x.Attributes));
+            foreach (var logRecord in logRecords)
+            {
+                foreach (var attribute in attributes)
+                {
+                    logRecord.Attributes.Should().ContainEquivalentOf(attribute);
+                }
+            }
         }
 
         protected static IEnumerable<string> CreateExpectedStackTrace()
@@ -82,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return stackTrace;
         }
 
-        protected static void ContainsExpectedAttributes(Resource resource)
+        protected static void ResourceContainsExpectedAttributes(Resource resource)
         {
             var constantAttributes = new List<KeyValue>
             {


### PR DESCRIPTION
## Why

Required by the GDI spec.

## What

Add `profiling.data.total.frame.count` attribute to `LogRecords` containing `pprof` profiles.

## Tests

Included in PR.
