### PR TITLE
[ci] alpine dockerimage changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ on:
 
 env:
   buildConfiguration: Release
-  dotnetSdkVersion: 7.0.202
+  dotnetSdkVersion: 7.0.406
   relativeTracerHome: /shared/bin/monitoring-home/tracer
   relativeArtifacts: /tracer/src/bin/artifacts
   binDir: ${{ github.workspace }}/tracer/src/bin
@@ -79,7 +79,7 @@ jobs:
           3.1.426
           5.0.408
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: Install CMake 3.19.8
@@ -136,7 +136,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: Build Docker image
@@ -184,7 +184,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - run: ./tracer/build.cmd Clean BuildTracerHome BuildAndRunManagedUnitTests
@@ -211,7 +211,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: Build Docker image
@@ -259,7 +259,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: Install CMake 3.19.8
@@ -286,7 +286,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: Build Docker image
@@ -337,7 +337,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     # Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
@@ -397,7 +397,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: Remove large node images
@@ -472,7 +472,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack
@@ -523,7 +523,7 @@ jobs:
           2.1.818
           3.1.426
           6.0.419
-          7.0.202
+          7.0.406
           8.0.200
 
     - name: install Microsoft.Net.Component.4.6.1.TargetingPack

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -55,7 +55,7 @@ jobs:
             3.1.426
             5.0.408
             6.0.419
-            7.0.202
+            7.0.406
             8.0.200
 
       - run: tracer\build.cmd Clean BuildTracerHome PackageTracerHome

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ linux-build:
     matrix:
       - baseImage: [ alpine, debian ]
   variables:
-    dotnetSdkVersion: 7.0.202
+    dotnetSdkVersion: 7.0.406
   script:
     - |
       rm .dockerignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -487,7 +487,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.202}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.406}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
     volumes:
@@ -510,7 +510,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.202}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.406}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: /bin/sh -c './tracer/build.sh RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage'
     volumes:
@@ -571,7 +571,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.202}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.406}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -614,7 +614,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.202}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.406}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -66,7 +66,7 @@ ENV IsAlpine=true \
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "ff2ff47318ffff0af9a6395ca6308b54376fba8c97a3a5eba3e848b0caf17b58  dotnet-install.sh" | sha256sum -c \
+    && echo "5eb82d8578f55cdadcb2edfd35ec649a2c6fc11a682e876b1cd68077badbf794  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
     && rm dotnet-install.sh \
@@ -86,7 +86,7 @@ FROM base as tester
 # Install .NET Core runtimes using install script
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "ff2ff47318ffff0af9a6395ca6308b54376fba8c97a3a5eba3e848b0caf17b58  dotnet-install.sh" | sha256sum -c \
+    && echo "5eb82d8578f55cdadcb2edfd35ec649a2c6fc11a682e876b1cd68077badbf794  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime aspnetcore --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.1.31 --install-dir /usr/share/dotnet --no-path \

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,11 +1,45 @@
+﻿FROM alpine:3.16 as base
 ARG DOTNETSDK_VERSION
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.16 as base
 
-# SECURITY NOTE: Exception is made for APK packages, 
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=$DOTNETSDK_VERSION \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip
+    # Disable LTTng tracing with QUIC
+    # QUIC_LTTng=0
+
+# SECURITY NOTE: Exception is made for APK packages,
 # no need to lock versions
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache --update \
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib-dev \
+        \
+        # SDK dependencies
+        curl \
+        icu-data-full \
+        icu-libs \
+        \
+        # our dependencies
         clang \
         cmake \
         git \
@@ -26,7 +60,18 @@ RUN apk update \
     && gem install --version 2.7.6 dotenv \
     && gem install --version 1.14.1 --minimal-deps --no-document fpm
 
-ENV IsAlpine=true
+ENV IsAlpine=true \
+    DOTNET_ROLL_FORWARD_TO_PRERELEASE=1
+
+# Install the .NET SDK
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
+    && echo "SHA256: $(sha256sum dotnet-install.sh)" \
+    && echo "ff2ff47318ffff0af9a6395ca6308b54376fba8c97a3a5eba3e848b0caf17b58  dotnet-install.sh" | sha256sum -c \
+    && chmod +x ./dotnet-install.sh \
+    && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
+    && rm dotnet-install.sh \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && dotnet help
 
 FROM base as releaser
 COPY . /project

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update \
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "ff2ff47318ffff0af9a6395ca6308b54376fba8c97a3a5eba3e848b0caf17b58  dotnet-install.sh" | sha256sum -c \
+    && echo "5eb82d8578f55cdadcb2edfd35ec649a2c6fc11a682e876b1cd68077badbf794  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
     && rm ./dotnet-install.sh \
@@ -76,7 +76,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     fi \
     && curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "ff2ff47318ffff0af9a6395ca6308b54376fba8c97a3a5eba3e848b0caf17b58  dotnet-install.sh" | sha256sum -c \
+    && echo "5eb82d8578f55cdadcb2edfd35ec649a2c6fc11a682e876b1cd68077badbf794  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh --runtime $NETCORERUNTIME2_1 --version 2.1.30 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --version 3.1.31 --install-dir /usr/share/dotnet --no-path \

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="signalfx-dotnet-tracing/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=7.0.202 \
+   --build-arg DOTNETSDK_VERSION=7.0.406 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/centos7.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
Install dotnet sdk in alpine docker image manually.
Based on `alpine.dockerfile` from upstream.
Environment variables set and packages installed resemble what's being set in sdk images from official [repository](https://github.com/dotnet/dotnet-docker).
Additional changes:
- dotnet sdk 7 version bump
- checksum update