### PR TITLE
[ci] container build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           --env artifacts=/project/${relativeArtifacts} \
           --env SIGNALFX_CLR_ENABLE_NGEN=${SIGNALFX_CLR_ENABLE_NGEN} \
           dd-trace-dotnet/${{ matrix.base-image }}-builder \
-          dotnet /build/bin/Debug/_build.dll Clean BuildTracerHome ZipMonitoringHome
+          /bin/sh -c 'git config --global --add safe.directory /project && ./tracer/build.sh Clean BuildTracerHome ZipMonitoringHome'
     - name: Publish Linux x64-musl packages
       uses: actions/upload-artifact@v3.1.2
       with:
@@ -231,7 +231,7 @@ jobs:
           --env artifacts=/project/${relativeArtifacts} \
           --env SIGNALFX_CLR_ENABLE_NGEN=${SIGNALFX_CLR_ENABLE_NGEN} \
           dd-trace-dotnet/${{ matrix.base-image }}-tester \
-          dotnet /build/bin/Debug/_build.dll Clean BuildTracerHome BuildAndRunManagedUnitTests
+          /bin/sh -c 'git config --global --add safe.directory /project && ./tracer/build.sh Clean BuildTracerHome BuildAndRunManagedUnitTests'
     - name: Publish managed tests results
       uses: actions/upload-artifact@v3.1.2
       with:
@@ -306,7 +306,7 @@ jobs:
           --env artifacts=/project/${relativeArtifacts} \
           --env SIGNALFX_CLR_ENABLE_NGEN=${SIGNALFX_CLR_ENABLE_NGEN} \
           dd-trace-dotnet/${{ matrix.base-image }}-builder \
-          dotnet /build/bin/Debug/_build.dll Clean BuildTracerHome BuildAndRunNativeUnitTests
+          /bin/sh -c 'git config --global --add safe.directory /project && ./tracer/build.sh Clean BuildTracerHome BuildAndRunNativeUnitTests'
     - name: Publish native tests results
       uses: actions/upload-artifact@v3.1.2
       with:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -34,7 +34,7 @@ jobs:
           --env tracerHome=/shared/bin/monitoring-home/tracer \
           --env artifacts=/project/tracer/src/bin/artifacts \
           dd-trace-dotnet/${baseImage}-builder \
-          dotnet /build/bin/Debug/_build.dll Clean BuildTracerHome ZipMonitoringHome
+          /bin/sh -c 'git config --global --add safe.directory /project && ./tracer/build.sh Clean BuildTracerHome ZipMonitoringHome'
     - name: Upload Linux x64 packages
       uses: actions/upload-artifact@v3.1.2
       with:

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -34,10 +34,7 @@ WORKDIR /project
 
 FROM base as builder
 
-# Copy the build project in and build it
 WORKDIR /project
-COPY . /build
-RUN dotnet build /build
 
 FROM base as tester
 
@@ -51,7 +48,4 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && ./dotnet-install.sh --runtime aspnetcore --version 6.0.11 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
-# Copy the build project in and build it
 WORKDIR /project
-COPY . /build
-RUN dotnet build /build

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -63,9 +63,6 @@ WORKDIR /project
 
 FROM base as builder
 
-# Copy the build project in and build it
-COPY . /build
-RUN dotnet build /build
 WORKDIR /project
 
 FROM base as tester
@@ -86,10 +83,6 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     && ./dotnet-install.sh --runtime aspnetcore --version 6.0.11 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
-
-# Copy the build project in and build it
-COPY . /build
-RUN dotnet build /build
 WORKDIR /project
 
 ENV IsDebian=true


### PR DESCRIPTION
## Why

Fix container builds in CI.

## What

Building the build project during docker build causes issues (see https://github.com/signalfx/signalfx-dotnet-tracing/actions/runs/7893081663/job/21552208069?pr=772  for recent example).

This PR moves building the build project to when container is ran.
