### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,12 @@ jobs:
     - name: Remove large node images
       run: docker rmi node:20 node:18 node:16
 
+    - name: Remove a few unused dirs
+      run: sudo rm -rf \
+            /usr/local/lib/android /opt/ghc \
+            /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+
     - name: Disk usage
       run: df -h
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
           dd-trace-dotnet/${{ matrix.base-image }}-builder \
           dotnet /build/bin/Debug/_build.dll Info Clean BuildTracerHome BuildLinuxIntegrationTests -Framework ${{ matrix.framework }}
     - name: Build dependencies
-      run: docker-compose build --build-arg SERVERLESS_ARTIFACTS_PATH=.${relativeTracerHome} serverless-lambda-no-param-sync serverless-lambda-one-param-sync serverless-lambda-two-params-sync serverless-lambda-no-param-async serverless-lambda-one-param-async serverless-lambda-two-params-async serverless-lambda-no-param-void serverless-lambda-one-param-void serverless-lambda-two-params-void
+      run: docker-compose build --build-arg SERVERLESS_ARTIFACTS_PATH=.${relativeTracerHome} StartDependencies
     - name: Start dependencies
       run: docker-compose up -d StartDependencies
     - name: Run integration tests in container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,13 @@ jobs:
           5.0.408
           6.0.404
           7.0.101
+
+    - name: Remove large node images
+      run: docker rmi node:20 node:18 node:16
+
+    - name: Disk usage
+      run: df -h
+
     - name: Build Docker image
       run: |
         docker build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,7 @@ jobs:
       fail-fast: false
       matrix:
         base-image: [ debian, alpine ]
-        framework: [ netcoreapp3.1, net5.0, net6.0, net7.0 ]
+        framework: [ netcoreapp3.1, net6.0, net7.0 ]
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     - name: Build Docker image
@@ -178,7 +177,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     - run: ./tracer/build.cmd Clean BuildTracerHome BuildAndRunManagedUnitTests
@@ -204,7 +202,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     - name: Build Docker image
@@ -251,7 +248,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     - name: Install CMake 3.19.8
@@ -277,7 +273,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     - name: Build Docker image
@@ -313,7 +308,7 @@ jobs:
       matrix:
         machine: [ windows-2022 ]
         platform: [ x64 ]
-        framework: [ net461, netcoreapp3.1, net5.0, net6.0, net7.0 ]
+        framework: [ net461, netcoreapp3.1, net6.0, net7.0 ]
         target: [ BuildAndRunWindowsIntegrationTests, BuildAndRunWindowsRegressionTests ]
     runs-on: ${{ matrix.machine }}
     timeout-minutes: 60
@@ -327,7 +322,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
@@ -387,7 +381,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
 
@@ -462,7 +455,6 @@ jobs:
         dotnet-version: | 
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
@@ -512,7 +504,6 @@ jobs:
         dotnet-version: |
           2.1.818
           3.1.426
-          5.0.408
           6.0.404
           7.0.101
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -544,18 +544,6 @@ services:
       - AEROSPIKE_HOST=aerospike:3000
       - COUCHBASE_HOST=couchbase
       - COUCHBASE_PORT=8091
-      - AWS_LAMBDA_ENDPOINT_NO_PARAM_SYNC=http://serverless-lambda-no-param-sync:8080
-      - AWS_LAMBDA_ENDPOINT_ONE_PARAM_SYNC=http://serverless-lambda-one-param-sync:8080
-      - AWS_LAMBDA_ENDPOINT_TWO_PARAMS_SYNC=http://serverless-lambda-two-params-sync:8080
-      - AWS_LAMBDA_ENDPOINT_NO_PARAM_SYNC_WITH_CONTEXT=http://serverless-lambda-no-param-sync-with-context:8080
-      - AWS_LAMBDA_ENDPOINT_ONE_PARAM_SYNC_WITH_CONTEXT=http://serverless-lambda-one-param-sync-with-context:8080
-      - AWS_LAMBDA_ENDPOINT_TWO_PARAMS_SYNC_WITH_CONTEXT=http://serverless-lambda-two-params-sync-with-context:8080
-      - AWS_LAMBDA_ENDPOINT_NO_PARAM_ASYNC=http://serverless-lambda-no-param-async:8080
-      - AWS_LAMBDA_ENDPOINT_ONE_PARAM_ASYNC=http://serverless-lambda-one-param-async:8080
-      - AWS_LAMBDA_ENDPOINT_TWO_PARAMS_ASYNC=http://serverless-lambda-two-params-async:8080
-      - AWS_LAMBDA_ENDPOINT_NO_PARAM_VOID=http://serverless-lambda-no-param-void:8080
-      - AWS_LAMBDA_ENDPOINT_ONE_PARAM_VOID=http://serverless-lambda-one-param-void:8080
-      - AWS_LAMBDA_ENDPOINT_TWO_PARAMS_VOID=http://serverless-lambda-two-params-void:8080
       - CONTAINER_HOSTNAME=http://integrationtests
     hostname: integrationtests
     depends_on:
@@ -617,23 +605,9 @@ services:
       - kafka-zookeeper
       - aws_sqs
       - couchbase
-      - serverless-lambda-no-param-sync
-      - serverless-lambda-one-param-sync
-      - serverless-lambda-two-params-sync
-      - serverless-lambda-no-param-sync-with-context
-      - serverless-lambda-one-param-sync-with-context
-      - serverless-lambda-two-params-sync-with-context
-      - serverless-lambda-no-param-async
-      - serverless-lambda-one-param-async
-      - serverless-lambda-two-params-async
-      - serverless-lambda-no-param-void
-      - serverless-lambda-one-param-void
-      - serverless-lambda-two-params-void
-      - serverless-integration-extension-mock
-      - serverless-integration-extension-mock-with-context
     environment:
       - TIMEOUT_LENGTH=120
-    command: aerospike:3000 servicestackredis:6379 stackexchangeredis:6379 elasticsearch5:9200 elasticsearch6:9200 elasticsearch7:9200 sqlserver:1433 mongo:27017 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 aws_sqs:9324 couchbase:11210 serverless-lambda-no-param-sync:8080 serverless-lambda-one-param-sync:8080 serverless-lambda-two-params-sync:8080 serverless-lambda-no-param-sync-with-context:8080 serverless-lambda-one-param-sync-with-context:8080 serverless-lambda-two-params-sync-with-context:8080 serverless-lambda-no-param-async:8080 serverless-lambda-one-param-async:8080 serverless-lambda-two-params-async:8080 serverless-integration-extension-mock:9003 serverless-integration-extension-mock-with-context:9004 serverless-lambda-no-param-void:8080 serverless-lambda-one-param-void:8080 serverless-lambda-two-params-void:8080
+    command: aerospike:3000 servicestackredis:6379 stackexchangeredis:6379 elasticsearch5:9200 elasticsearch6:9200 elasticsearch7:9200 sqlserver:1433 mongo:27017 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 aws_sqs:9324 couchbase:11210
 
   IntegrationTests.ARM64:
     build:

--- a/docs/internal/developing.md
+++ b/docs/internal/developing.md
@@ -17,7 +17,6 @@ Minimum requirements:
 - Optional: [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
 - Optional: [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) to test in .NET Core 3.0 locally.
 - Optional: [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1) to test in .NET Core 3.1 locally.
-- Optional: [ASP.NET 5.0 Runtime](https://dotnet.microsoft.com/download/dotnet/5.0) to test in .NET 5.0 locally.
 - Optional: [ASP.NET 6.0 Runtime](https://dotnet.microsoft.com/download/dotnet/6.0) to test in .NET 6.0 locally.
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)

--- a/docs/internal/pull-from-upstream.md
+++ b/docs/internal/pull-from-upstream.md
@@ -46,7 +46,6 @@ Windows in Git Bash:
 git clean -fXd ; ./tracer/build.cmd ; \
 Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.cmd BuildAndRunWindowsIntegrationTests --framework net7.0 ; \
 Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.cmd BuildAndRunWindowsIntegrationTests --framework net6.0 ; \
-Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.cmd BuildAndRunWindowsIntegrationTests --framework net5.0 ; \
 Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.cmd BuildAndRunWindowsIntegrationTests --framework netcoreapp3.1 ; \
 Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.cmd BuildAndRunWindowsIntegrationTests --framework net461 ; \
 ./tracer/build.cmd OverwriteSnapshotFiles
@@ -59,7 +58,6 @@ git clean -fXd ; ./tracer/build.sh ; \
 docker-compose run --rm StartDependencies ; \
 Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.sh BuildAndRunLinuxIntegrationTests --framework net7.0 ; \
 Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.sh BuildAndRunLinuxIntegrationTests --framework net6.0 ; \
-Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.sh BuildAndRunLinuxIntegrationTests --framework net5.0 ; \
 Verify_DisableClipboard=true DiffEngine_Disabled=true ./tracer/build.sh BuildAndRunLinuxIntegrationTests --framework netcoreapp3.1 ; \
 docker-compose down ; \
 ./tracer/build.sh OverwriteSnapshotFiles

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -47,9 +47,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "a07fe1945b0e619797125f08762195227e7a76218deeabea0f88d3a0c0588964  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime aspnetcore --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 3.0.3 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.1.31 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 5.0.17 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 6.0.11 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -44,7 +44,7 @@ FROM base as tester
 # Install .NET Core runtimes using install script
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "5840ce64f4186ccc4dac0c0fd8703acd0d387091ce48f310fef758e5f84d7a7f  dotnet-install.sh" | sha256sum -c \
+    && echo "a07fe1945b0e619797125f08762195227e7a76218deeabea0f88d3a0c0588964  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime aspnetcore --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.0.3 --install-dir /usr/share/dotnet --no-path \

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
         git=1:2.20.1-2+deb10u3 \
         procps=2:3.3.15-2 \
         wget=1.20.1-1.1 \
-        curl=7.64.0-4+deb10u6 \
+        curl=7.64.0-4+deb10u7 \
         cmake=3.13.4-1 \
         make=4.2.1-1.2 \
         llvm=1:7.0-47 \

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -91,3 +91,5 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
 COPY . /build
 RUN dotnet build /build
 WORKDIR /project
+
+ENV IsDebian=true

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -82,9 +82,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     && echo "a07fe1945b0e619797125f08762195227e7a76218deeabea0f88d3a0c0588964  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime $NETCORERUNTIME2_1 --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 3.0.3 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.1.31 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh --runtime aspnetcore --version 5.0.17 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 6.0.11 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update \
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "5840ce64f4186ccc4dac0c0fd8703acd0d387091ce48f310fef758e5f84d7a7f  dotnet-install.sh" | sha256sum -c \
+    && echo "a07fe1945b0e619797125f08762195227e7a76218deeabea0f88d3a0c0588964  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
     && rm ./dotnet-install.sh \
@@ -79,7 +79,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     fi \
     && curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "5840ce64f4186ccc4dac0c0fd8703acd0d387091ce48f310fef758e5f84d7a7f  dotnet-install.sh" | sha256sum -c \
+    && echo "a07fe1945b0e619797125f08762195227e7a76218deeabea0f88d3a0c0588964  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime $NETCORERUNTIME2_1 --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.0.3 --install-dir /usr/share/dotnet --no-path \

--- a/tracer/samples/NugetDeployment/HttpListenerExample.csproj
+++ b/tracer/samples/NugetDeployment/HttpListenerExample.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <TargetFrameworks>net48;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
         [Trait("Category", "Lambda")]
         public async Task SubmitsTraces()
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsAlpine")))
+            if (Environment.GetEnvironmentVariable("IsAlpine") == "true" || Environment.GetEnvironmentVariable("IsDebian") == "true")
             {
                 Output.WriteLine("Skipping");
                 return;

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -3,8 +3,8 @@
 
   <PropertyGroup>
     <!-- only run .NET Framework tests on Windows -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <!-- only run .NET Framework tests on Windows -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <Platforms>x64;x86</Platforms>

--- a/tracer/test/test-applications/debugger/Samples.Probes/Samples.Probes.csproj
+++ b/tracer/test/test-applications/debugger/Samples.Probes/Samples.Probes.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <RuntimeIdentifiers Condition="'$(OS)' == 'Windows_NT' AND '$(TargetFramework)' == 'net461'">win7-x86;win7-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/LogsInjection.ILogger.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/LogsInjection.ILogger.VersionConflict.2x.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/LogsInjection.Log4Net.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/LogsInjection.Log4Net.VersionConflict.2x.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- Exclude .NET Core 2.1 because it doesn't have the AssemblyLoadContext.All API-->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/LogsInjection.NLog.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/LogsInjection.NLog.VersionConflict.2x.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- Exclude .NET Core 2.1 because it doesn't have the AssemblyLoadContext.All API-->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/LogsInjection.Serilog.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/LogsInjection.Serilog.VersionConflict.2x.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- Exclude .NET Core 2.1 because it doesn't have the AssemblyLoadContext.All API-->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Samples.AspNetCoreRazorPages.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Samples.AspNetCoreRazorPages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-      <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
       <Configurations>Debug;Release</Configurations>
       <Platforms>x64;x86;AnyCPU</Platforms>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/Samples.GraphQL4/Samples.GraphQL4.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GraphQL4/Samples.GraphQL4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <ApiVersion Condition="'$(ApiVersion)' == ''">5.1.1</ApiVersion>
     <DefineConstants Condition="$(ApiVersion) &gt;= 5.0.0">$(DefineConstants);GRAPHQL_5_0</DefineConstants>
 

--- a/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Platforms>x86;x64</Platforms>
     <NoWarn>0618;NETSDK1138</NoWarn>

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <LangVersion>latest</LangVersion>

--- a/tracer/test/test-applications/regression/AssemblyLoadContextRedirect/AssemblyLoadContextRedirect.csproj
+++ b/tracer/test/test-applications/regression/AssemblyLoadContextRedirect/AssemblyLoadContextRedirect.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Datadog.Trace" Version="2.1.0" />

--- a/tracer/test/test-applications/regression/Devart.Data.DBCommand/Devart.Data.DBCommand.csproj
+++ b/tracer/test/test-applications/regression/Devart.Data.DBCommand/Devart.Data.DBCommand.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--<TargetFrameworks>net461</TargetFrameworks>-->
-    <TargetFrameworks>net461;netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;net6.0;net7.0</TargetFrameworks>
 
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>

--- a/tracer/test/test-applications/regression/MismatchedTracerVersions/Mismatched.AspNetCore/MismatchedTracerVersions.AspNetCore.csproj
+++ b/tracer/test/test-applications/regression/MismatchedTracerVersions/Mismatched.AspNetCore/MismatchedTracerVersions.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>

--- a/tracer/test/test-applications/regression/MismatchedTracerVersions/Mismatched.Cli/MismatchedTracerVersions.Cli.csproj
+++ b/tracer/test/test-applications/regression/MismatchedTracerVersions/Mismatched.Cli/MismatchedTracerVersions.Cli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net6.0;net7.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>

--- a/tracer/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
+++ b/tracer/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RequiresDockerDependency>true</RequiresDockerDependency>
   </PropertyGroup>

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>x64;x86;AnyCPU</Platforms>
   </PropertyGroup>
 


### PR DESCRIPTION
## Why

Fix CI: failing Linux container integration tests for various reasons, with chief reason being lack of space. This likely broke with the upgrade of the GH runner. 

## What

* Removed dotnet 5.0 from build.
* Removed dotnet install for SDK 3.0 and 5.0 on Linux container tests
* Removed docker images and files to get space on the runner
* Removed Lambda tests (and related images) since they were taking too much space.

## Tests

N/A