### PR TITLE
Use smaller banner msg on destination folder page

### DIFF
--- a/shared/src/msi-installer/Strings.wxl
+++ b/shared/src/msi-installer/Strings.wxl
@@ -18,7 +18,7 @@
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>
   <String Id="LicenseAgreementDlgDescription">{\WixUI_Font_Normal_White}Please read the following license agreement carefully</String>
   <String Id="InstallDirDlgTitle">{\WixUI_Font_Title_White}Destination Folder</String>
-  <String Id="InstallDirDlgDescription">{\WixUI_Font_Normal_White}Click Next to install to the default folder or click Change to choose another.</String>
+  <String Id="InstallDirDlgDescription">{\WixUI_Font_Normal_White}Select the destination folder</String>
   <String Id="BrowseDlgTitle">{\WixUI_Font_Title_White}Change destination folder</String>
   <String Id="BrowseDlgDescription">{\WixUI_Font_Normal_White}Browse to the destination folder</String>
   <String Id="ProgressDlgTitleInstalling">{\WixUI_Font_Title_White}Installing [ProductName]</String>

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -301,3 +303,5 @@ internal record BoundLineProbeLocation
 
     public int LineNumber { get; set; }
 }
+
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially

--- a/tracer/src/Datadog.Trace/Debugger/Models/ProbeSnapshot.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Models/ProbeSnapshot.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -192,3 +194,5 @@ namespace Datadog.Trace.Debugger
         }
     }
 }
+
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially

--- a/tracer/src/WindowsInstaller/Strings.wxl
+++ b/tracer/src/WindowsInstaller/Strings.wxl
@@ -18,7 +18,7 @@
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>
   <String Id="LicenseAgreementDlgDescription">{\WixUI_Font_Normal_White}Please read the following license agreement carefully</String>
   <String Id="InstallDirDlgTitle">{\WixUI_Font_Title_White}Destination Folder</String>
-  <String Id="InstallDirDlgDescription">{\WixUI_Font_Normal_White}Click Next to install to the default folder or click Change to choose another.</String>
+  <String Id="InstallDirDlgDescription">{\WixUI_Font_Normal_White}Select the destination folder</String>
   <String Id="BrowseDlgTitle">{\WixUI_Font_Title_White}Change destination folder</String>
   <String Id="BrowseDlgDescription">{\WixUI_Font_Normal_White}Browse to the destination folder</String>
   <String Id="ProgressDlgTitleInstalling">{\WixUI_Font_Title_White}Installing [ProductName]</String>


### PR DESCRIPTION
## Why

Reduce redundant message that was overlapping with logo.

![image](https://github.com/signalfx/signalfx-dotnet-tracing/assets/5600755/65ec00d4-1c3b-4821-90e8-5526b0c8076c)


## What

Replaced the very lengthy and detailed message with a short direct message.

Side note: we only ship the tracer/src/WindowsInstaller but I changed the shared installer for consistency.

## Tests

N/A