### PR TITLE
Releasing - remove reference to microservices-demo

### DIFF
--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -42,6 +42,4 @@ needs any adjustments. Contact @signalfx/gdi-docs team if needed.
 1. [Publish](https://docs.microsoft.com/en-us/nuget/nuget-org/publish-a-package)
    the NuGet packages to the official [nuget.org feed](https://www.nuget.org/).
 
-1. Update `TRACER_VERSION` in [demo repository](https://github.com/signalfx/microservices-demo/blob/main/src/cartservice/Dockerfile)
-
 1. Update `TRACER_VERSION` in [examples repository](https://github.com/signalfx/tracing-examples/blob/main/signalfx-tracing/signalfx-dotnet-tracing/aspnetcore-and-mongodb/InstrumentContainer/Dockerfile)


### PR DESCRIPTION
## Why & What

Releasing - remove reference to microservices-demo. It was switched to Splunk OTel .NET

## Tests

N/A