### PR TITLE
Run CI workflow on every Mon, Wed, and Fri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ on:
     - shared/src/native-src/*
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1,3,5' # Every Monday, Wednesday, and Friday at midnight UTC
 
 env:
   buildConfiguration: Release


### PR DESCRIPTION
## Why

Avoid CI getting broke silently and requiring work only when we need to merge something.

## What

Run the CI workflow on every Monday, Wednesday, and Friday.

## Tests

N/A